### PR TITLE
fix: redisplay missing agent safe info in debug window

### DIFF
--- a/frontend/components/SettingsPage/DebugInfoSection.tsx
+++ b/frontend/components/SettingsPage/DebugInfoSection.tsx
@@ -175,25 +175,19 @@ export const DebugInfoSection = () => {
         ?.instances?.[0];
     if (instanceAddress) {
       result.push({
-        title: 'Agent instance',
+        title: 'Agent Instance EOA',
         ...getItemData(walletBalances, instanceAddress!),
       });
     }
 
-    // COMMENTED UNTIL PANDORA UPDATES GRAPH ENDPOINT 5/9
-    //
-    // const multisigAddress =
-    //   services[0]?.chain_configs?.[CHAINS.GNOSIS.chainId]?.chain_data?.multisig;
-    // if (multisigAddress) {
-    //   result.push({
-    //     title: 'Agent Safe',
-    //     ...getItemData(walletBalances, multisigAddress),
-    //     link: {
-    //       title: 'See agent activity on Pandora',
-    //       href: `https://pandora.computer/predict/${multisigAddress}`,
-    //     },
-    //   });
-    // }
+    const multisigAddress =
+      services[0]?.chain_configs?.[CHAINS.GNOSIS.chainId]?.chain_data?.multisig;
+    if (multisigAddress) {
+      result.push({
+        title: 'Agent Safe',
+        ...getItemData(walletBalances, multisigAddress),
+      });
+    }
 
     return result;
   }, [


### PR DESCRIPTION
Commented too much code when removing the broken pandora link in #328.

## Issue
![image](https://github.com/user-attachments/assets/aeeff98e-1c9e-4f6d-a9af-fa0209a3c311)

## Fix
![image](https://github.com/user-attachments/assets/600a1422-965d-4e41-b36b-82d3405f66f2)

