### PR TITLE
Fix: Apply env-vars to overrides in ServiceHelper

### DIFF
--- a/operate/services/service.py
+++ b/operate/services/service.py
@@ -41,6 +41,7 @@ from aea.configurations.constants import (
     SKILL,
 )
 from aea.configurations.data_types import PackageType
+from aea.helpers.env_vars import apply_env_variables
 from aea.helpers.yaml_utils import yaml_dump, yaml_load, yaml_load_all
 from aea_cli_ipfs.ipfs_utils import IPFSTool
 from autonomy.cli.helpers.deployment import run_deployment, stop_deployment
@@ -244,6 +245,9 @@ class ServiceHelper:
         """Initialize object."""
         self.path = path
         self.config = load_service_config(service_path=path)
+        self.config.overrides = apply_env_variables(
+            self.config.overrides, os.environ.copy()
+        )
 
     def ledger_configs(self) -> LedgerConfigs:
         """Get ledger configs."""


### PR DESCRIPTION
## Proposed changes
Apply environment variables to service overrides, when loading them.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
