### PR TITLE
Add Funds section address fix (while safe is not present)

### DIFF
--- a/frontend/components/Main/MainAddFunds.tsx
+++ b/frontend/components/Main/MainAddFunds.tsx
@@ -81,7 +81,7 @@ export const MainAddFunds = () => {
           <AddFundsWarningAlertSection />
           <AddFundsAddressSection
             truncatedFundingAddress={truncatedFundingAddress}
-            fundingAddress={masterSafeAddress}
+            fundingAddress={fundingAddress}
             handleCopy={handleCopyAddress}
           />
           <AddFundsGetTokensSection />


### PR DESCRIPTION
Funding address was set to `masterSafeAddress`

If the user progresses without setting up their safe, `fundingAddress` will revert to the `masterEaoAddress`.

Unsure if this approach is correct, but fixes the visual bug for now.
