### PR TITLE
fix: ensure backup address is checksummed before submitting to backend

### DIFF
--- a/frontend/components/SetupPage/Create/SetupBackupSigner.tsx
+++ b/frontend/components/SetupPage/Create/SetupBackupSigner.tsx
@@ -1,5 +1,5 @@
 import { Button, Flex, Form, Input, Typography } from 'antd';
-import { ethers } from 'ethers';
+import { getAddress } from 'ethers/lib/utils';
 
 import { CardFlex } from '@/components/styled/CardFlex';
 import { FormFlex } from '@/components/styled/FormFlex';
@@ -17,8 +17,8 @@ export const SetupBackupSigner = () => {
   const [form] = Form.useForm();
 
   const handleFinish = (values: { 'backup-signer': string }) => {
-    const checksummedAddress = ethers.utils.getAddress(
-      values['backup-signer'],
+    const checksummedAddress = getAddress(
+      values['backup-signer'].toLowerCase(), // important to lowercase the address before checksumming, invalid checksums will cause ethers to throw
     ) as Address | null; // returns null if invalid, ethers type is incorrect...
 
     // If the address is invalid, show an error message
@@ -50,7 +50,7 @@ export const SetupBackupSigner = () => {
             rules={[
               {
                 required: true,
-                min: 42,
+                len: 42,
                 pattern: /^0x[a-fA-F0-9]{40}$/,
                 type: 'string',
                 message: invalidAddressMessage,

--- a/frontend/components/SetupPage/Create/SetupBackupSigner.tsx
+++ b/frontend/components/SetupPage/Create/SetupBackupSigner.tsx
@@ -1,4 +1,5 @@
 import { Button, Flex, Form, Input, Typography } from 'antd';
+import { ethers } from 'ethers';
 
 import { CardFlex } from '@/components/styled/CardFlex';
 import { FormFlex } from '@/components/styled/FormFlex';
@@ -8,13 +9,26 @@ import { Address } from '@/types/Address';
 
 import { SetupCreateHeader } from './SetupCreateHeader';
 
+const invalidAddressMessage = 'Please input a valid backup wallet address!';
+
 export const SetupBackupSigner = () => {
   const { goto } = useSetup();
   const { setBackupSigner } = useSetup();
   const [form] = Form.useForm();
 
-  const handleFinish = (values: { 'backup-signer': Address }) => {
-    setBackupSigner(values['backup-signer']);
+  const handleFinish = (values: { 'backup-signer': string }) => {
+    const checksummedAddress = ethers.utils.getAddress(
+      values['backup-signer'],
+    ) as Address | null; // returns null if invalid, ethers type is incorrect...
+
+    // If the address is invalid, show an error message
+    if (!checksummedAddress) {
+      return form.setFields([
+        { name: 'backup-signer', errors: [invalidAddressMessage] },
+      ]);
+    }
+
+    setBackupSigner(checksummedAddress);
     goto(SetupScreen.SetupEoaFunding);
   };
 
@@ -39,7 +53,7 @@ export const SetupBackupSigner = () => {
                 min: 42,
                 pattern: /^0x[a-fA-F0-9]{40}$/,
                 type: 'string',
-                message: 'Please input a valid backup wallet address!',
+                message: invalidAddressMessage,
               },
             ]}
           >


### PR DESCRIPTION
@oaksprout mentioned he experienced errors when backup wallet address was not checksummed

fix **ensures the address is checksummed in the background**
- allows for non-checksummed input (as to not frustrate users)
- will send the checksummed address to middleware when creating a safe (to add as signer)

tried using validation `rules` on the Antd input, but `transform` and `validator` functions don't update input value. hence the validation on submit.

should resolve #331, [Trello ticket](https://trello.com/c/Cp0Q36i9/2141-backup-wallet-is-not-added)

## Video
(made [a small fix](https://github.com/valory-xyz/olas-operate-app/pull/351/commits/32d137934cee0b91e90f76a2fbdf3726a9886e61) mid way through, works as expected now)

https://github.com/user-attachments/assets/0ad0af9d-00c2-4013-8f82-29a0219de381

