### PR TITLE
fix: display primary instance when attempting to start another

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -120,20 +120,20 @@ const createTray = () => {
   const trayPath = getUpdatedTrayIcon(
     isWindows || isMac ? TRAY_ICONS.LOGGED_OUT : TRAY_ICONS_PATHS.LOGGED_OUT,
   );
-  const tray = new Tray(trayPath);
+  tray = new Tray(trayPath);
 
   const contextMenu = Menu.buildFromTemplate([
     {
       label: 'Show app',
-      click: mainWindow.show,
+      click: () => mainWindow?.show(),
     },
     {
       label: 'Hide app',
-      click: mainWindow.hide,
+      click: () => mainWindow?.hide(),
     },
     {
       label: 'Quit',
-      click: app.quit,
+      click: () => app.quit(),
     },
   ]);
   tray.setToolTip('Pearl');

--- a/electron/main.js
+++ b/electron/main.js
@@ -99,7 +99,7 @@ async function beforeQuit() {
   }
 
   tray?.destroy();
-  mainWindow.destroy();
+  mainWindow?.destroy();
   splashWindow?.destroy();
 }
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -36,7 +36,7 @@ if (!singleInstanceLock) {
   } catch (e) {
     console.error(e);
   } finally {
-    app.quit();
+    app.exit();
   }
 }
 
@@ -529,27 +529,25 @@ ipcMain.on('check', async function (event, _argument) {
 });
 
 // APP-SPECIFIC EVENTS
-app.on('ready', async () => {
-  app.on('second-instance', () => {
-    logger.electron('Tried to open second instance.');
+app.on('second-instance', () => {
+  logger.electron('User attempted to open a second instance.');
 
-    if (mainWindow) {
-      logger.electron('Restoring main window.');
-      mainWindow.show();
-      return;
-    }
+  if (mainWindow) {
+    logger.electron('Restoring primary main window.');
+    mainWindow.show();
+    return;
+  }
 
-    if (splashWindow) {
-      logger.electron('Restoring splash window as there is no main window.');
-      splashWindow.show();
-      return;
-    }
+  if (splashWindow) {
+    logger.electron(
+      'Restoring primary splash window as there is no main window.',
+    );
+    splashWindow.show();
+    return;
+  }
+});
 
-    logger.electron('Nothing to restore, reloading.');
-    app.relaunch();
-    app.quit();
-  });
-
+app.once('ready', async () => {
   app.on('window-all-closed', () => {
     app.quit();
   });


### PR DESCRIPTION
Added logging around single instance locking
Added event handler to bring active Pearl window into focus if another instance is started

https://github.com/user-attachments/assets/5f9f320f-d909-404b-a4c2-783996a71ff3

