### PR TITLE
Show notification once agent is running and app is hidden

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -218,6 +218,14 @@ const createMainWindow = () => {
     mainWindow.setSize(width, height);
   });
 
+  ipcMain.on('notify-agent-running', () => {
+    if (!mainWindow.isVisible()) {
+      new Notification({
+        title: 'Your agent is now running!',
+      }).show();
+    }
+  });
+
   mainWindow.webContents.on('did-fail-load', () => {
     mainWindow.webContents.reloadIgnoringCache();
   });

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -5,4 +5,5 @@ contextBridge.exposeInMainWorld('electronAPI', {
   closeApp: () => ipcRenderer.send('close-app'),
   minimizeApp: () => ipcRenderer.send('minimize-app'),
   setAppHeight: (height) => ipcRenderer.send('set-height', height),
+  notifyAgentRunning: () => ipcRenderer.send('notify-agent-running'),
 });

--- a/frontend/components/Main/MainHeader.tsx
+++ b/frontend/components/Main/MainHeader.tsx
@@ -1,6 +1,7 @@
 import { InfoCircleOutlined } from '@ant-design/icons';
 import { Badge, Button, Flex, Popover, Typography } from 'antd';
 import { formatUnits } from 'ethers/lib/utils';
+import get from 'lodash/get';
 import Image from 'next/image';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -23,6 +24,11 @@ enum ServiceButtonLoadingState {
   Pausing,
   NotLoading,
 }
+
+const notifyAgentRunning = () => {
+  const fn = get(window, 'electronAPI.notifyAgentRunning') ?? (() => null);
+  return fn();
+};
 
 export const MainHeader = () => {
   const { services, serviceStatus, setServiceStatus } = useServices();
@@ -112,6 +118,7 @@ export const MainHeader = () => {
         setServiceStatus(DeploymentStatus.DEPLOYED);
         setIsBalancePollingPaused(false);
         setServiceButtonState(ServiceButtonLoadingState.NotLoading);
+        notifyAgentRunning();
       });
     } catch (error) {
       setIsBalancePollingPaused(false);


### PR DESCRIPTION
![image](https://github.com/valory-xyz/olas-operate-app/assets/22725775/b85f544d-4546-44a1-b215-664b08657a5f)

Even though I specified the title, it became a description on my Mac.
I also hope that once the app is built, the icon and title will become Pearl's. However maybe you know more about this (I tried setting an icon and only description instead of title - didn't work)