### PR TITLE
fix: make log export Windows friendly (`:` not supported in filename)

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -688,7 +688,9 @@ ipcMain.handle('save-logs', async (_, data) => {
     title: 'Save Logs',
     defaultPath: path.join(
       os.homedir(),
-      `pearl_logs_${new Date(Date.now()).toISOString()}-${app.getVersion()}.zip`,
+      `pearl_logs_${new Date(Date.now())
+        .toISOString()
+        .replaceAll(':', '-')}-${app.getVersion()}.zip`,
     ),
     filters: [{ name: 'Zip Files', extensions: ['zip'] }],
   });


### PR DESCRIPTION
Was unable to export logs smoothly as `:` used to seperate ISO time string was blocked on Windows