### PR TITLE
fix: remove hardcoded OLAS requirement from "now running" notification

### DIFF
--- a/frontend/components/MainPage/header/AgentButton.tsx
+++ b/frontend/components/MainPage/header/AgentButton.tsx
@@ -4,7 +4,6 @@ import { useCallback, useMemo } from 'react';
 
 import { Chain, DeploymentStatus } from '@/client';
 import { COLOR } from '@/constants/colors';
-import { StakingProgram } from '@/enums/StakingProgram';
 import { useBalance } from '@/hooks/useBalance';
 import { useElectronApi } from '@/hooks/useElectronApi';
 import { useServices } from '@/hooks/useServices';
@@ -170,18 +169,7 @@ const AgentNotRunningButton = () => {
 
     // Show success notification based on whether there was a service prior to starting
     try {
-      if (!service) {
-        showNotification?.('Your agent is now running!');
-      } else {
-        const minimumStakedAmountRequired = getMinimumStakedAmountRequired(
-          serviceTemplate,
-          StakingProgram.Beta, // users should always deploy on Beta if they are yet to start their agent
-        );
-
-        showNotification?.(
-          `Your agent is running and you've staked ${minimumStakedAmountRequired} OLAS!`,
-        );
-      }
+      showNotification?.(`Your agent is running!`);
     } catch (error) {
       console.error(error);
       showNotification?.('Error while showing "running" notification');
@@ -202,7 +190,6 @@ const AgentNotRunningButton = () => {
     activeStakingProgram,
     defaultStakingProgram,
     serviceTemplate,
-    service,
   ]);
 
   const isDeployable = useMemo(() => {


### PR DESCRIPTION
Removed as per @oaksprout's request.