### PR TITLE
fix: hide funding until completed staking period

### DIFF
--- a/frontend/components/ManageStakingPage/StakingContractSection/index.tsx
+++ b/frontend/components/ManageStakingPage/StakingContractSection/index.tsx
@@ -115,7 +115,8 @@ export const StakingContractSection = ({
 
   const activeStakingContractSupportsMigration =
     !activeStakingProgram ||
-    activeStakingProgramMeta?.canMigrateTo.includes(stakingProgram);
+    (activeStakingProgramMeta?.canMigrateTo.includes(stakingProgram) &&
+      isServiceStakedForMinimumDuration);
 
   const canMigrate =
     // checks for both initial deployment and migration


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fb2e55c5-4117-4867-bf3c-e0bb025de54f)

Funding section and top-up alert no longer shows if the user is ineligible to migrate due to not being staked long enough.