### PR TITLE
Add process termination handling

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -24,7 +24,7 @@ const {
   OperateCmd,
   OperateDirectory,
 } = require('./install');
-const { killProcessAndChildren } = require('./processes');
+const { killProcesses } = require('./processes');
 
 // Attempt to acquire the single instance lock
 const singleInstanceLock = app.requestSingleInstanceLock();
@@ -58,7 +58,7 @@ let tray,
 async function beforeQuit() {
   if (operateDaemonPid) {
     try {
-      await killProcessAndChildren(operateDaemonPid);
+      await killProcesses(operateDaemonPid);
     } catch (e) {
       console.error(e);
     }
@@ -66,7 +66,7 @@ async function beforeQuit() {
 
   if (nextAppProcessPid) {
     try {
-      await killProcessAndChildren(nextAppProcessPid);
+      await killProcesses(nextAppProcessPid);
     } catch (e) {
       console.error(e);
     }

--- a/electron/processes.js
+++ b/electron/processes.js
@@ -6,7 +6,7 @@ const windowsKillCommand = 'taskkill /F /PID';
 
 const isWindows = process.platform === 'win32';
 
-function killProcessAndChildren(pid) {
+function killProcesses(pid) {
   return new Promise((resolve, reject) => {
     psTree(pid, (err, children) => {
       if (err) {
@@ -37,4 +37,4 @@ function killProcessAndChildren(pid) {
   });
 }
 
-module.exports = { killProcessAndChildren };
+module.exports = { killProcesses };


### PR DESCRIPTION
- ensures child processes are killed as well as parent processes
- also handles sigint and sigterm signals, and unhandled exceptions
- removed beforeQuit once check; if beforeQuit fails, user cannnot attempt to exit application again