### PR TITLE
Fix image hash

### DIFF
--- a/frontend/constants/serviceTemplates.ts
+++ b/frontend/constants/serviceTemplates.ts
@@ -9,7 +9,7 @@ export const SERVICE_TEMPLATES: ServiceTemplate[] = [
       'https://operate.olas.network/_next/image?url=%2Fimages%2Fprediction-agent.png&w=3840&q=75',
     configuration: {
       trader_version: 'v0.16.4',
-      nft: 'bafybeiei7wb5jvrn7e7fss2t6ajnkjakgf7uaz42fvvlkolhpnez2dlfsy',
+      nft: 'bafybeig64atqaladigoc3ds4arltdu63wkdrk3gesjfvnfdmz35amv7faq',
       agent_id: 14,
       threshold: 1,
       use_staking: true,

--- a/templates/trader.yaml
+++ b/templates/trader.yaml
@@ -4,7 +4,7 @@ hash: bafybeidgjgjj5ul6xkubicbemppufgsbx5sr5rwhtrwttk2oivp5bkdnce
 image: https://operate.olas.network/_next/image?url=%2Fimages%2Fprediction-agent.png&w=3840&q=75
 configuration:
   trader_version: v0.16.4
-  nft: bafybeidok5gwivdabwiuqigy3qzq5ulbw6uqgrlc7aq2ihrazxvil2lxkm
+  nft: bafybeig64atqaladigoc3ds4arltdu63wkdrk3gesjfvnfdmz35amv7faq
   rpc: http://localhost:8545 # User provided
   agent_id: 14
   threshold: 1 # TODO: Move to service component


### PR DESCRIPTION
Fix image hash. The image NFT hash had been inadvertently changed both in `trader.yaml` and `serviceTemplate.ts`. This has no major effect other than displaying a wrong image for the agent.