### PR TITLE
fix: cannot start agent glitch (workaround )

### DIFF
--- a/frontend/components/MainPage/header/AgentButton.tsx
+++ b/frontend/components/MainPage/header/AgentButton.tsx
@@ -117,6 +117,7 @@ const AgentRunningButton = () => {
   );
 };
 
+/** Button used to start / deploy the agent */
 const AgentNotRunningButton = () => {
   const { wallets, masterSafeAddress } = useWallet();
   const {
@@ -124,6 +125,7 @@ const AgentNotRunningButton = () => {
     serviceStatus,
     setServiceStatus,
     setIsServicePollingPaused,
+    updateServicesState,
   } = useServices();
   const { serviceTemplate } = useServiceTemplates();
   const { showNotification } = useElectronApi();
@@ -133,9 +135,15 @@ const AgentNotRunningButton = () => {
     isLowBalance,
     totalOlasStakedBalance,
     totalEthBalance,
+    updateBalances,
   } = useBalance();
   const { storeState } = useStore();
-  const { isEligibleForStaking, isAgentEvicted } = useStakingContractInfo();
+  const {
+    isEligibleForStaking,
+    isAgentEvicted,
+    setIsPaused: setIsStakingContractInfoPollingPaused,
+    updateActiveStakingContractInfo,
+  } = useStakingContractInfo();
   const { activeStakingProgramId, defaultStakingProgramId } =
     useStakingProgram();
 
@@ -164,6 +172,9 @@ const AgentNotRunningButton = () => {
     // Paused to stop confusing balance transitions while starting the agent
     setIsBalancePollingPaused(true);
 
+    // Paused to stop overlapping staking contract info poll while starting the agent
+    setIsStakingContractInfoPollingPaused(true);
+
     // Mock "DEPLOYING" status (service polling will update this once resumed)
     setServiceStatus(DeploymentStatus.DEPLOYING);
 
@@ -176,6 +187,7 @@ const AgentNotRunningButton = () => {
       console.error(error);
       setServiceStatus(undefined);
       showNotification?.('Error while creating safe');
+      setIsStakingContractInfoPollingPaused(false);
       setIsServicePollingPaused(false);
       setIsBalancePollingPaused(false);
       return;
@@ -194,6 +206,7 @@ const AgentNotRunningButton = () => {
       showNotification?.('Error while deploying service');
       setIsServicePollingPaused(false);
       setIsBalancePollingPaused(false);
+      setIsStakingContractInfoPollingPaused(false);
       return;
     }
 
@@ -205,21 +218,39 @@ const AgentNotRunningButton = () => {
       showNotification?.('Error while showing "running" notification');
     }
 
+    // TODO: remove this workaround, middleware should respond when agent is staked & confirmed running after `createService` call
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+
     // Can assume successful deployment
-    // resume polling, optimistically update service status (poll will update, if needed)
-    setIsServicePollingPaused(false);
-    setIsBalancePollingPaused(false);
     setServiceStatus(DeploymentStatus.DEPLOYED);
+
+    // update provider states sequentially
+    try {
+      await updateServicesState(); // reload the available services
+      await updateActiveStakingContractInfo(); // reload active staking contract with new service
+      await updateBalances(); // reload the balances
+    } catch (error) {
+      console.error(error);
+    } finally {
+      // resume polling
+      setIsServicePollingPaused(false);
+      setIsStakingContractInfoPollingPaused(false);
+      setIsBalancePollingPaused(false);
+    }
   }, [
     wallets,
     setIsServicePollingPaused,
     setIsBalancePollingPaused,
+    setIsStakingContractInfoPollingPaused,
     setServiceStatus,
     masterSafeAddress,
     showNotification,
     activeStakingProgramId,
     defaultStakingProgramId,
     serviceTemplate,
+    updateServicesState,
+    updateActiveStakingContractInfo,
+    updateBalances,
   ]);
 
   const isDeployable = useMemo(() => {

--- a/frontend/components/MainPage/header/AgentButton.tsx
+++ b/frontend/components/MainPage/header/AgentButton.tsx
@@ -218,13 +218,14 @@ const AgentNotRunningButton = () => {
       showNotification?.('Error while showing "running" notification');
     }
 
-    // TODO: remove this workaround, middleware should respond when agent is staked & confirmed running after `createService` call
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     // Can assume successful deployment
     setServiceStatus(DeploymentStatus.DEPLOYED);
 
+    // TODO: remove this workaround, middleware should respond when agent is staked & confirmed running after `createService` call
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+
     // update provider states sequentially
+    // service id is required before activeStakingContractInfo & balances can be updated
     try {
       await updateServicesState(); // reload the available services
       await updateActiveStakingContractInfo(); // reload active staking contract with new service

--- a/frontend/hooks/useStakingContractInfo.ts
+++ b/frontend/hooks/useStakingContractInfo.ts
@@ -8,14 +8,23 @@ import { useServices } from './useServices';
 export const useStakingContractInfo = () => {
   const {
     activeStakingContractInfo,
-    stakingContractInfoRecord,
+    isPaused,
     isStakingContractInfoLoaded,
+    stakingContractInfoRecord,
+    updateActiveStakingContractInfo,
+    setIsPaused,
   } = useContext(StakingContractInfoContext);
 
-  const { services } = useServices();
+  const { service } = useServices();
 
-  if (!services?.[0] || !activeStakingContractInfo)
-    return { stakingContractInfoRecord };
+  // TODO: find a better way to handle this, currently stops react lifecycle hooks being implemented below it
+  if (!service || !activeStakingContractInfo)
+    return {
+      stakingContractInfoRecord,
+      updateActiveStakingContractInfo,
+      setIsPaused,
+      isPaused,
+    };
 
   const {
     serviceStakingState,
@@ -72,12 +81,15 @@ export const useStakingContractInfo = () => {
   return {
     activeStakingContractInfo,
     hasEnoughServiceSlots,
-    isEligibleForStaking,
-    isRewardsAvailable,
     isAgentEvicted,
+    isEligibleForStaking,
+    isPaused,
+    isRewardsAvailable,
     isServiceStakedForMinimumDuration,
     isServiceStaked,
     isStakingContractInfoLoaded,
     stakingContractInfoRecord,
+    updateActiveStakingContractInfo,
+    setIsPaused,
   };
 };


### PR DESCRIPTION
- paused staking contract info polling while deploying
- added 5s timeout after deployment success response as a workaround

**not** a good approach, would prefer to receive success responses from middleware once agent is confirmed deployed, staked, and running ..

however, in the interest of having this patched for tomorrow, have raised this PR

**balance transition** 
experienced as service is progressing through registry service states
only seen when deploying for the first time

https://github.com/user-attachments/assets/5ebcdc03-768d-48eb-96c0-b15ea641cff4
