### PR TITLE
Add rewards today tooltip

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -236,7 +236,7 @@ const createMainWindow = () => {
     mainWindow.setSize(width, height);
   });
 
-  ipcMain.on('show-notification', (title, description) => {
+  ipcMain.on('show-notification', (_event, title, description) => {
     showNotification(title, description || undefined);
   });
 

--- a/frontend/components/Main/KeepAgentRunning.tsx
+++ b/frontend/components/Main/KeepAgentRunning.tsx
@@ -9,6 +9,8 @@ import { CardSection } from '../styled/CardSection';
 
 const { Text } = Typography;
 
+const COVER_BLOCK_BORDERS_STYLE = { marginBottom: '-1px' };
+
 export const KeepAgentRunning = () => {
   const { storeState } = useStore();
   const { serviceStatus } = useServices();
@@ -17,7 +19,7 @@ export const KeepAgentRunning = () => {
   if (serviceStatus !== DeploymentStatus.DEPLOYED) return null;
 
   return (
-    <CardSection>
+    <CardSection style={COVER_BLOCK_BORDERS_STYLE}>
       <Alert
         type="info"
         fullWidth

--- a/frontend/components/Main/MainHeader.tsx
+++ b/frontend/components/Main/MainHeader.tsx
@@ -169,6 +169,8 @@ export const MainHeader = () => {
       //   });
       // }
 
+      const isFirstTimeStaking = totalOlasStakedBalance === 0;
+
       // For now POST /api/services will take care of creating, starting and updating the service
       return ServicesService.createService({
         serviceTemplate,
@@ -176,7 +178,7 @@ export const MainHeader = () => {
       })
         .then(() => {
           setServiceStatus(DeploymentStatus.DEPLOYED);
-          if (totalOlasStakedBalance === 0) {
+          if (isFirstTimeStaking) {
             showNotification?.(
               `Your agent is running and you've staked ${minimumStakedAmountRequired} OLAS!`,
             );

--- a/frontend/components/Main/MainHeader.tsx
+++ b/frontend/components/Main/MainHeader.tsx
@@ -1,5 +1,5 @@
 import { InfoCircleOutlined } from '@ant-design/icons';
-import { Badge, Button, Flex, Popover, Typography } from 'antd';
+import { Badge, Button, Flex, Modal, Popover, Typography } from 'antd';
 import { formatUnits } from 'ethers/lib/utils';
 import Image from 'next/image';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -8,22 +8,72 @@ import { Chain, DeploymentStatus } from '@/client';
 import { COLOR, LOW_BALANCE, SERVICE_TEMPLATES } from '@/constants';
 import { useBalance, useServiceTemplates } from '@/hooks';
 import { useElectronApi } from '@/hooks/useElectronApi';
+import { useReward } from '@/hooks/useReward';
 import { useServices } from '@/hooks/useServices';
 import { useStore } from '@/hooks/useStore';
 import { useWallet } from '@/hooks/useWallet';
 import { ServicesService } from '@/service';
 import { WalletService } from '@/service/Wallet';
 
-const { Text } = Typography;
+const { Text, Title, Paragraph } = Typography;
 
 const LOADING_MESSAGE =
   "It may take a while to start your agent, so feel free to close the app. We'll notify you once your agent is running.";
-
 enum ServiceButtonLoadingState {
   Starting,
   Pausing,
   NotLoading,
 }
+
+const FirstRunModal = ({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) => {
+  const { minimumStakedAmountRequired } = useReward();
+
+  if (!open) return null;
+  return (
+    <Modal
+      open={open}
+      width={412}
+      onCancel={onClose}
+      footer={[
+        <Button
+          key="ok"
+          type="primary"
+          block
+          size="large"
+          className="mt-8"
+          onClick={onClose}
+        >
+          Got it
+        </Button>,
+      ]}
+    >
+      <Flex align="center" justify="center">
+        <Image
+          src="/splash-robot-head.png"
+          width={100}
+          height={100}
+          alt="OLAS logo"
+        />
+      </Flex>
+      <Title level={5} className="mt-12 text-center">
+        Your agent is running and you&apos;ve staked{' '}
+        {minimumStakedAmountRequired} OLAS!
+      </Title>
+      <Paragraph>Your agent is working towards earning rewards.</Paragraph>
+      <Paragraph>
+        Pearl is designed to make it easy for you to earn staking rewards every
+        day. Simply leave the app and agent running in the background for ~1hr a
+        day.
+      </Paragraph>
+    </Modal>
+  );
+};
 
 export const MainHeader = () => {
   const { storeState } = useStore();
@@ -38,6 +88,11 @@ export const MainHeader = () => {
     isBalanceLoaded,
     setIsPaused: setIsBalancePollingPaused,
   } = useBalance();
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const handleModalClose = useCallback(() => setIsModalOpen(false), []);
+
+  const { minimumStakedAmountRequired } = useReward();
 
   const safeOlasBalanceWithStaked = useMemo(() => {
     if (safeBalance?.OLAS === undefined) return;
@@ -122,7 +177,14 @@ export const MainHeader = () => {
       })
         .then(() => {
           setServiceStatus(DeploymentStatus.DEPLOYED);
-          showNotification?.('Your agent is now running!');
+          if (totalOlasStakedBalance === 0) {
+            showNotification?.(
+              `Your agent is running and you've staked ${minimumStakedAmountRequired} OLAS!`,
+            );
+            setIsModalOpen(true);
+          } else {
+            showNotification?.('Your agent is now running!');
+          }
         })
         .finally(() => {
           setIsBalancePollingPaused(false);
@@ -134,11 +196,13 @@ export const MainHeader = () => {
     }
   }, [
     masterSafeAddress,
+    minimumStakedAmountRequired,
     serviceTemplate,
     setIsBalancePollingPaused,
     setServiceStatus,
-    wallets,
     showNotification,
+    totalOlasStakedBalance,
+    wallets,
   ]);
 
   const handlePause = useCallback(() => {
@@ -253,14 +317,14 @@ export const MainHeader = () => {
     if (!isDeployable) {
       return (
         <Button type="default" size="large" disabled>
-          Start agent
+          Start agent {totalOlasStakedBalance === 0 && '& stake'}
         </Button>
       );
     }
 
     return (
       <Button type="primary" size="large" onClick={handleStart}>
-        Start agent
+        Start agent {totalOlasStakedBalance === 0 && '& stake'}
       </Button>
     );
   }, [
@@ -273,12 +337,14 @@ export const MainHeader = () => {
     services,
     storeState?.isInitialFunded,
     totalEthBalance,
+    totalOlasStakedBalance,
   ]);
 
   return (
     <Flex justify="start" align="center" gap={10}>
       {agentHead}
       {serviceToggleButton}
+      <FirstRunModal open={isModalOpen} onClose={handleModalClose} />
     </Flex>
   );
 };

--- a/frontend/components/Main/MainHeader.tsx
+++ b/frontend/components/Main/MainHeader.tsx
@@ -169,7 +169,7 @@ export const MainHeader = () => {
       //   });
       // }
 
-      const isFirstTimeStaking = totalOlasStakedBalance === 0;
+      const serviceExists = !!services?.[0];
 
       // For now POST /api/services will take care of creating, starting and updating the service
       return ServicesService.createService({
@@ -178,13 +178,13 @@ export const MainHeader = () => {
       })
         .then(() => {
           setServiceStatus(DeploymentStatus.DEPLOYED);
-          if (isFirstTimeStaking) {
+          if (serviceExists) {
+            showNotification?.('Your agent is now running!');
+          } else {
             showNotification?.(
               `Your agent is running and you've staked ${minimumStakedAmountRequired} OLAS!`,
             );
             setIsModalOpen(true);
-          } else {
-            showNotification?.('Your agent is now running!');
           }
         })
         .finally(() => {
@@ -199,10 +199,10 @@ export const MainHeader = () => {
     masterSafeAddress,
     minimumStakedAmountRequired,
     serviceTemplate,
+    services,
     setIsBalancePollingPaused,
     setServiceStatus,
     showNotification,
-    totalOlasStakedBalance,
     wallets,
   ]);
 
@@ -315,17 +315,19 @@ export const MainHeader = () => {
       );
     })();
 
+    const serviceExists = !!services?.[0];
+
     if (!isDeployable) {
       return (
         <Button type="default" size="large" disabled>
-          Start agent {totalOlasStakedBalance === 0 && '& stake'}
+          Start agent {!serviceExists && '& stake'}
         </Button>
       );
     }
 
     return (
       <Button type="primary" size="large" onClick={handleStart}>
-        Start agent {totalOlasStakedBalance === 0 && '& stake'}
+        Start agent {!serviceExists && '& stake'}
       </Button>
     );
   }, [
@@ -338,7 +340,6 @@ export const MainHeader = () => {
     services,
     storeState?.isInitialFunded,
     totalEthBalance,
-    totalOlasStakedBalance,
   ]);
 
   return (

--- a/frontend/components/Main/MainHeader.tsx
+++ b/frontend/components/Main/MainHeader.tsx
@@ -62,8 +62,7 @@ const FirstRunModal = ({
         />
       </Flex>
       <Title level={5} className="mt-12 text-center">
-        Your agent is running and you&apos;ve staked{' '}
-        {minimumStakedAmountRequired} OLAS!
+        {`Your agent is running and you&apos;ve staked ${minimumStakedAmountRequired} OLAS!`}
       </Title>
       <Paragraph>Your agent is working towards earning rewards.</Paragraph>
       <Paragraph>

--- a/frontend/components/Main/MainOlasBalance.tsx
+++ b/frontend/components/Main/MainOlasBalance.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import styled from 'styled-components';
 
 import { balanceFormat } from '@/common-util/numberFormatters';
+import { COLOR } from '@/constants';
 import { UNICODE_SYMBOLS } from '@/constants/unicode';
 import { useBalance } from '@/hooks';
 import { useReward } from '@/hooks/useReward';
@@ -24,10 +25,10 @@ const BalanceBreakdownLine = styled.div`
   align-items: center;
   justify-content: space-between;
   font-size: 14px;
-  color: #1f2229;
+  color: ${COLOR.TEXT};
 
   > span {
-    background: #fff;
+    background: ${COLOR.WHITE};
     z-index: 1;
     &:first-child {
       padding-right: 6px;
@@ -42,7 +43,7 @@ const BalanceBreakdownLine = styled.div`
     position: absolute;
     bottom: 6px;
     width: 100%;
-    border-bottom: 2px dotted #c2cbd7;
+    border-bottom: 2px dotted ${COLOR.BORDER_GRAY};
   }
 
   &:not(:last-child) {

--- a/frontend/components/Main/MainOlasBalance.tsx
+++ b/frontend/components/Main/MainOlasBalance.tsx
@@ -1,16 +1,103 @@
-import { Skeleton } from 'antd';
+import { InfoCircleOutlined } from '@ant-design/icons';
+import { Flex, Skeleton, Tooltip, Typography } from 'antd';
 import { useMemo } from 'react';
 import styled from 'styled-components';
 
 import { balanceFormat } from '@/common-util/numberFormatters';
 import { UNICODE_SYMBOLS } from '@/constants/unicode';
 import { useBalance } from '@/hooks';
+import { useReward } from '@/hooks/useReward';
 
 import { CardSection } from '../styled/CardSection';
 
+const { Text } = Typography;
 const Balance = styled.span`
   letter-spacing: -2px;
+  margin-right: 4px;
 `;
+const BalanceBreakdown = styled.div`
+  padding: 4px;
+`;
+const BalanceBreakdownLine = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 14px;
+  color: #1f2229;
+
+  > span {
+    background: #fff;
+    z-index: 1;
+    &:first-child {
+      padding-right: 6px;
+    }
+    &:last-child {
+      padding-left: 6px;
+    }
+  }
+
+  &:before {
+    content: '';
+    position: absolute;
+    bottom: 6px;
+    width: 100%;
+    border-bottom: 2px dotted #c2cbd7;
+  }
+
+  &:not(:last-child) {
+    margin-bottom: 8px;
+  }
+`;
+const OVERLAY_STYLE = { maxWidth: '300px', width: '300px' };
+
+const CurrentBalance = () => {
+  const { totalOlasBalance, totalOlasStakedBalance } = useBalance();
+  const { accruedServiceStakingRewards } = useReward();
+
+  const balances = useMemo(() => {
+    return [
+      {
+        title: 'Staked amount',
+        value: balanceFormat(totalOlasStakedBalance ?? 0, 2),
+      },
+      {
+        title: 'Unclaimed rewards',
+        value: balanceFormat(accruedServiceStakingRewards ?? 0, 2),
+      },
+      {
+        title: 'Unused funds',
+        value: balanceFormat(
+          (totalOlasBalance ?? 0) - (totalOlasStakedBalance ?? 0),
+          2,
+        ),
+      },
+    ];
+  }, [accruedServiceStakingRewards, totalOlasBalance, totalOlasStakedBalance]);
+
+  return (
+    <Text type="secondary">
+      Current balance&nbsp;
+      <Tooltip
+        arrow={false}
+        placement="bottom"
+        overlayStyle={OVERLAY_STYLE}
+        title={
+          <BalanceBreakdown>
+            {balances.map((item, index) => (
+              <BalanceBreakdownLine key={index}>
+                <span>{item.title}</span>
+                <span className="font-weight-600">{item.value} OLAS</span>
+              </BalanceBreakdownLine>
+            ))}
+          </BalanceBreakdown>
+        }
+      >
+        <InfoCircleOutlined />
+      </Tooltip>
+    </Text>
+  );
+};
 
 export const MainOlasBalance = () => {
   const { isBalanceLoaded, totalOlasBalance } = useBalance();
@@ -21,12 +108,15 @@ export const MainOlasBalance = () => {
   }, [totalOlasBalance]);
 
   return (
-    <CardSection align="end" gap={5} bordertop="true" borderbottom="true">
+    <CardSection vertical gap={8} bordertop="true" borderbottom="true">
       {isBalanceLoaded ? (
         <>
-          <span className="balance-symbol">{UNICODE_SYMBOLS.OLAS}</span>
-          <Balance className="balance">{balance}</Balance>
-          <span className="balance-currency">OLAS</span>
+          <CurrentBalance />
+          <Flex align="end">
+            <span className="balance-symbol">{UNICODE_SYMBOLS.OLAS}</span>
+            <Balance className="balance">{balance}</Balance>
+            <span className="balance-currency">OLAS</span>
+          </Flex>
         </>
       ) : (
         <Skeleton.Input active size="large" style={{ margin: '4px 0' }} />

--- a/frontend/components/Main/MainRewards.tsx
+++ b/frontend/components/Main/MainRewards.tsx
@@ -1,44 +1,18 @@
 import { InfoCircleOutlined } from '@ant-design/icons';
-import {
-  Button,
-  Col,
-  Flex,
-  Modal,
-  Row,
-  Skeleton,
-  Tag,
-  Tooltip,
-  Typography,
-} from 'antd';
+import { Button, Flex, Modal, Skeleton, Tag, Tooltip, Typography } from 'antd';
 import Image from 'next/image';
 import { useCallback, useEffect, useState } from 'react';
-import styled from 'styled-components';
 
 import { balanceFormat } from '@/common-util';
-import { COLOR } from '@/constants';
 import { useBalance } from '@/hooks';
 import { useElectronApi } from '@/hooks/useElectronApi';
 import { useReward } from '@/hooks/useReward';
 import { useStore } from '@/hooks/useStore';
 
 import { ConfettiAnimation } from '../common/ConfettiAnimation';
+import { CardSection } from '../styled/CardSection';
 
 const { Text, Title, Paragraph } = Typography;
-
-const RewardsRow = styled(Row)`
-  margin: 0 -24px;
-  > .ant-col {
-    padding: 24px;
-    &:not(:last-child) {
-      border-right: 1px solid ${COLOR.BORDER_GRAY};
-    }
-  }
-`;
-
-const TOOLTIP_OVERLAY_STYLE = {
-  maxWidth: 'calc(100% - 48px)',
-  left: '24px',
-};
 
 const Loader = () => (
   <Flex vertical gap={8}>
@@ -62,69 +36,36 @@ const DisplayRewards = () => {
     totalOlasStakedBalance >= minimumStakedAmountRequired;
 
   return (
-    <RewardsRow>
-      <Col span={12}>
-        <Flex vertical gap={4} align="flex-start">
-          <Text type="secondary">Staking rewards today</Text>
-          {isBalanceLoaded ? (
-            <>
-              <Text className="text-xl font-weight-600">
-                {balanceFormat(availableRewardsForEpochEth, 2)} OLAS&nbsp;
-                <Text type="secondary">
-                  <Tooltip
-                    arrow={false}
-                    overlayStyle={TOOLTIP_OVERLAY_STYLE}
-                    title={
-                      <>
-                        <Text className="text-sm font-weight-600">
-                          Rewards are specified for the ongoing epoch
-                        </Text>
-
-                        <Paragraph className="text-sm mt-8">
-                          An epoch is a period when the agent can earn the
-                          staking rewards. It lasts approximately one day, from
-                          12 am to 12 am UTC. Start your agent earlier in the
-                          day to get all the rewards. Sometimes, epochs can last
-                          longer, and you can earn more than the number
-                          specified here.
-                        </Paragraph>
-                      </>
-                    }
-                  >
-                    <InfoCircleOutlined />
-                  </Tooltip>
-                </Text>
-              </Text>
-              {isEligibleForRewards ? (
-                <Tag color="success">Earned</Tag>
-              ) : (
-                <Tag color="processing">Not yet earned</Tag>
-              )}
-            </>
+    <CardSection vertical gap={8} padding="16px 24px" align="start">
+      <Text type="secondary">
+        Staking rewards this work period&nbsp;
+        <Tooltip
+          arrow={false}
+          title={
+            <Paragraph className="text-sm m-0">
+              The agent&apos;s working period lasts at least 24 hours, but its
+              start and end point may not be at the same time every day.
+            </Paragraph>
+          }
+        >
+          <InfoCircleOutlined />
+        </Tooltip>
+      </Text>
+      {isBalanceLoaded ? (
+        <Flex align="center" gap={12}>
+          <Text className="text-xl font-weight-600">
+            {balanceFormat(availableRewardsForEpochEth, 2)} OLAS&nbsp;
+          </Text>
+          {isEligibleForRewards ? (
+            <Tag color="success">Earned</Tag>
           ) : (
-            <Loader />
+            <Tag color="processing">Not yet earned</Tag>
           )}
         </Flex>
-      </Col>
-
-      <Col span={12}>
-        <Flex vertical gap={4} align="flex-start">
-          <Text type="secondary">Staked amount</Text>
-          {isBalanceLoaded ? (
-            <>
-              <Text className="text-xl font-weight-600">
-                {balanceFormat(totalOlasStakedBalance, 2)} OLAS
-              </Text>
-              {minimumStakedAmountRequired && !isStaked ? (
-                <Tag color="processing">Not yet staked</Tag>
-              ) : null}
-            </>
-          ) : (
-            <Loader />
-          )}
-        </Flex>
-      </Col>
-    </RewardsRow>
+      ) : (
+        <Loader />
+      )}
+    </CardSection>
   );
 };
 

--- a/frontend/components/Main/MainRewards.tsx
+++ b/frontend/components/Main/MainRewards.tsx
@@ -22,18 +22,8 @@ const Loader = () => (
 );
 
 const DisplayRewards = () => {
-  const {
-    availableRewardsForEpochEth,
-    isEligibleForRewards,
-    minimumStakedAmountRequired,
-  } = useReward();
-  const { isBalanceLoaded, totalOlasStakedBalance } = useBalance();
-
-  // check if the staked amount is greater than the minimum required
-  const isStaked =
-    minimumStakedAmountRequired &&
-    totalOlasStakedBalance &&
-    totalOlasStakedBalance >= minimumStakedAmountRequired;
+  const { availableRewardsForEpochEth, isEligibleForRewards } = useReward();
+  const { isBalanceLoaded } = useBalance();
 
   return (
     <CardSection vertical gap={8} padding="16px 24px" align="start">

--- a/frontend/components/Main/MainRewards.tsx
+++ b/frontend/components/Main/MainRewards.tsx
@@ -1,4 +1,15 @@
-import { Button, Col, Flex, Modal, Row, Skeleton, Tag, Typography } from 'antd';
+import { InfoCircleOutlined } from '@ant-design/icons';
+import {
+  Button,
+  Col,
+  Flex,
+  Modal,
+  Row,
+  Skeleton,
+  Tag,
+  Tooltip,
+  Typography,
+} from 'antd';
 import Image from 'next/image';
 import { useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
@@ -12,7 +23,7 @@ import { useStore } from '@/hooks/useStore';
 
 import { ConfettiAnimation } from '../common/ConfettiAnimation';
 
-const { Text, Title } = Typography;
+const { Text, Title, Paragraph } = Typography;
 
 const RewardsRow = styled(Row)`
   margin: 0 -24px;
@@ -23,6 +34,11 @@ const RewardsRow = styled(Row)`
     }
   }
 `;
+
+const TOOLTIP_OVERLAY_STYLE = {
+  maxWidth: 'calc(100% - 48px)',
+  left: '24px',
+};
 
 const Loader = () => (
   <Flex vertical gap={8}>
@@ -52,8 +68,32 @@ const DisplayRewards = () => {
           <Text type="secondary">Staking rewards today</Text>
           {isBalanceLoaded ? (
             <>
-              <Text strong style={{ fontSize: 20 }}>
-                {balanceFormat(availableRewardsForEpochEth, 2)} OLAS
+              <Text className="text-xl font-weight-600">
+                {balanceFormat(availableRewardsForEpochEth, 2)} OLAS&nbsp;
+                <Text type="secondary">
+                  <Tooltip
+                    arrow={false}
+                    overlayStyle={TOOLTIP_OVERLAY_STYLE}
+                    title={
+                      <>
+                        <Text className="text-sm font-weight-600">
+                          Rewards are specified for the ongoing epoch
+                        </Text>
+
+                        <Paragraph className="text-sm mt-8">
+                          An epoch is a period when the agent can earn the
+                          staking rewards. It lasts approximately one day, from
+                          12 am to 12 am UTC. Start your agent earlier in the
+                          day to get all the rewards. Sometimes, epochs can last
+                          longer, and you can earn more than the number
+                          specified here.
+                        </Paragraph>
+                      </>
+                    }
+                  >
+                    <InfoCircleOutlined />
+                  </Tooltip>
+                </Text>
               </Text>
               {isEligibleForRewards ? (
                 <Tag color="success">Earned</Tag>
@@ -72,7 +112,7 @@ const DisplayRewards = () => {
           <Text type="secondary">Staked amount</Text>
           {isBalanceLoaded ? (
             <>
-              <Text strong style={{ fontSize: 20 }}>
+              <Text className="text-xl font-weight-600">
                 {balanceFormat(totalOlasStakedBalance, 2)} OLAS
               </Text>
               {minimumStakedAmountRequired && !isStaked ? (

--- a/frontend/constants/color.ts
+++ b/frontend/constants/color.ts
@@ -8,4 +8,5 @@ export const COLOR = {
   WHITE: '#ffffff',
   BORDER_GRAY: '#DFE5EE',
   BROWN: '#873800',
+  TEXT: '#1f2229',
 };

--- a/frontend/context/ElectronApiProvider.tsx
+++ b/frontend/context/ElectronApiProvider.tsx
@@ -28,7 +28,7 @@ type ElectronApiContextProps = {
   saveLogs?: (data: {
     store?: ElectronStore;
     debugData?: Record<string, unknown>;
-  }) => Promise<{ success: true; dirPath: string } | { success: false }>;
+  }) => Promise<{ success: true; dirPath: string } | { success?: false }>;
   openPath?: (filePath: string) => void;
 };
 

--- a/frontend/hooks/useReward.ts
+++ b/frontend/hooks/useReward.ts
@@ -8,6 +8,7 @@ export const useReward = () => {
     availableRewardsForEpochEth,
     isEligibleForRewards,
     minimumStakedAmountRequired,
+    accruedServiceStakingRewards,
   } = useContext(RewardContext);
 
   return {
@@ -15,5 +16,6 @@ export const useReward = () => {
     availableRewardsForEpochEth,
     isEligibleForRewards,
     minimumStakedAmountRequired,
+    accruedServiceStakingRewards,
   };
 };

--- a/frontend/styles/globals.scss
+++ b/frontend/styles/globals.scss
@@ -141,6 +141,10 @@ button, input, select, textarea, .ant-input-suffix {
   margin-right: auto !important;
 } 
 
+.text-xl {
+  font-size: 20px;
+}
+
 .text-base {
   font-size: 16px !important;
 }

--- a/frontend/styles/globals.scss
+++ b/frontend/styles/globals.scss
@@ -153,6 +153,10 @@ button, input, select, textarea, .ant-input-suffix {
   font-size: 14px !important;
 }
 
+.text-center {
+  text-align: center !important;
+}
+
 .font-weight-600 {
   font-weight: 600 !important;
 }


### PR DESCRIPTION
what's changed:
1) "Staking Rewards Today" changed to "Staking Rewards This Work Period," with a tooltip providing further explanation.
2) The staked amount block removed.
3) A breakdown of the balance added.
4) The "Start agent" button now has the "& stake" postfix, If it is the agent's first run. After first run the modal is shown and notification text is updated


| Full view      | Rewards tooltip | Balance breakdown b/ staking | After staking | Modal |
| ----------- | ----------- | ----------- | ----------- | ----------- |
| ![image](https://github.com/valory-xyz/olas-operate-app/assets/22725775/56a5b116-b0ff-4402-ba47-ff3b925cbea1)      | <img width="468" alt="Screenshot 2024-06-03 at 10 05 58" src="https://github.com/valory-xyz/olas-operate-app/assets/22725775/a2301df6-e498-4e3d-9a84-ecaa7c315b02">       | <img width="351" alt="Screenshot 2024-06-03 at 10 06 04" src="https://github.com/valory-xyz/olas-operate-app/assets/22725775/0c284f61-d5d7-4b1c-8379-95d3d58219eb">  | <img width="365" alt="Screenshot 2024-06-03 at 10 37 22" src="https://github.com/valory-xyz/olas-operate-app/assets/22725775/283242f4-8141-46e5-ad3a-837c0934c132">       | ![image](https://github.com/valory-xyz/olas-operate-app/assets/22725775/249ee5da-6876-4424-8216-611c548ee3c3)       |
