### PR TITLE
Handle createService failing correctly

### DIFF
--- a/frontend/components/Main/MainHeader.tsx
+++ b/frontend/components/Main/MainHeader.tsx
@@ -111,12 +111,15 @@ export const MainHeader = () => {
       return ServicesService.createService({
         serviceTemplate,
         deploy: true,
-      }).then(() => {
-        setServiceStatus(DeploymentStatus.DEPLOYED);
-        setIsBalancePollingPaused(false);
-        setServiceButtonState(ServiceButtonLoadingState.NotLoading);
-        showNotification?.('Your agent is now running!');
-      });
+      })
+        .then(() => {
+          setServiceStatus(DeploymentStatus.DEPLOYED);
+          showNotification?.('Your agent is now running!');
+        })
+        .finally(() => {
+          setIsBalancePollingPaused(false);
+          setServiceButtonState(ServiceButtonLoadingState.NotLoading);
+        });
     } catch (error) {
       setIsBalancePollingPaused(false);
       setServiceButtonState(ServiceButtonLoadingState.NotLoading);

--- a/frontend/service/Services.ts
+++ b/frontend/service/Services.ts
@@ -35,20 +35,27 @@ const createService = async ({
   serviceTemplate: ServiceTemplate;
   deploy: boolean;
 }): Promise<Service> =>
-  fetch(`${BACKEND_URL}/services`, {
-    method: 'POST',
-    body: JSON.stringify({
-      ...serviceTemplate,
-      deploy,
-      configuration: {
-        ...serviceTemplate.configuration,
-        rpc: `${process.env.GNOSIS_RPC}`,
+  new Promise((resolve, reject) =>
+    fetch(`${BACKEND_URL}/services`, {
+      method: 'POST',
+      body: JSON.stringify({
+        ...serviceTemplate,
+        deploy,
+        configuration: {
+          ...serviceTemplate.configuration,
+          rpc: `${process.env.GNOSIS_RPC}`,
+        },
+      }),
+      headers: {
+        'Content-Type': 'application/json',
       },
+    }).then((response) => {
+      if (response.ok) {
+        resolve(response.json());
+      }
+      reject('Failed to create service');
     }),
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  }).then((response) => response.json());
+  );
 
 const deployOnChain = async (serviceHash: ServiceHash): Promise<Deployment> =>
   fetch(`${BACKEND_URL}/services/${serviceHash}/onchain/deploy`, {


### PR DESCRIPTION
re: tray icons changes to "running" and notification shows even if the createService fails

the problem was that in case of an unsuccessful response, it didn't fall into the "catch" block