### PR TITLE
fix: notifications fixes

### DIFF
--- a/frontend/components/Main/MainHeader/FirstRunModal.tsx
+++ b/frontend/components/Main/MainHeader/FirstRunModal.tsx
@@ -2,16 +2,22 @@ import { Button, Flex, Modal, Typography } from 'antd';
 import Image from 'next/image';
 import { FC } from 'react';
 
-import { useReward } from '@/hooks/useReward';
+import { useServiceTemplates } from '@/hooks/useServiceTemplates';
+import { getMinimumStakedAmountRequired } from '@/utils/service';
 
 const { Title, Paragraph } = Typography;
 
 type FirstRunModalProps = { open: boolean; onClose: () => void };
 
 export const FirstRunModal: FC<FirstRunModalProps> = ({ open, onClose }) => {
-  const { minimumStakedAmountRequired } = useReward();
+  const { getServiceTemplates } = useServiceTemplates();
 
   if (!open) return null;
+
+  const minimumStakedAmountRequired = getMinimumStakedAmountRequired(
+    getServiceTemplates()[0],
+  );
+
   return (
     <Modal
       open={open}

--- a/frontend/components/Main/MainHeader/index.tsx
+++ b/frontend/components/Main/MainHeader/index.tsx
@@ -8,7 +8,6 @@ import { COLOR } from '@/constants/colors';
 import { LOW_BALANCE } from '@/constants/thresholds';
 import { useBalance } from '@/hooks/useBalance';
 import { useElectronApi } from '@/hooks/useElectronApi';
-import { useReward } from '@/hooks/useReward';
 import { useServices } from '@/hooks/useServices';
 import { useServiceTemplates } from '@/hooks/useServiceTemplates';
 import { useStakingContractInfo } from '@/hooks/useStakingContractInfo';
@@ -16,6 +15,7 @@ import { useStore } from '@/hooks/useStore';
 import { useWallet } from '@/hooks/useWallet';
 import { ServicesService } from '@/service/Services';
 import { WalletService } from '@/service/Wallet';
+import { getMinimumStakedAmountRequired } from '@/utils/service';
 
 import { CannotStartAgent } from './CannotStartAgent';
 import { requiredGas, requiredOlas } from './constants';
@@ -85,8 +85,6 @@ export const MainHeader = () => {
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const handleModalClose = useCallback(() => setIsModalOpen(false), []);
-
-  const { minimumStakedAmountRequired } = useReward();
 
   const { isInitialStakingLoad, isAgentEvicted, canStartAgent } =
     useStakingContractInfo();
@@ -172,6 +170,9 @@ export const MainHeader = () => {
           if (serviceExists) {
             showNotification?.('Your agent is now running!');
           } else {
+            const minimumStakedAmountRequired =
+              getMinimumStakedAmountRequired(serviceTemplate);
+
             showNotification?.(
               `Your agent is running and you've staked ${minimumStakedAmountRequired} OLAS!`,
             );
@@ -188,7 +189,6 @@ export const MainHeader = () => {
     }
   }, [
     masterSafeAddress,
-    minimumStakedAmountRequired,
     serviceTemplate,
     services,
     setIsBalancePollingPaused,

--- a/frontend/components/Main/MainNeedsFunds.tsx
+++ b/frontend/components/Main/MainNeedsFunds.tsx
@@ -17,7 +17,11 @@ const COVER_PREV_BLOCK_BORDER_STYLE = { marginTop: '-1px' };
 
 const useNeedsFunds = () => {
   const { getServiceTemplates } = useServiceTemplates();
-  const serviceTemplate = useMemo(() => getServiceTemplates()[0], []);
+
+  const serviceTemplate = useMemo(
+    () => getServiceTemplates()[0],
+    [getServiceTemplates],
+  );
 
   const { storeState } = useStore();
   const { safeBalance, totalOlasStakedBalance } = useBalance();

--- a/frontend/components/Main/MainRewards.tsx
+++ b/frontend/components/Main/MainRewards.tsx
@@ -1,7 +1,7 @@
 import { InfoCircleOutlined } from '@ant-design/icons';
 import { Button, Flex, Modal, Skeleton, Tag, Tooltip, Typography } from 'antd';
 import Image from 'next/image';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useBalance } from '@/hooks/useBalance';
 import { useElectronApi } from '@/hooks/useElectronApi';
@@ -73,6 +73,8 @@ const NotifyRewards = () => {
 
   const [canShowNotification, setCanShowNotification] = useState(false);
 
+  const firstRewardRef = useRef<number>();
+
   // hook to set the flag to show the notification
   useEffect(() => {
     if (!isEligibleForRewards) return;
@@ -80,13 +82,9 @@ const NotifyRewards = () => {
     if (storeState?.firstRewardNotificationShown) return;
     if (!availableRewardsForEpochEth) return;
 
+    firstRewardRef.current = availableRewardsForEpochEth;
     setCanShowNotification(true);
-  }, [
-    isEligibleForRewards,
-    availableRewardsForEpochEth,
-    showNotification,
-    storeState,
-  ]);
+  }, [isEligibleForRewards, availableRewardsForEpochEth, storeState]);
 
   // hook to show desktop app notification
   useEffect(() => {
@@ -94,9 +92,9 @@ const NotifyRewards = () => {
 
     showNotification?.(
       'Your agent earned its first staking rewards!',
-      `Congratulations! Your agent just got the first reward for you! Your current balance: ${availableRewardsForEpochEth} OLAS`,
+      `Congratulations! Your agent just got the first reward for you! Your current balance: ${firstRewardRef.current} OLAS`,
     );
-  }, [canShowNotification, availableRewardsForEpochEth, showNotification]);
+  }, [canShowNotification, showNotification]);
 
   const closeNotificationModal = useCallback(() => {
     setCanShowNotification(false);

--- a/frontend/context/RewardProvider.tsx
+++ b/frontend/context/RewardProvider.tsx
@@ -48,8 +48,6 @@ export const RewardProvider = ({ children }: PropsWithChildren) => {
   const [availableRewardsForEpoch, setAvailableRewardsForEpoch] =
     useState<number>();
   const [isEligibleForRewards, setIsEligibleForRewards] = useState<boolean>();
-  const [minimumStakedAmountRequired, setMinimumStakedAmountRequired] =
-    useState<number>();
 
   const availableRewardsForEpochEth = useMemo<number | undefined>(() => {
     if (!availableRewardsForEpoch) return;
@@ -87,7 +85,6 @@ export const RewardProvider = ({ children }: PropsWithChildren) => {
     setAccruedServiceStakingRewards(
       stakingRewardsInfo?.accruedServiceStakingRewards,
     );
-    setMinimumStakedAmountRequired(stakingRewardsInfo?.minimumStakedAmount);
     setAvailableRewardsForEpoch(rewards);
   }, [service]);
 
@@ -114,7 +111,6 @@ export const RewardProvider = ({ children }: PropsWithChildren) => {
         availableRewardsForEpochEth,
         isEligibleForRewards,
         optimisticRewardsEarnedForEpoch,
-        minimumStakedAmountRequired,
         updateRewards,
       }}
     >

--- a/frontend/hooks/useReward.ts
+++ b/frontend/hooks/useReward.ts
@@ -7,7 +7,6 @@ export const useReward = () => {
     availableRewardsForEpoch,
     availableRewardsForEpochEth,
     isEligibleForRewards,
-    minimumStakedAmountRequired,
     accruedServiceStakingRewards,
   } = useContext(RewardContext);
 
@@ -15,7 +14,6 @@ export const useReward = () => {
     availableRewardsForEpoch,
     availableRewardsForEpochEth,
     isEligibleForRewards,
-    minimumStakedAmountRequired,
     accruedServiceStakingRewards,
   };
 };

--- a/frontend/utils/service.ts
+++ b/frontend/utils/service.ts
@@ -1,0 +1,13 @@
+import { ServiceTemplate } from "@/client";
+import { formatUnits } from "ethers/lib/utils";
+
+export const getMinimumStakedAmountRequired = (serviceTemplate: ServiceTemplate) => {
+  const olasCostOfBond = Number(
+    formatUnits(`${serviceTemplate.configuration.olas_cost_of_bond}`, 18)
+  );
+  const olasRequiredToStake = Number(
+    formatUnits(`${serviceTemplate.configuration.olas_required_to_stake}`, 18)
+  );
+
+  return olasCostOfBond + olasRequiredToStake;
+};


### PR DESCRIPTION
There are two issues with notifications:
1) On the first run, a user should stake 20 OLAS. When the agent runs for the first time, we show a modal and a notification. The problem is that the notification shows "undefined" instead of "20" because we get the value from the existing service, which is actually not yet created when we call showNotification.

I changed the logic to get the `minimumStakedAmountRequired` from the template instead of from the service and removed it from the `useReward` since it's not used anywhere else. I also updated the NeedsFunds modal so it has the same source of truth.

The error:
<img width="346" alt="image" src="https://github.com/user-attachments/assets/add08a49-4013-4a4f-a7a7-c91185ccf1f5">


After the fix:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/403d1f79-14f8-4f84-af4b-df822a47228a">

2)The "first staking rewards earned" notification is shown for me multiple times in a row until the modal is closed. It happens due to the fact that useEffect has availableRewardsForEpochEth in its dependencies, which is slightly updated with every balance request that happens by interval. I used a ref here to get the first value, so the showNotification is only triggered once.

<img width="360" alt="image" src="https://github.com/user-attachments/assets/3ed6b60a-6803-44c2-bdb6-16a978458fd8">


