### PR TITLE
bump for release 26.1

### DIFF
--- a/electron/constants/publishOptions.js
+++ b/electron/constants/publishOptions.js
@@ -2,7 +2,7 @@ const publishOptions = {
   provider: 'github',
   owner: 'valory-xyz',
   repo: 'olas-operate-app',
-  releaseType: 'release',
+  releaseType: 'draft',
   token: process.env.GH_TOKEN,
   private: false,
   publishAutoUpdate: true,

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "main": "electron/main.js",
   "name": "olas-operate-app",
   "productName": "Pearl",
-  "private": true,
   "scripts": {
     "build:frontend": "cd frontend && yarn build && rm -rf ../electron/.next && cp -r .next ../electron/.next && rm -rf ../electron/public && cp -r public ../electron/public",
     "dev:backend": "poetry run python operate/cli.py",
@@ -54,5 +53,5 @@
     "start": "electron .",
     "build": "rm -rf dist/ && electron-builder build"
   },
-  "version": "0.1.0-rc26"
+  "version": "0.1.0-rc26.1"
 }


### PR DESCRIPTION
…version to '0.1.0-rc26.1' in package.json

- changed releaseType to draft so we manually promote
- removed `private` from package.json (no longer needed)