### PR TITLE
feat: share first reward on twitter

### DIFF
--- a/frontend/components/Main/MainRewards.tsx
+++ b/frontend/components/Main/MainRewards.tsx
@@ -80,7 +80,7 @@ const DisplayRewards = () => {
 };
 
 const SHARE_TEXT = `I just earned my first reward through the Operate app powered by #olas!\n\nDownload the Pearl app:`;
-const OPERATE_URL = 'https://olas.network/operate?pearl=first-reward'; // Replace with your URL
+const OPERATE_URL = 'https://olas.network/operate?pearl=first-reward';
 
 const NotifyRewards = () => {
   const { isEligibleForRewards, availableRewardsForEpochEth } = useReward();


### PR DESCRIPTION
I don't think it's possible to include the image with a button click directly. One workaround could be to update the meta tag of "olas.network/operate" to the desired image. However, this isn't ideal because using the "olas.network/operate" URL will always display that specific image.

Let me know if you have any other way @Tanya-atatakai @truemiller 

<img width="379" alt="11" src="https://github.com/valory-xyz/olas-operate-app/assets/22061815/3d2674d1-01be-4f89-a647-67bb92c7c11c">

<img width="606" alt="22" src="https://github.com/valory-xyz/olas-operate-app/assets/22061815/88fee854-0d5c-4224-b26b-570936d6cefd">

additional PR - https://github.com/valory-xyz/olas-website/pull/70
