### PR TITLE
feat: load last transaction after 1 minute

### DIFF
--- a/frontend/components/MainPage/header/LastTransaction.tsx
+++ b/frontend/components/MainPage/header/LastTransaction.tsx
@@ -1,6 +1,5 @@
-import { Skeleton, Typography } from 'antd';
-import { useCallback, useEffect, useState } from 'react';
-import styled from 'styled-components';
+import { Typography } from 'antd';
+import { useCallback, useState } from 'react';
 import { useInterval } from 'usehooks-ts';
 
 import { useAddress } from '@/hooks/useAddress';
@@ -10,19 +9,10 @@ import { getTimeAgo } from '@/utils/time';
 
 const { Text } = Typography;
 
-const Loader = styled(Skeleton.Input)`
-  line-height: 1;
-  span {
-    width: 120px !important;
-    height: 12px !important;
-    margin-top: 6px !important;
-  }
-`;
-
 const POLLING_INTERVAL = 60 * 1000; // 1 minute
 
 /**
- * Component to display the last transaction time and link to the transaction on GnosisScan
+ * Displays the last transaction time and link to the transaction on GnosisScan
  * by agent safe.
  */
 export const LastTransaction = () => {
@@ -42,17 +32,10 @@ export const LastTransaction = () => {
       .finally(() => setIsFetching(false));
   }, [multisigAddress]);
 
-  // Fetch the latest transaction on mount
-  useEffect(() => {
-    fetchTransaction();
-  }, [fetchTransaction]);
-
   // Poll for the latest transaction
   useInterval(() => fetchTransaction(), POLLING_INTERVAL);
 
-  if (isFetching) {
-    return <Loader active size="small" />;
-  }
+  if (isFetching) return null;
 
   if (!transaction) {
     return (


### PR DESCRIPTION
- The last transaction will be fetched after one minute, not during the initial load.
- The loader has been removed.

https://github.com/user-attachments/assets/5c5da825-d348-49e8-8203-1c323ab5b600

