### PR TITLE
Fix missing tendermint installation

### DIFF
--- a/electron/constants/index.js
+++ b/electron/constants/index.js
@@ -17,7 +17,7 @@ const isProd = !isDev;
 // Paths
 const dotOperateDirectory = isProd
   ? path.join(os.homedir(), '.operate')
-  : '.operate';
+  : path.join(process.cwd(), '.operate');
 
 const paths = {
   dotOperateDirectory,

--- a/electron/install.js
+++ b/electron/install.js
@@ -119,10 +119,10 @@ async function downloadFile(url, dest) {
 }
 
 async function installTendermintUnix() {
+  logger.electron(`Installing tendermint for ${os.platform()}-${process.arch}`);
   const cwd = process.cwd();
   process.chdir(paths.tempDir);
 
-  logger.electron(`Installing tendermint for ${os.platform()}-${process.arch}`);
   const url = TendermintUrls[os.platform()][process.arch];
 
   logger.electron(`Downloading ${url}, might take a while...`);
@@ -136,7 +136,7 @@ async function installTendermintUnix() {
     if (!fs.existsSync('/usr/local/bin')) {
       await runSudoUnix('mkdir', '/usr/local/bin');
     }
-    await runSudoUnix('install', 'tendermint /usr/local/bin/tendermint');
+    await runSudoUnix('install', `${paths.tempDir}/tendermint /usr/local/bin/tendermint`);
   }
   process.chdir(cwd);
 }

--- a/electron/install.js
+++ b/electron/install.js
@@ -5,14 +5,11 @@ const sudo = require('sudo-prompt');
 const process = require('process');
 const axios = require('axios');
 const { spawnSync } = require('child_process');
+const { logger } = require('./logger');
 
 const { paths } = require('./constants');
 
-/**
- * current version of the pearl release
- * - use "" (nothing as a suffix) for latest release candidate, for example "0.1.0rc26"
- * - use "alpha" for alpha release, for example "0.1.0rc26-alpha"
- */
+/** @deprecated PyPi is not used any more, this OlasMiddlewareVersion will be removed in the future */
 const OlasMiddlewareVersion = '0.1.0rc83';
 
 const Env = {
@@ -20,10 +17,12 @@ const Env = {
   PATH: `${process.env.PATH}:/opt/homebrew/bin:/usr/local/bin`,
   HOMEBREW_NO_AUTO_UPDATE: '1',
 };
+
 const SudoOptions = {
   name: 'Pearl',
   env: Env,
 };
+
 const TendermintUrls = {
   darwin: {
     x64: 'https://github.com/tendermint/tendermint/releases/download/v0.34.19/tendermint_0.34.19_darwin_amd64.tar.gz',
@@ -48,19 +47,8 @@ function getBinPath(command) {
     .trim();
 }
 
-function appendInstallationLog(log) {
-  fs.appendFileSync(paths.OperateInstallationLog, `${log}\n`, {
-    encoding: 'utf-8',
-  });
-  return log;
-}
-
 function runCmdUnix(command, options) {
-  console.log(
-    appendInstallationLog(
-      `Running ${command} with options ${JSON.stringify(options)}`,
-    ),
-  );
+  logger.electron(`Running ${command} with options ${JSON.stringify(options)}`);
   let bin = getBinPath(command);
   if (!bin) {
     throw new Error(`Command ${command} not found; Path : ${Env.PATH}`);
@@ -72,9 +60,9 @@ function runCmdUnix(command, options) {
             Error: ${output.error}; Stdout: ${output.stdout}; Stderr: ${output.stderr}`,
     );
   }
-  console.log(appendInstallationLog(`Executed ${command} ${options} with`));
-  console.log(appendInstallationLog(`===== stdout =====  \n${output.stdout}`));
-  console.log(appendInstallationLog(`===== stderr =====  \n${output.stderr}`));
+  logger.electron(`Executed ${command} ${options} with`);
+  logger.electron(`===== stdout =====  \n${output.stdout}`);
+  logger.electron(`===== stderr =====  \n${output.stderr}`);
 }
 
 function runSudoUnix(command, options) {
@@ -98,15 +86,9 @@ function runSudoUnix(command, options) {
             Error: ${output.error}; Stdout: ${output.stdout}; Stderr: ${output.stderr}`,
           );
         }
-        console.log(
-          appendInstallationLog(`Executed ${command} ${options} with`),
-        );
-        console.log(
-          appendInstallationLog(`===== stdout =====  \n${output.stdout}`),
-        );
-        console.log(
-          appendInstallationLog(`===== stderr =====  \n${output.stderr}`),
-        );
+        logger.electron(`Executed ${command} ${options} with`);
+        logger.electron(`===== stdout =====  \n${output.stdout}`);
+        logger.electron(`===== stderr =====  \n${output.stderr}`);
         resolve();
       },
     );
@@ -140,19 +122,13 @@ async function installTendermintUnix() {
   const cwd = process.cwd();
   process.chdir(paths.tempDir);
 
-  console.log(
-    appendInstallationLog(
-      `Installing tendermint for ${os.platform()}-${process.arch}`,
-    ),
-  );
+  logger.electron(`Installing tendermint for ${os.platform()}-${process.arch}`);
   const url = TendermintUrls[os.platform()][process.arch];
 
-  console.log(
-    appendInstallationLog(`Downloading ${url}, might take a while...`),
-  );
+  logger.electron(`Downloading ${url}, might take a while...`);
   await downloadFile(url, `${paths.tempDir}/tendermint.tar.gz`);
 
-  console.log(appendInstallationLog(`Installing tendermint binary`));
+  logger.electron(`Installing tendermint binary`);
   runCmdUnix('tar', ['-xvf', 'tendermint.tar.gz']);
 
   // TOFIX: Install tendermint in .operate instead of globally
@@ -163,62 +139,6 @@ async function installTendermintUnix() {
     await runSudoUnix('install', 'tendermint /usr/local/bin/tendermint');
   }
   process.chdir(cwd);
-}
-
-function createVirtualEnvUnix(path) {
-  runCmdUnix('python3.10', ['-m', 'venv', path]);
-}
-
-function isPythonInstalledUbuntu() {
-  return Boolean(getBinPath('python3.10'));
-}
-
-function isGitInstalledUbuntu() {
-  return Boolean(getBinPath('git'));
-}
-
-function installPythonUbuntu() {
-  return runSudoUnix('apt', 'install -y python3.10 python3.10-dev python3-pip');
-}
-
-function installGitUbuntu() {
-  return runSudoUnix('apt', 'install -y git');
-}
-
-function installOperatePackageUnix(path) {
-  runCmdUnix(`${path}/venv/bin/python3.10`, [
-    '-m',
-    'pip',
-    'install',
-    `olas-operate-middleware==${OlasMiddlewareVersion}`,
-  ]);
-}
-
-function reInstallOperatePackageUnix(path) {
-  console.log(appendInstallationLog('Reinstalling pearl CLI'));
-  runCmdUnix(`${path}/venv/bin/python3.10`, [
-    '-m',
-    'pip',
-    'install',
-    `olas-operate-middleware==${OlasMiddlewareVersion}`,
-    '--force-reinstall',
-  ]);
-}
-
-function installOperateCli(path) {
-  let installPath = `${path}/operate`;
-  if (fs.existsSync(installPath)) {
-    fs.rmSync(installPath);
-  }
-  return new Promise((resolve, _reject) => {
-    fs.copyFile(
-      `${paths.dotOperateDirectory}/venv/bin/operate`,
-      installPath,
-      function (error, _stdout, _stderr) {
-        resolve(!error);
-      },
-    );
-  });
 }
 
 function createDirectory(path) {
@@ -232,118 +152,35 @@ function createDirectory(path) {
   });
 }
 
-function writeVersion() {
-  fs.writeFileSync(paths.versionFile, OlasMiddlewareVersion);
-}
-
-function versionBumpRequired() {
-  if (!fs.existsSync(paths.versionFile)) {
-    return true;
-  }
-  const olasMiddlewareVersionInFile = fs
-    .readFileSync(paths.versionFile)
-    .toString();
-  return olasMiddlewareVersionInFile != OlasMiddlewareVersion;
-}
-
-function removeLogFile() {
-  if (fs.existsSync(paths.LogFile)) {
-    fs.rmSync(paths.LogFile);
-  }
-}
-
-function removeInstallationLogFile() {
-  if (fs.existsSync(paths.OperateInstallationLog)) {
-    fs.rmSync(paths.OperateInstallationLog);
-  }
-}
-
 /*******************************/
 // NOTE: "Installing" is string matched in loading.html to detect installation
 /*******************************/
 
 async function setupDarwin(ipcChannel) {
-  removeInstallationLogFile();
-  console.log(appendInstallationLog('Creating required directories'));
+  logger.electron('Creating required directories');
   await createDirectory(`${paths.dotOperateDirectory}`);
   await createDirectory(`${paths.tempDir}`);
 
-  console.log(appendInstallationLog('Checking tendermint installation'));
+  logger.electron('Checking tendermint installation');
   if (!isTendermintInstalledUnix()) {
     ipcChannel.send('response', 'Installing Pearl Daemon');
-    console.log(appendInstallationLog('Installing tendermint'));
+    logger.electron('Installing tendermint');
     await installTendermintUnix();
   }
-
-  // console.log(appendInstallationLog('Checking if upgrade is required'));
-  // if (versionBumpRequired()) {
-  //   console.log(
-  //     appendInstallationLog(
-  //       `Upgrading pearl daemon to ${OlasMiddlewareVersion}`,
-  //     ),
-  //   );
-  //   writeVersion();
-  //   removeLogFile();
-  //   // reInstallOperatePackageUnix(OperateDirectory);
-  // }
 }
 
 // TODO: Add Tendermint installation
 async function setupUbuntu(ipcChannel) {
-  removeInstallationLogFile();
-
-  // console.log(appendInstallationLog('Checking python installation'));
-  // if (!isPythonInstalledUbuntu()) {
-  //   ipcChannel.send('response', 'Installing Pearl Daemon');
-  //   console.log(appendInstallationLog('Installing Python'));
-  //   await installPythonUbuntu(paths.dotOperateDirectory);
-  // }
-
-  // console.log(appendInstallationLog('Checking git installation'));
-  // if (!isGitInstalledUbuntu()) {
-  //   ipcChannel.send('response', 'Installing Pearl Daemon');
-  //   console.log(appendInstallationLog('Installing git'));
-  //   await installGitUbuntu(paths.dotOperateDirectory);
-  // }
-
-  console.log(appendInstallationLog('Creating required directories'));
+  logger.electron('Creating required directories');
   await createDirectory(`${paths.dotOperateDirectory}`);
   await createDirectory(`${paths.tempDir}`);
 
-  console.log(appendInstallationLog('Checking tendermint installation'));
+  logger.electron('Checking tendermint installation');
   if (!isTendermintInstalledUnix()) {
     ipcChannel.send('response', 'Installing Pearl Daemon');
-    console.log(appendInstallationLog('Installing tendermint'));
+    logger.electron('Installing tendermint');
     await installTendermintUnix();
   }
-
-  // if (!fs.existsSync(paths.venvDir)) {
-  //   ipcChannel.send('response', 'Installing Pearl Daemon');
-  //   console.log(appendInstallationLog('Creating virtual environment'));
-  //   createVirtualEnvUnix(paths.venvDir);
-
-  //   console.log(appendInstallationLog('Installing pearl backend'));
-  //   installOperatePackageUnix(paths.dotOperateDirectory);
-  // }
-
-  // console.log(appendInstallationLog('Checking if upgrade is required'));
-  // if (versionBumpRequired()) {
-  //   console.log(
-  //     appendInstallationLog(
-  //       `Upgrading pearl daemon to ${OlasMiddlewareVersion}`,
-  //     ),
-  //   );
-  //   reInstallOperatePackageUnix(paths.dotOperateDirectory);
-  //   writeVersion();
-  //   removeLogFile();
-  // }
-
-  // if (!fs.existsSync(`${paths.dotOperateDirectory}/venv/bin/operate`)) {
-  //   reInstallOperatePackageUnix(paths.dotOperateDirectory);
-  // }
-
-  // console.log(appendInstallationLog('Installing pearl CLI'));
-  // await installOperateCli('/usr/local/bin');
 }
 
 module.exports = {

--- a/electron/install.js
+++ b/electron/install.js
@@ -9,7 +9,11 @@ const { logger } = require('./logger');
 
 const { paths } = require('./constants');
 
-/** @deprecated PyPi is not used any more, this OlasMiddlewareVersion will be removed in the future */
+/**
+ * current version of the pearl release
+ * - use "" (nothing as a suffix) for latest release candidate, for example "0.1.0rc26"
+ * - use "alpha" for alpha release, for example "0.1.0rc26-alpha"
+ */
 const OlasMiddlewareVersion = '0.1.0rc87';
 
 const Env = {

--- a/electron/install.js
+++ b/electron/install.js
@@ -264,9 +264,9 @@ function removeInstallationLogFile() {
 
 async function setupDarwin(ipcChannel) {
   removeInstallationLogFile();
-  // console.log(appendInstallationLog('Creating required directories'));
-  // await createDirectory(`${paths.dotOperateDirectory}`);
-  // await createDirectory(`${paths.dotOperateDirectory}/temp`);
+  console.log(appendInstallationLog('Creating required directories'));
+  await createDirectory(`${paths.dotOperateDirectory}`);
+  await createDirectory(`${paths.tempDir}`);
 
   console.log(appendInstallationLog('Checking tendermint installation'));
   if (!isTendermintInstalledUnix()) {

--- a/electron/install.js
+++ b/electron/install.js
@@ -13,7 +13,7 @@ const { paths } = require('./constants');
  * - use "" (nothing as a suffix) for latest release candidate, for example "0.1.0rc26"
  * - use "alpha" for alpha release, for example "0.1.0rc26-alpha"
  */
-const OlasMiddlewareVersion = '0.1.0rc71';
+const OlasMiddlewareVersion = '0.1.0rc83';
 
 const Env = {
   ...process.env,

--- a/electron/install.js
+++ b/electron/install.js
@@ -264,9 +264,9 @@ function removeInstallationLogFile() {
 
 async function setupDarwin(ipcChannel) {
   removeInstallationLogFile();
-  console.log(appendInstallationLog('Creating required directories'));
-  await createDirectory(`${paths.dotOperateDirectory}`);
-  await createDirectory(`${paths.dotOperateDirectory}/temp`);
+  // console.log(appendInstallationLog('Creating required directories'));
+  // await createDirectory(`${paths.dotOperateDirectory}`);
+  // await createDirectory(`${paths.dotOperateDirectory}/temp`);
 
   console.log(appendInstallationLog('Checking tendermint installation'));
   if (!isTendermintInstalledUnix()) {
@@ -275,40 +275,40 @@ async function setupDarwin(ipcChannel) {
     await installTendermintUnix();
   }
 
-  console.log(appendInstallationLog('Checking if upgrade is required'));
-  if (versionBumpRequired()) {
-    console.log(
-      appendInstallationLog(
-        `Upgrading pearl daemon to ${OlasMiddlewareVersion}`,
-      ),
-    );
-    writeVersion();
-    removeLogFile();
-    // reInstallOperatePackageUnix(OperateDirectory);
-  }
+  // console.log(appendInstallationLog('Checking if upgrade is required'));
+  // if (versionBumpRequired()) {
+  //   console.log(
+  //     appendInstallationLog(
+  //       `Upgrading pearl daemon to ${OlasMiddlewareVersion}`,
+  //     ),
+  //   );
+  //   writeVersion();
+  //   removeLogFile();
+  //   // reInstallOperatePackageUnix(OperateDirectory);
+  // }
 }
 
 // TODO: Add Tendermint installation
 async function setupUbuntu(ipcChannel) {
   removeInstallationLogFile();
 
-  console.log(appendInstallationLog('Checking python installation'));
-  if (!isPythonInstalledUbuntu()) {
-    ipcChannel.send('response', 'Installing Pearl Daemon');
-    console.log(appendInstallationLog('Installing Python'));
-    await installPythonUbuntu(paths.dotOperateDirectory);
-  }
+  // console.log(appendInstallationLog('Checking python installation'));
+  // if (!isPythonInstalledUbuntu()) {
+  //   ipcChannel.send('response', 'Installing Pearl Daemon');
+  //   console.log(appendInstallationLog('Installing Python'));
+  //   await installPythonUbuntu(paths.dotOperateDirectory);
+  // }
 
-  console.log(appendInstallationLog('Checking git installation'));
-  if (!isGitInstalledUbuntu()) {
-    ipcChannel.send('response', 'Installing Pearl Daemon');
-    console.log(appendInstallationLog('Installing git'));
-    await installGitUbuntu(paths.dotOperateDirectory);
-  }
+  // console.log(appendInstallationLog('Checking git installation'));
+  // if (!isGitInstalledUbuntu()) {
+  //   ipcChannel.send('response', 'Installing Pearl Daemon');
+  //   console.log(appendInstallationLog('Installing git'));
+  //   await installGitUbuntu(paths.dotOperateDirectory);
+  // }
 
-  console.log(appendInstallationLog('Creating required directories'));
-  await createDirectory(`${paths.dotOperateDirectory}`);
-  await createDirectory(`${paths.dotOperateDirectory}/temp`);
+  // console.log(appendInstallationLog('Creating required directories'));
+  // await createDirectory(`${paths.dotOperateDirectory}`);
+  // await createDirectory(`${paths.dotOperateDirectory}/temp`);
 
   console.log(appendInstallationLog('Checking tendermint installation'));
   if (!isTendermintInstalledUnix()) {
@@ -317,33 +317,33 @@ async function setupUbuntu(ipcChannel) {
     await installTendermintUnix();
   }
 
-  if (!fs.existsSync(paths.venvDir)) {
-    ipcChannel.send('response', 'Installing Pearl Daemon');
-    console.log(appendInstallationLog('Creating virtual environment'));
-    createVirtualEnvUnix(paths.venvDir);
+  // if (!fs.existsSync(paths.venvDir)) {
+  //   ipcChannel.send('response', 'Installing Pearl Daemon');
+  //   console.log(appendInstallationLog('Creating virtual environment'));
+  //   createVirtualEnvUnix(paths.venvDir);
 
-    console.log(appendInstallationLog('Installing pearl backend'));
-    installOperatePackageUnix(paths.dotOperateDirectory);
-  }
+  //   console.log(appendInstallationLog('Installing pearl backend'));
+  //   installOperatePackageUnix(paths.dotOperateDirectory);
+  // }
 
-  console.log(appendInstallationLog('Checking if upgrade is required'));
-  if (versionBumpRequired()) {
-    console.log(
-      appendInstallationLog(
-        `Upgrading pearl daemon to ${OlasMiddlewareVersion}`,
-      ),
-    );
-    reInstallOperatePackageUnix(paths.dotOperateDirectory);
-    writeVersion();
-    removeLogFile();
-  }
+  // console.log(appendInstallationLog('Checking if upgrade is required'));
+  // if (versionBumpRequired()) {
+  //   console.log(
+  //     appendInstallationLog(
+  //       `Upgrading pearl daemon to ${OlasMiddlewareVersion}`,
+  //     ),
+  //   );
+  //   reInstallOperatePackageUnix(paths.dotOperateDirectory);
+  //   writeVersion();
+  //   removeLogFile();
+  // }
 
-  if (!fs.existsSync(`${paths.dotOperateDirectory}/venv/bin/operate`)) {
-    reInstallOperatePackageUnix(paths.dotOperateDirectory);
-  }
+  // if (!fs.existsSync(`${paths.dotOperateDirectory}/venv/bin/operate`)) {
+  //   reInstallOperatePackageUnix(paths.dotOperateDirectory);
+  // }
 
-  console.log(appendInstallationLog('Installing pearl CLI'));
-  await installOperateCli('/usr/local/bin');
+  // console.log(appendInstallationLog('Installing pearl CLI'));
+  // await installOperateCli('/usr/local/bin');
 }
 
 module.exports = {

--- a/electron/install.js
+++ b/electron/install.js
@@ -10,7 +10,7 @@ const { logger } = require('./logger');
 const { paths } = require('./constants');
 
 /** @deprecated PyPi is not used any more, this OlasMiddlewareVersion will be removed in the future */
-const OlasMiddlewareVersion = '0.1.0rc83';
+const OlasMiddlewareVersion = '0.1.0rc87';
 
 const Env = {
   ...process.env,

--- a/electron/install.js
+++ b/electron/install.js
@@ -306,9 +306,9 @@ async function setupUbuntu(ipcChannel) {
   //   await installGitUbuntu(paths.dotOperateDirectory);
   // }
 
-  // console.log(appendInstallationLog('Creating required directories'));
-  // await createDirectory(`${paths.dotOperateDirectory}`);
-  // await createDirectory(`${paths.dotOperateDirectory}/temp`);
+  console.log(appendInstallationLog('Creating required directories'));
+  await createDirectory(`${paths.dotOperateDirectory}`);
+  await createDirectory(`${paths.tempDir}`);
 
   console.log(appendInstallationLog('Checking tendermint installation'));
   if (!isTendermintInstalledUnix()) {

--- a/electron/install.js
+++ b/electron/install.js
@@ -129,7 +129,7 @@ async function installTendermintUnix() {
 
   const url = TendermintUrls[os.platform()][process.arch];
 
-  logger.electron(`Downloading ${url}, might take a while...`);
+  logger.electron(`Downloading ${url} to ${paths.tempDir}. This might take a while...`);
   await downloadFile(url, `${paths.tempDir}/tendermint.tar.gz`);
 
   logger.electron(`Installing tendermint binary`);

--- a/electron/main.js
+++ b/electron/main.js
@@ -429,11 +429,11 @@ ipcMain.on('check', async function (event, _argument) {
     event.sender.send('response', 'Checking installation');
     if (!isDev) {
       if (platform === 'darwin') {
-        //await setupDarwin(event.sender);
+        await setupDarwin(event.sender);
       } else if (platform === 'win32') {
         // TODO
       } else {
-        //await setupUbuntu(event.sender);
+        await setupUbuntu(event.sender);
       }
     }
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -17,7 +17,7 @@ const http = require('http');
 const AdmZip = require('adm-zip');
 const { TRAY_ICONS, TRAY_ICONS_PATHS } = require('./icons');
 
-const {setupDarwin, setupUbuntu, Env } = require('./install');
+const { setupDarwin, setupUbuntu, Env } = require('./install');
 
 const { paths } = require('./constants');
 const { killProcesses } = require('./processes');

--- a/electron/main.js
+++ b/electron/main.js
@@ -427,14 +427,13 @@ ipcMain.on('check', async function (event, _argument) {
   // Setup
   try {
     event.sender.send('response', 'Checking installation');
-    if (!isDev) {
-      if (platform === 'darwin') {
-        await setupDarwin(event.sender);
-      } else if (platform === 'win32') {
-        // TODO
-      } else {
-        await setupUbuntu(event.sender);
-      }
+
+    if (platform === 'darwin') {
+      await setupDarwin(event.sender);
+    } else if (platform === 'win32') {
+      // TODO
+    } else {
+      await setupUbuntu(event.sender);
     }
 
     if (isDev) {

--- a/electron/main.js
+++ b/electron/main.js
@@ -17,7 +17,7 @@ const http = require('http');
 const AdmZip = require('adm-zip');
 const { TRAY_ICONS, TRAY_ICONS_PATHS } = require('./icons');
 
-const { Env } = require('./install');
+const {setupDarwin, setupUbuntu, Env } = require('./install');
 
 const { paths } = require('./constants');
 const { killProcesses } = require('./processes');

--- a/package.json
+++ b/package.json
@@ -56,5 +56,5 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "0.1.0-rc71"
+  "version": "0.1.0-rc83"
 }

--- a/package.json
+++ b/package.json
@@ -56,5 +56,5 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "0.1.0-rc83"
+  "version": "0.1.0-rc87"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "olas-operate-middleware"
-version = "0.1.0-rc83"
+version = "0.1.0-rc87"
 description = ""
 authors = ["David Vilela <dvilelaf@gmail.com>", "Viraj Patel <vptl185@gmail.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "olas-operate-middleware"
-version = "0.1.0-rc71"
+version = "0.1.0-rc83"
 description = ""
 authors = ["David Vilela <dvilelaf@gmail.com>", "Viraj Patel <vptl185@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
Fix missing tendermint installation.

If not present on the PATH, tendermint will be downloaded and sudo-installed on `/usr/local/bin/tendermint`. This will promt the sudo password to the user.