### PR TITLE
feat: Improve service toggle button behavior

### DIFF
--- a/frontend/components/Main/MainHeader.tsx
+++ b/frontend/components/Main/MainHeader.tsx
@@ -125,10 +125,15 @@ export const MainHeader = () => {
   }, [services, setServiceStatus]);
 
   const serviceToggleButton = useMemo(() => {
-    if (
-      serviceButtonState === ServiceButtonLoadingState.Starting ||
-      serviceButtonState === ServiceButtonLoadingState.Pausing
-    ) {
+    if (serviceButtonState === ServiceButtonLoadingState.Pausing) {
+      return (
+        <Button type="default" size="large" ghost disabled loading>
+          Stopping...
+        </Button>
+      );
+    }
+
+    if (serviceButtonState === ServiceButtonLoadingState.Starting) {
       return (
         <Popover
           trigger={['hover', 'click']}
@@ -144,10 +149,7 @@ export const MainHeader = () => {
           }
         >
           <Button type="default" size="large" ghost disabled loading>
-            {serviceButtonState === ServiceButtonLoadingState.Starting &&
-              'Starting...'}
-            {serviceButtonState === ServiceButtonLoadingState.Pausing &&
-              'Stopping...'}
+            Starting...
           </Button>
         </Popover>
       );


### PR DESCRIPTION
The app currently shows the 'starting' message even when the agent is being stopped. 

<img width="413" alt="Screenshot222" src="https://github.com/valory-xyz/olas-operate-app/assets/22061815/4a55a6c2-2b0d-4c50-80ac-93106ddb4a0d">
