### PR TITLE
Fix "needs funds" Alert visibility

### DIFF
--- a/frontend/components/Main/MainHeader.tsx
+++ b/frontend/components/Main/MainHeader.tsx
@@ -33,11 +33,17 @@ export const MainHeader = () => {
   const { wallets, masterSafeAddress } = useWallet();
   const {
     safeBalance,
-    totalOlasBalance,
+    totalOlasStakedBalance,
     totalEthBalance,
     isBalanceLoaded,
     setIsPaused: setIsBalancePollingPaused,
   } = useBalance();
+
+  const safeOlasBalanceWithStaked = useMemo(() => {
+    if (safeBalance?.OLAS === undefined) return;
+    if (totalOlasStakedBalance === undefined) return;
+    return totalOlasStakedBalance + safeBalance.OLAS;
+  }, [safeBalance?.OLAS, totalOlasStakedBalance]);
 
   const [serviceButtonState, setServiceButtonState] =
     useState<ServiceButtonLoadingState>(ServiceButtonLoadingState.NotLoading);
@@ -226,7 +232,7 @@ export const MainHeader = () => {
     const isDeployable = (() => {
       // case where required values are undefined (not fetched from the server)
       if (totalEthBalance === undefined) return false;
-      if (totalOlasBalance === undefined) return false;
+      if (safeOlasBalanceWithStaked === undefined) return false;
       if (!services) return false;
 
       // deployment statuses where agent should not be deployed
@@ -236,9 +242,12 @@ export const MainHeader = () => {
 
       // case where service exists & user has initial funded
       if (services[0] && storeState?.isInitialFunded)
-        return totalOlasBalance >= requiredOlas; // at present agent will always require staked/bonded OLAS
+        return safeOlasBalanceWithStaked >= requiredOlas; // at present agent will always require staked/bonded OLAS
 
-      return totalOlasBalance >= requiredOlas && totalEthBalance > requiredGas;
+      return (
+        safeOlasBalanceWithStaked >= requiredOlas &&
+        totalEthBalance > requiredGas
+      );
     })();
 
     if (!isDeployable) {
@@ -258,12 +267,12 @@ export const MainHeader = () => {
     handlePause,
     handleStart,
     isBalanceLoaded,
+    safeOlasBalanceWithStaked,
     serviceButtonState,
     serviceStatus,
     services,
     storeState?.isInitialFunded,
     totalEthBalance,
-    totalOlasBalance,
   ]);
 
   return (

--- a/frontend/components/Main/MainHeader.tsx
+++ b/frontend/components/Main/MainHeader.tsx
@@ -242,7 +242,7 @@ export const MainHeader = () => {
 
       // case where service exists & user has initial funded
       if (services[0] && storeState?.isInitialFunded)
-        return safeOlasBalanceWithStaked >= requiredOlas; // at present agent will always require staked/bonded OLAS
+        return safeOlasBalanceWithStaked >= requiredOlas; // at present agent will always require staked/bonded OLAS (or the ability to stake/bond)
 
       return (
         safeOlasBalanceWithStaked >= requiredOlas &&

--- a/frontend/components/Main/MainNeedsFunds.tsx
+++ b/frontend/components/Main/MainNeedsFunds.tsx
@@ -129,10 +129,6 @@ export const MainNeedsFunds = () => {
   );
 
   useEffect(() => {
-    if (isInitialFunded) {
-      electronApi.store?.set?.('isInitialFunded', false);
-    }
-
     if (
       hasEnoughEthForInitialFunding &&
       hasEnoughOlasForInitialFunding &&

--- a/frontend/components/Main/MainNeedsFunds.tsx
+++ b/frontend/components/Main/MainNeedsFunds.tsx
@@ -52,9 +52,10 @@ const useNeedsFunds = () => {
   const hasEnoughOlasForInitialFunding = useMemo(() => {
     const olasInSafe = safeBalance?.OLAS || 0;
     const olasStakedBySafe = totalOlasStakedBalance || 0;
+
     const olasInSafeAndStaked = olasInSafe + olasStakedBySafe;
 
-    return olasInSafeAndStaked >= (serviceFundRequirements.olas || 0);
+    return olasInSafeAndStaked >= serviceFundRequirements.olas;
   }, [
     safeBalance?.OLAS,
     totalOlasStakedBalance,


### PR DESCRIPTION
safe's staked funds were not considered in OLAS balance, resulting in visible "needs funds" alert

- added staked OLAS funds in condition
- also, adjusted some Start Agent conditions to implement similar logic (edge cases where users could send OLAS to other wallets considered in totalOlasBalance)