### PR TITLE
fix: allowlist evm public keys in gitleaks CI

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -534,10 +534,9 @@ regex = '''(?i)((key|api|token|secret|password)[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|
 entropy = 3.7
 secretGroup = 4
 
-[[rules]]
-description = "evm-public-keys"
+[allowlist]
+description = "evm public keys"
 regex = '''^0x[a-fA-F0-9]{40}$'''
-allowlist = true
 
 [allowlist]
 description = "global allow lists"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -534,12 +534,11 @@ regex = '''(?i)((key|api|token|secret|password)[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|
 entropy = 3.7
 secretGroup = 4
 
+[[allowlist]]
+description = "ignore evm public keys"
+regex = '''^0x[a-fA-F0-9]{40}$'''
+
 [allowlist]
 description = "global allow lists"
-regexes = [
-    '''219-09-9999''', 
-    '''078-05-1120''', 
-    '''(9[0-9]{2}|666)-\d{2}-\d{4}''',
-    '''^0x[a-fA-F0-9]{40}$''', # evm public keys
-    ]
+regexes = ['''219-09-9999''', '''078-05-1120''', '''(9[0-9]{2}|666)-\d{2}-\d{4}''']
 paths = ['''(.*?)(jpg|gif|doc|pdf|bin|svg|socket)$''']

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -536,9 +536,10 @@ secretGroup = 4
 
 [allowlist]
 description = "allowlist"
+regexTarget = "match"
 regexes = [
-    '''^0x[a-fA-F0-9]{40}$''',  # ignore evm public keys
-    '''219-09-9999''',          # global allow lists
+    '''\b(0x)?[0-9a-fA-F]{40}\b''', # ignore evm public keys
+    '''219-09-9999''', # global allow lists
     '''078-05-1120''',
     '''(9[0-9]{2}|666)-\d{2}-\d{4}'''
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -535,10 +535,10 @@ entropy = 3.7
 secretGroup = 4
 
 [allowlist]
-description = "ignore evm public keys"
-regex = '''^0x[a-fA-F0-9]{40}$'''
-
-[allowlist]
-description = "global allow lists"
-regexes = ['''219-09-9999''', '''078-05-1120''', '''(9[0-9]{2}|666)-\d{2}-\d{4}''']
-paths = ['''(.*?)(jpg|gif|doc|pdf|bin|svg|socket)$''']
+description = "allowlist"
+regexes = [
+    '''^0x[a-fA-F0-9]{40}$''',  # ignore evm public keys
+    '''219-09-9999''',          # global allow lists
+    '''078-05-1120''',
+    '''(9[0-9]{2}|666)-\d{2}-\d{4}'''
+]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -534,11 +534,11 @@ regex = '''(?i)((key|api|token|secret|password)[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|
 entropy = 3.7
 secretGroup = 4
 
-[[allowlist]]
+[allowlist]
 description = "ignore evm public keys"
 regex = '''^0x[a-fA-F0-9]{40}$'''
 
-[[allowlist]]
+[allowlist]
 description = "global allow lists"
 regexes = ['''219-09-9999''', '''078-05-1120''', '''(9[0-9]{2}|666)-\d{2}-\d{4}''']
 paths = ['''(.*?)(jpg|gif|doc|pdf|bin|svg|socket)$''']

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -538,7 +538,7 @@ secretGroup = 4
 description = "ignore evm public keys"
 regex = '''^0x[a-fA-F0-9]{40}$'''
 
-[allowlist]
+[[allowlist]]
 description = "global allow lists"
 regexes = ['''219-09-9999''', '''078-05-1120''', '''(9[0-9]{2}|666)-\d{2}-\d{4}''']
 paths = ['''(.*?)(jpg|gif|doc|pdf|bin|svg|socket)$''']

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -534,8 +534,13 @@ regex = '''(?i)((key|api|token|secret|password)[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|
 entropy = 3.7
 secretGroup = 4
 
+[[rules]]
+description = "evm-public-keys"
+regex = '''^0x[a-fA-F0-9]{40}$'''
+allowlist = true
 
 [allowlist]
 description = "global allow lists"
 regexes = ['''219-09-9999''', '''078-05-1120''', '''(9[0-9]{2}|666)-\d{2}-\d{4}''']
 paths = ['''(.*?)(jpg|gif|doc|pdf|bin|svg|socket)$''']
+

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -535,11 +535,11 @@ entropy = 3.7
 secretGroup = 4
 
 [allowlist]
-description = "evm public keys"
-regex = '''^0x[a-fA-F0-9]{40}$'''
-
-[allowlist]
 description = "global allow lists"
-regexes = ['''219-09-9999''', '''078-05-1120''', '''(9[0-9]{2}|666)-\d{2}-\d{4}''']
+regexes = [
+    '''219-09-9999''', 
+    '''078-05-1120''', 
+    '''(9[0-9]{2}|666)-\d{2}-\d{4}''',
+    '''^0x[a-fA-F0-9]{40}$''', # evm public keys
+    ]
 paths = ['''(.*?)(jpg|gif|doc|pdf|bin|svg|socket)$''']
-


### PR DESCRIPTION
allowlisting EVM public keys, stops CI failures whenever contracts are added/updated