### PR TITLE
Disable update on hash change

### DIFF
--- a/operate/services/manage.py
+++ b/operate/services/manage.py
@@ -559,8 +559,9 @@ class ServiceManager:
             (not is_first_mint)
             and (on_chain_hash is not None)
             and (
-                on_chain_hash != service.hash
-                or current_agent_id != staking_params["agent_ids"][0]
+                # TODO Discuss how to manage on-chain hash updates with staking programs.
+                # on_chain_hash != service.hash or  # noqa
+                current_agent_id != staking_params["agent_ids"][0]
                 or current_agent_bond != staking_params["min_staking_deposit"]
             )
         )


### PR DESCRIPTION
Disable on-chain update on hash change. This mitigation is implemented to avoid users automatically update the service when there is a hash change. This will avoid a re-staking process that will impact the UX (as they will need to wait for minimum staking time).

The issue occurs as follows:
1. Release includes hash change + new staking contracts
2. User updates and runs agent WITHOUT having chosen a new staking contract.
3. This triggers an on-chain update + re-staking
4. As a result, users will not be able to change immediately the staking contract.