### PR TITLE
Script for building middleware binary locally 

### DIFF
--- a/build_pearl.sh
+++ b/build_pearl.sh
@@ -1,3 +1,23 @@
+#!/bin/bash
+
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2023-2024 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 BIN_DIR="electron/bins/"

--- a/build_pearl.sh
+++ b/build_pearl.sh
@@ -1,0 +1,27 @@
+cd "$(dirname "$0")"
+
+BIN_DIR="electron/bins/"
+mkdir -p $BIN_DIR
+
+poetry install
+
+poetry run pyinstaller operate/services/utils/tendermint.py --onefile --distpath $BIN_DIR
+
+poetry run pyinstaller \
+    --collect-data eth_account \
+    --collect-all aea \
+    --collect-all autonomy \
+    --collect-all operate \
+    --collect-all aea_ledger_ethereum \
+    --collect-all aea_ledger_cosmos \
+    --collect-all aea_ledger_ethereum_flashbots \
+    --hidden-import aea_ledger_ethereum \
+    --hidden-import aea_ledger_cosmos \
+    --hidden-import aea_ledger_ethereum_flashbots \
+    operate/pearl.py \
+    --add-binary ${BIN_DIR}/aea_bin_x64:. \
+    --add-binary ${BIN_DIR}/aea_bin_arm64:. \
+    --onefile \
+    --distpath $BIN_DIR \
+    --name pearl_$(uname -m)
+

--- a/package.json
+++ b/package.json
@@ -55,7 +55,9 @@
     "dev": "dotenv -e .env -- yarn start",
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test",
-    "download-binaries": "sh download_binaries.sh"
+    "download-binaries": "sh download_binaries.sh",
+    "build:pearl": "sh build_pearl.sh"
+
   },
   "version": "0.1.0-rc97"
 }


### PR DESCRIPTION
Trello Ticket: https://trello.com/c/tumGdJxq/2020-script-to-build-the-operate-cli-into-pyinstaller-binary-enables-local-testing-in-production-mode