### PR TITLE
fix: pre install wheel into venv to allow bdist_wheel intallations

### DIFF
--- a/operate/services/service.py
+++ b/operate/services/service.py
@@ -390,6 +390,17 @@ def _setup_agent(working_dir: Path) -> None:
     venv = working_dir / "venv"
     pbin = str(venv / "bin" / "python")
 
+    # Install wheel to install agent dependencies
+    _run_cmd(
+        args=[
+            pbin,
+            "-m",
+            "pip",
+            "install",
+            "wheel",
+        ],
+    )
+
     # Install agent dependencies
     _run_cmd(
         args=[


### PR DESCRIPTION
got an issue on linux in dev mode.
dependencies fail to install cause pip has no bdist support