### PR TITLE
fix: start agent button conditions

### DIFF
--- a/frontend/components/Main/MainHeader.tsx
+++ b/frontend/components/Main/MainHeader.tsx
@@ -215,9 +215,8 @@ export const MainHeader = () => {
     );
 
     if (
-      (totalOlasBalance &&
-        totalOlasBalance < olasCostOfBond + olasRequiredToStake) ||
-      (totalEthBalance && totalEthBalance < monthlyGasEstimate)
+      (totalOlasBalance ?? 0) < olasCostOfBond + olasRequiredToStake ||
+      (totalEthBalance ?? 0) < monthlyGasEstimate
     ) {
       return (
         <Button type="default" size="large" disabled>


### PR DESCRIPTION
`totalOlasBalance` & `totalEthBalance` can be `undefined`

falling back to 0 so the conditions render the disabled button during this period.
