### PR TITLE
fix: disabled on-chain hash update, added countdown until user can migrate

### DIFF
--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -1,12 +1,5 @@
 name: Release for Windows
 
-# This workflow is triggered on pushing a tag BE CAREFUL this application AUTO UPDATES !!! 
-# git tag vX.Y.Z
-# git push origin tag vX.Y.Z
-
-# on: [pull_request]
-
-
 on:
   push:
       tags:
@@ -15,9 +8,6 @@ on:
 jobs:
     build-windows:
       runs-on: windows-latest
-      #strategy:
-      #  matrix:
-      #    arch: [ x64, arm64 ]
       defaults:
        run:
          shell: bash
@@ -35,13 +25,11 @@ jobs:
         - name: Install and configure Poetry
           uses: snok/install-poetry@v1
           with:
-            # version: '1.4.0'
+            version: '1.4.0'
             virtualenvs-create: true
             virtualenvs-in-project: false
             virtualenvs-path: ~/my-custom-path
             installer-parallel: true
-        #- name: Setup tmate session
-        #  uses: mxschmitt/action-tmate@v3
         - name: Install dependencies
           run: poetry install
 

--- a/frontend/components/ManageStakingPage/StakingContractSection/index.tsx
+++ b/frontend/components/ManageStakingPage/StakingContractSection/index.tsx
@@ -389,9 +389,10 @@ const CountdownUntilMigration = ({
 
   return (
     <Flex vertical gap={1}>
-      <span>Your agent must continue staking for</span>
+      <strong>Can&apos;t switch because you unstaked too recently.</strong>
+      <span>This may be because your agent was suspended.</span>
+      <span>Keep running your agent and you&apos;ll be able to switch in</span>
       <span>{countdownDisplayFormat(secondsUntilReady)}</span>
-      <span>before it can switch to a new contract</span>
     </Flex>
   );
 };

--- a/frontend/components/ManageStakingPage/StakingContractSection/index.tsx
+++ b/frontend/components/ManageStakingPage/StakingContractSection/index.tsx
@@ -389,9 +389,9 @@ const CountdownUntilMigration = ({
 
   return (
     <Flex vertical gap={1}>
-      <span>Your agent must continuing staking for</span>
+      <span>Your agent must continue staking for</span>
       <span>{countdownDisplayFormat(secondsUntilReady)}</span>
-      <span>before it can switch to a new program!</span>
+      <span>before it can switch to a new contract</span>
     </Flex>
   );
 };


### PR DESCRIPTION
includes @jmoreira-valory's [fix: disable hash update](https://github.com/valory-xyz/olas-operate-app/commit/7d1c6ef86d2913b5651fd15fc7da5a9fe308fa43)

added [fix: migration countdown, and minimum duration fix from staging](https://github.com/valory-xyz/olas-operate-app/commit/5d2720db93adcb9158924ea7f838134c4807f27e)

copied fix for hiding funding options (merged earlier to staging) when user is not able to migrate due to staking duration