### PR TITLE
fix: fetch response parsing, create safe retry

### DIFF
--- a/electron/install.js
+++ b/electron/install.js
@@ -14,7 +14,7 @@ const homedir = os.homedir();
  * - use "" (nothing as a suffix) for latest release candidate, for example "0.1.0rc26"
  * - use "alpha" for alpha release, for example "0.1.0rc26-alpha"
  */
-const OlasMiddlewareVersion = '0.1.0rc158';
+const OlasMiddlewareVersion = '0.1.0rc162';
 
 const path = require('path');
 const { app } = require('electron');

--- a/frontend/components/SetupPage/Create/SetupCreateSafe.tsx
+++ b/frontend/components/SetupPage/Create/SetupCreateSafe.tsx
@@ -56,7 +56,7 @@ export const SetupCreateSafe = () => {
         })
         .catch(async (e) => {
           console.error(e);
-          // Wait for 1 second before retrying
+          // Wait for 5 seconds before retrying
           await new Promise((resolve) => setTimeout(resolve, 5000));
           // Retry
           const newRetries = retries - 1;

--- a/frontend/components/SetupPage/Create/SetupCreateSafe.tsx
+++ b/frontend/components/SetupPage/Create/SetupCreateSafe.tsx
@@ -12,6 +12,7 @@ import { usePageState } from '@/hooks/usePageState';
 import { useSetup } from '@/hooks/useSetup';
 import { useWallet } from '@/hooks/useWallet';
 import { WalletService } from '@/service/Wallet';
+import { delayInSeconds } from '@/utils/delay';
 
 export const SetupCreateSafe = () => {
   const { goto } = usePageState();
@@ -58,7 +59,7 @@ export const SetupCreateSafe = () => {
         .catch(async (e) => {
           console.error(e);
           // Wait for 5 seconds before retrying
-          await new Promise((resolve) => setTimeout(resolve, 5000));
+          await delayInSeconds(5);
           // Retry
           const newRetries = retries - 1;
           if (newRetries <= 0) {
@@ -81,9 +82,7 @@ export const SetupCreateSafe = () => {
 
   useEffect(() => {
     if (failed || isCreatingSafe || isCreateSafeSuccessful) return;
-    (async () => {
-      createSafeWithRetries(3);
-    })();
+    createSafeWithRetries(3);
   }, [
     backupSigner,
     createSafeWithRetries,

--- a/frontend/components/SetupPage/Create/SetupCreateSafe.tsx
+++ b/frontend/components/SetupPage/Create/SetupCreateSafe.tsx
@@ -113,7 +113,7 @@ export const SetupCreateSafe = () => {
           <Typography.Text>
             If the issue persists, please{' '}
             <a href={SUPPORT_URL} target="_blank" rel="noreferrer">
-              contact Olas community support.
+              contact Olas community support. {UNICODE_SYMBOLS.EXTERNAL_LINK}
             </a>
             .
           </Typography.Text>

--- a/frontend/components/SetupPage/Create/SetupCreateSafe.tsx
+++ b/frontend/components/SetupPage/Create/SetupCreateSafe.tsx
@@ -65,7 +65,7 @@ export const SetupCreateSafe = () => {
           } else {
             message.error('Failed to create account, retrying in 5 seconds');
           }
-          createSafeWithRetries(retries - 1);
+          createSafeWithRetries(newRetries);
         });
     },
     [backupSigner, updateMasterSafeOwners, updateWallets],

--- a/frontend/components/SetupPage/Create/SetupCreateSafe.tsx
+++ b/frontend/components/SetupPage/Create/SetupCreateSafe.tsx
@@ -113,7 +113,7 @@ export const SetupCreateSafe = () => {
           <Typography.Text>
             If the issue persists, please{' '}
             <a href={SUPPORT_URL} target="_blank" rel="noreferrer">
-              contact Olas community support. {UNICODE_SYMBOLS.EXTERNAL_LINK}
+              contact Olas community support {UNICODE_SYMBOLS.EXTERNAL_LINK}
             </a>
             .
           </Typography.Text>

--- a/frontend/components/SetupPage/Create/SetupCreateSafe.tsx
+++ b/frontend/components/SetupPage/Create/SetupCreateSafe.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Chain } from '@/client';
 import { CardSection } from '@/components/styled/CardSection';
+import { UNICODE_SYMBOLS } from '@/constants/symbols';
 import { SUPPORT_URL } from '@/constants/urls';
 import { Pages } from '@/enums/PageState';
 import { useMasterSafe } from '@/hooks/useMasterSafe';

--- a/frontend/components/SetupPage/Create/SetupSeedPhrase.tsx
+++ b/frontend/components/SetupPage/Create/SetupSeedPhrase.tsx
@@ -28,19 +28,21 @@ export const SetupSeedPhrase = () => {
           <Tag key={word}>{word}</Tag>
         ))}
       </Flex>
-      <Button
-        size="large"
-        onClick={() =>
-          copyToClipboard(mnemonic.join(' ')).then(() =>
-            message.success('Seed phrase is copied!'),
-          )
-        }
-      >
-        <CopyOutlined /> Copy to clipboard
-      </Button>
-      <Button type="primary" size="large" onClick={handleNext}>
-        Continue
-      </Button>
+      <Flex gap={10}>
+        <Button
+          size="large"
+          onClick={() =>
+            copyToClipboard(mnemonic.join(' ')).then(() =>
+              message.success('Seed phrase is copied!'),
+            )
+          }
+        >
+          <CopyOutlined /> Copy to clipboard
+        </Button>
+        <Button type="primary" size="large" onClick={handleNext}>
+          Continue
+        </Button>
+      </Flex>
     </CardFlex>
   );
 };

--- a/frontend/components/styled/CardFlex.tsx
+++ b/frontend/components/styled/CardFlex.tsx
@@ -13,7 +13,7 @@ export const CardFlex = styled(Card).withConfig({
       const { gap, noBodyPadding } = props;
 
       const gapStyle = gap ? `gap: ${gap}px;` : '';
-      const paddingStyle = noBodyPadding === 'true' ? 'padding: 0;' : undefined;
+      const paddingStyle = noBodyPadding === 'true' ? 'padding: 0;' : '';
 
       return `${gapStyle} ${paddingStyle}`;
     }}

--- a/frontend/constants/headers.ts
+++ b/frontend/constants/headers.ts
@@ -1,0 +1,3 @@
+export const CONTENT_TYPE_JSON_UTF8 = {
+  'Content-Type': 'application/json; charset=utf-8',
+};

--- a/frontend/constants/headers.ts
+++ b/frontend/constants/headers.ts
@@ -1,3 +1,3 @@
 export const CONTENT_TYPE_JSON_UTF8 = {
   'Content-Type': 'application/json; charset=utf-8',
-};
+} as const;

--- a/frontend/context/MasterSafeProvider.tsx
+++ b/frontend/context/MasterSafeProvider.tsx
@@ -19,7 +19,7 @@ export const MasterSafeContext = createContext<{
   masterSafeAddress?: Address;
   masterEoaAddress?: Address;
   masterSafeOwners?: Address[];
-  updateMasterSafeOwners?: () => Promise<void>;
+  updateMasterSafeOwners: () => Promise<void>;
 }>({
   backupSafeAddress: undefined,
   masterSafeAddress: undefined,

--- a/frontend/context/ServicesProvider.tsx
+++ b/frontend/context/ServicesProvider.tsx
@@ -84,7 +84,8 @@ export const ServicesProvider = ({ children }: PropsWithChildren) => {
           setHasInitialLoaded(true);
         })
         .catch((e) => {
-          message.error(e.message);
+          console.error(e);
+          // message.error(e.message); Commented out to avoid showing error message; need to handle "isAuthenticated" in a better way
         }),
     [],
   );

--- a/frontend/context/WalletProvider.tsx
+++ b/frontend/context/WalletProvider.tsx
@@ -29,9 +29,12 @@ export const WalletProvider = ({ children }: PropsWithChildren) => {
   const masterSafeAddress: Address | undefined = wallets?.[0]?.safe;
 
   const updateWallets = async () => {
-    const wallets = await WalletService.getWallets();
-    if (!wallets) return;
-    setWallets(wallets);
+    try {
+      const wallets = await WalletService.getWallets();
+      setWallets(wallets);
+    } catch (e) {
+      console.error(e);
+    }
   };
 
   useInterval(updateWallets, isOnline ? FIVE_SECONDS_INTERVAL : null);

--- a/frontend/service/Account.ts
+++ b/frontend/service/Account.ts
@@ -4,7 +4,10 @@ import { BACKEND_URL } from '@/constants/urls';
  * Gets account status "is_setup"
  */
 const getAccount = () =>
-  fetch(`${BACKEND_URL}/account`).then((res) => res.json());
+  fetch(`${BACKEND_URL}/account`).then((res) => {
+    if (res.ok) return res.json();
+    throw new Error('Failed to get account');
+  });
 
 /**
  * Creates a local user account
@@ -13,10 +16,13 @@ const createAccount = (password: string) =>
   fetch(`${BACKEND_URL}/account`, {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json',
+      'Content-Type': 'application/json; charset=utf-8',
     },
     body: JSON.stringify({ password }),
-  }).then((res) => res.json());
+  }).then((res) => {
+    if (res.ok) return res.json();
+    throw new Error('Failed to create account');
+  });
 
 /**
  * Updates user's password
@@ -25,13 +31,16 @@ const updateAccount = (oldPassword: string, newPassword: string) =>
   fetch(`${BACKEND_URL}/account`, {
     method: 'PUT',
     headers: {
-      'Content-Type': 'application/json',
+      'Content-Type': 'application/json; charset=utf-8',
     },
     body: JSON.stringify({
       old_password: oldPassword,
       new_password: newPassword,
     }),
-  }).then((res) => res.json());
+  }).then((res) => {
+    if (res.ok) return res.json();
+    throw new Error('Failed to update account');
+  });
 
 /**
  * Logs in a user
@@ -40,14 +49,14 @@ const loginAccount = (password: string) =>
   fetch(`${BACKEND_URL}/account/login`, {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json',
+      'Content-Type': 'application/json; charset=utf-8',
     },
     body: JSON.stringify({
       password,
     }),
   }).then((res) => {
-    if (![200, 201].includes(res.status)) throw new Error('Login failed');
-    res.json();
+    if (res.ok) return res.json();
+    throw new Error('Failed to login');
   });
 
 export const AccountService = {

--- a/frontend/service/Account.ts
+++ b/frontend/service/Account.ts
@@ -1,10 +1,15 @@
+import { CONTENT_TYPE_JSON_UTF8 } from '@/constants/headers';
 import { BACKEND_URL } from '@/constants/urls';
 
 /**
  * Gets account status "is_setup"
  */
 const getAccount = () =>
-  fetch(`${BACKEND_URL}/account`).then((res) => {
+  fetch(`${BACKEND_URL}/account`, {
+    headers: {
+      ...CONTENT_TYPE_JSON_UTF8,
+    },
+  }).then((res) => {
     if (res.ok) return res.json();
     throw new Error('Failed to get account');
   });
@@ -16,7 +21,7 @@ const createAccount = (password: string) =>
   fetch(`${BACKEND_URL}/account`, {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json; charset=utf-8',
+      ...CONTENT_TYPE_JSON_UTF8,
     },
     body: JSON.stringify({ password }),
   }).then((res) => {
@@ -30,9 +35,7 @@ const createAccount = (password: string) =>
 const updateAccount = (oldPassword: string, newPassword: string) =>
   fetch(`${BACKEND_URL}/account`, {
     method: 'PUT',
-    headers: {
-      'Content-Type': 'application/json; charset=utf-8',
-    },
+    headers: { ...CONTENT_TYPE_JSON_UTF8 },
     body: JSON.stringify({
       old_password: oldPassword,
       new_password: newPassword,
@@ -48,9 +51,7 @@ const updateAccount = (oldPassword: string, newPassword: string) =>
 const loginAccount = (password: string) =>
   fetch(`${BACKEND_URL}/account/login`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json; charset=utf-8',
-    },
+    headers: { ...CONTENT_TYPE_JSON_UTF8 },
     body: JSON.stringify({
       password,
     }),

--- a/frontend/service/Services.ts
+++ b/frontend/service/Services.ts
@@ -8,9 +8,17 @@ import { StakingProgramId } from '@/enums/StakingProgram';
  * @returns
  */
 const getService = async (serviceHash: ServiceHash): Promise<Service> =>
-  fetch(`${BACKEND_URL}/services/${serviceHash}`).then((response) =>
-    response.json(),
-  );
+  fetch(`${BACKEND_URL}/services/${serviceHash}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+  }).then((response) => {
+    if (response.ok) {
+      return response.json();
+    }
+    throw new Error(`Failed to fetch service ${serviceHash}`);
+  });
 
 /**
  * Gets an array of services from the backend
@@ -20,9 +28,14 @@ const getServices = async (): Promise<Service[]> =>
   fetch(`${BACKEND_URL}/services`, {
     method: 'GET',
     headers: {
-      'Content-Type': 'application/json',
+      'Content-Type': 'application/json; charset=utf-8',
     },
-  }).then((response) => response.json());
+  }).then((response) => {
+    if (response.ok) {
+      return response.json();
+    }
+    throw new Error('Failed to fetch services array');
+  });
 
 /**
  * Creates a service
@@ -53,7 +66,7 @@ const createService = async ({
         },
       }),
       headers: {
-        'Content-Type': 'application/json',
+        'Content-Type': 'application/json; charset=utf-8',
       },
     }).then((response) => {
       if (response.ok) {
@@ -66,39 +79,95 @@ const createService = async ({
 const deployOnChain = async (serviceHash: ServiceHash): Promise<Deployment> =>
   fetch(`${BACKEND_URL}/services/${serviceHash}/onchain/deploy`, {
     method: 'POST',
-  }).then((response) => response.json());
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+  }).then((response) => {
+    if (response.ok) {
+      return response.json();
+    }
+    throw new Error('Failed to deploy service on chain');
+  });
 
 const stopOnChain = async (serviceHash: ServiceHash): Promise<Deployment> =>
   fetch(`${BACKEND_URL}/services/${serviceHash}/onchain/stop`, {
     method: 'POST',
-  }).then((response) => response.json());
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+  }).then((response) => {
+    if (response.ok) {
+      return response.json();
+    }
+    throw new Error('Failed to stop service on chain');
+  });
 
 const buildDeployment = async (serviceHash: ServiceHash): Promise<Deployment> =>
   fetch(`${BACKEND_URL}/services/${serviceHash}/deployment/build`, {
     method: 'POST',
-  }).then((response) => response.json());
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+  }).then((response) => {
+    if (response.ok) {
+      return response.json();
+    }
+    throw new Error('Failed to build deployment');
+  });
 
 const startDeployment = async (serviceHash: ServiceHash): Promise<Deployment> =>
   fetch(`${BACKEND_URL}/services/${serviceHash}/deployment/start`, {
     method: 'POST',
-  }).then((response) => response.json());
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+  }).then((response) => {
+    if (response.ok) {
+      return response.json();
+    }
+    throw new Error('Failed to start deployment');
+  });
 
 const stopDeployment = async (serviceHash: ServiceHash): Promise<Deployment> =>
   fetch(`${BACKEND_URL}/services/${serviceHash}/deployment/stop`, {
     method: 'POST',
-  }).then((response) => response.json());
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+  }).then((response) => {
+    if (response.ok) {
+      return response.json();
+    }
+    throw new Error('Failed to stop deployment');
+  });
 
 const deleteDeployment = async (
   serviceHash: ServiceHash,
 ): Promise<Deployment> =>
   fetch(`${BACKEND_URL}/services/${serviceHash}/deployment/delete`, {
     method: 'POST',
-  }).then((response) => response.json());
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+  }).then((response) => {
+    if (response.ok) {
+      return response.json();
+    }
+    throw new Error('Failed to delete deployment');
+  });
 
 const getDeployment = async (serviceHash: ServiceHash): Promise<Deployment> =>
-  fetch(`${BACKEND_URL}/services/${serviceHash}/deployment`).then((response) =>
-    response.json(),
-  );
+  fetch(`${BACKEND_URL}/services/${serviceHash}/deployment`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+  }).then((response) => {
+    if (response.ok) {
+      return response.json();
+    }
+    throw new Error('Failed to get deployment');
+  });
 
 export const ServicesService = {
   getService,

--- a/frontend/service/Services.ts
+++ b/frontend/service/Services.ts
@@ -34,7 +34,7 @@ const getServices = async (): Promise<Service[]> =>
     if (response.ok) {
       return response.json();
     }
-    throw new Error('Failed to fetch services array');
+    throw new Error('Failed to fetch services');
   });
 
 /**

--- a/frontend/service/Services.ts
+++ b/frontend/service/Services.ts
@@ -1,4 +1,5 @@
 import { Deployment, Service, ServiceHash, ServiceTemplate } from '@/client';
+import { CONTENT_TYPE_JSON_UTF8 } from '@/constants/headers';
 import { BACKEND_URL } from '@/constants/urls';
 import { StakingProgramId } from '@/enums/StakingProgram';
 
@@ -11,7 +12,7 @@ const getService = async (serviceHash: ServiceHash): Promise<Service> =>
   fetch(`${BACKEND_URL}/services/${serviceHash}`, {
     method: 'GET',
     headers: {
-      'Content-Type': 'application/json; charset=utf-8',
+      ...CONTENT_TYPE_JSON_UTF8,
     },
   }).then((response) => {
     if (response.ok) {
@@ -28,7 +29,7 @@ const getServices = async (): Promise<Service[]> =>
   fetch(`${BACKEND_URL}/services`, {
     method: 'GET',
     headers: {
-      'Content-Type': 'application/json; charset=utf-8',
+      ...CONTENT_TYPE_JSON_UTF8,
     },
   }).then((response) => {
     if (response.ok) {
@@ -66,7 +67,7 @@ const createService = async ({
         },
       }),
       headers: {
-        'Content-Type': 'application/json; charset=utf-8',
+        ...CONTENT_TYPE_JSON_UTF8,
       },
     }).then((response) => {
       if (response.ok) {
@@ -80,7 +81,7 @@ const deployOnChain = async (serviceHash: ServiceHash): Promise<Deployment> =>
   fetch(`${BACKEND_URL}/services/${serviceHash}/onchain/deploy`, {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json; charset=utf-8',
+      ...CONTENT_TYPE_JSON_UTF8,
     },
   }).then((response) => {
     if (response.ok) {
@@ -93,7 +94,7 @@ const stopOnChain = async (serviceHash: ServiceHash): Promise<Deployment> =>
   fetch(`${BACKEND_URL}/services/${serviceHash}/onchain/stop`, {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json; charset=utf-8',
+      ...CONTENT_TYPE_JSON_UTF8,
     },
   }).then((response) => {
     if (response.ok) {
@@ -106,7 +107,7 @@ const buildDeployment = async (serviceHash: ServiceHash): Promise<Deployment> =>
   fetch(`${BACKEND_URL}/services/${serviceHash}/deployment/build`, {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json; charset=utf-8',
+      ...CONTENT_TYPE_JSON_UTF8,
     },
   }).then((response) => {
     if (response.ok) {
@@ -119,7 +120,7 @@ const startDeployment = async (serviceHash: ServiceHash): Promise<Deployment> =>
   fetch(`${BACKEND_URL}/services/${serviceHash}/deployment/start`, {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json; charset=utf-8',
+      ...CONTENT_TYPE_JSON_UTF8,
     },
   }).then((response) => {
     if (response.ok) {
@@ -132,7 +133,7 @@ const stopDeployment = async (serviceHash: ServiceHash): Promise<Deployment> =>
   fetch(`${BACKEND_URL}/services/${serviceHash}/deployment/stop`, {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json; charset=utf-8',
+      ...CONTENT_TYPE_JSON_UTF8,
     },
   }).then((response) => {
     if (response.ok) {
@@ -147,7 +148,7 @@ const deleteDeployment = async (
   fetch(`${BACKEND_URL}/services/${serviceHash}/deployment/delete`, {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json; charset=utf-8',
+      ...CONTENT_TYPE_JSON_UTF8,
     },
   }).then((response) => {
     if (response.ok) {
@@ -160,7 +161,7 @@ const getDeployment = async (serviceHash: ServiceHash): Promise<Deployment> =>
   fetch(`${BACKEND_URL}/services/${serviceHash}/deployment`, {
     method: 'GET',
     headers: {
-      'Content-Type': 'application/json; charset=utf-8',
+      ...CONTENT_TYPE_JSON_UTF8,
     },
   }).then((response) => {
     if (response.ok) {

--- a/frontend/service/Wallet.ts
+++ b/frontend/service/Wallet.ts
@@ -1,4 +1,5 @@
 import { Chain } from '@/client';
+import { CONTENT_TYPE_JSON_UTF8 } from '@/constants/headers';
 import { BACKEND_URL } from '@/constants/urls';
 
 /**
@@ -14,7 +15,7 @@ const createEoa = async (chain: Chain) =>
   fetch(`${BACKEND_URL}/wallet`, {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json; charset=utf-8',
+      ...CONTENT_TYPE_JSON_UTF8,
     },
     body: JSON.stringify({ chain_type: chain }),
   }).then((res) => {
@@ -26,7 +27,7 @@ const createSafe = async (chain: Chain, owner?: string) =>
   fetch(`${BACKEND_URL}/wallet/safe`, {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json; charset=utf-8',
+      ...CONTENT_TYPE_JSON_UTF8,
     },
     body: JSON.stringify({ chain_type: chain, owner: owner }),
   }).then((res) => {
@@ -38,7 +39,7 @@ const addBackupOwner = async (chain: Chain, owner: string) =>
   fetch(`${BACKEND_URL}/wallet/safe`, {
     method: 'PUT',
     headers: {
-      'Content-Type': 'application/json; charset=utf-8',
+      ...CONTENT_TYPE_JSON_UTF8,
     },
     body: JSON.stringify({ chain_type: chain, owner: owner }),
   }).then((res) => {

--- a/frontend/service/Wallet.ts
+++ b/frontend/service/Wallet.ts
@@ -5,34 +5,46 @@ import { BACKEND_URL } from '@/constants/urls';
  * Returns a list of available wallets
  */
 const getWallets = async () =>
-  fetch(`${BACKEND_URL}/wallet`).then((res) => res.json());
+  fetch(`${BACKEND_URL}/wallet`).then((res) => {
+    if (res.ok) return res.json();
+    throw new Error('Failed to get wallets');
+  });
 
 const createEoa = async (chain: Chain) =>
   fetch(`${BACKEND_URL}/wallet`, {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json',
+      'Content-Type': 'application/json; charset=utf-8',
     },
     body: JSON.stringify({ chain_type: chain }),
-  }).then((res) => res.json());
+  }).then((res) => {
+    if (res.ok) return res.json();
+    throw new Error('Failed to create EOA');
+  });
 
 const createSafe = async (chain: Chain, owner?: string) =>
   fetch(`${BACKEND_URL}/wallet/safe`, {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json',
+      'Content-Type': 'application/json; charset=utf-8',
     },
     body: JSON.stringify({ chain_type: chain, owner: owner }),
-  }).then((res) => res.json());
+  }).then((res) => {
+    if (res.ok) return res.json();
+    throw new Error('Failed to create safe');
+  });
 
 const addBackupOwner = async (chain: Chain, owner: string) =>
   fetch(`${BACKEND_URL}/wallet/safe`, {
     method: 'PUT',
     headers: {
-      'Content-Type': 'application/json',
+      'Content-Type': 'application/json; charset=utf-8',
     },
     body: JSON.stringify({ chain_type: chain, owner: owner }),
-  }).then((res) => res.json());
+  }).then((res) => {
+    if (res.ok) return res.json();
+    throw new Error('Failed to add backup owner');
+  });
 
 export const WalletService = {
   getWallets,

--- a/package.json
+++ b/package.json
@@ -62,5 +62,5 @@
     "download-binaries": "sh download_binaries.sh",
     "build:pearl": "sh build_pearl.sh"
   },
-  "version": "0.1.0-rc158"
+  "version": "0.1.0-rc162"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "olas-operate-middleware"
-version = "0.1.0-rc158"
+version = "0.1.0-rc162"
 description = ""
 authors = ["David Vilela <dvilelaf@gmail.com>", "Viraj Patel <vptl185@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Proposed changes

- update API services to parse error statuses and throw
- add utf-8 charset, unlikely to be required, but may support decoding issues on middleware 
- add create safe retries
- updates "creating safe" text at different steps
- check backup signer exists before continuing to main (stops missing backup wallet alert appearing)
- added error message notifications during creation (i.e. if retrying)

no real UI changes, will ask @iasonrovis to test rc162

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
