### PR TITLE
fix: lost the 'installing dependencies' message on all loads.

### DIFF
--- a/electron/loading/index.html
+++ b/electron/loading/index.html
@@ -34,7 +34,7 @@
             `Installing app dependencies...
             <br />
             This might take a while`;
-        } else if (arg.includes("Development mode")) {
+        } else if (arg.includes("Development")) {
           document.getElementById("text").innerHTML = arg;
         }
       }


### PR DESCRIPTION
- Implemented a falsy check to verify if the message is displayed. Could someone please double-check this? 🙏

<img width="448" alt="Screenshot2" src="https://github.com/valory-xyz/olas-operate-app/assets/22061815/0e089821-83b4-4329-b6ea-e9f5aa272d16">
