### PR TITLE
refactor AgentNotRunningButton (useBalance consumer) + small changes to serviceTemplate, createService API, support multi-chain service templates and remove 

### DIFF
--- a/frontend/components/MainPage/header/AgentButton/AgentNotRunningButton.tsx
+++ b/frontend/components/MainPage/header/AgentButton/AgentNotRunningButton.tsx
@@ -181,7 +181,7 @@ export const AgentNotRunningButton = (serviceConfigId: string) => {
 
     return (
       (safeOlasBalanceWithStaked ?? 0) >= requiredStakedOlas &&
-      (totalEthBalance ?? 0) > LOW_MASTER_SAFE_BALANCE
+      (totalEthBalance ?? 0) > LOW_MASTER_SAFE_BALANCE // TODO: change to service/chain dynamic threshold
     );
   }, [
     isAllStakingContractDetailsRecordLoaded,

--- a/frontend/components/MainPage/header/AgentButton/AgentNotRunningButton.tsx
+++ b/frontend/components/MainPage/header/AgentButton/AgentNotRunningButton.tsx
@@ -5,7 +5,7 @@ import { MiddlewareChain, MiddlewareDeploymentStatus } from '@/client';
 import { STAKING_PROGRAMS } from '@/config/stakingPrograms';
 import { ChainId } from '@/enums/Chain';
 import { StakingProgramId } from '@/enums/StakingProgram';
-import { useBalance } from '@/hooks/useBalance';
+import { useBalanceContext } from '@/hooks/useBalanceContext';
 import { useElectronApi } from '@/hooks/useElectronApi';
 import { useService } from '@/hooks/useService';
 import { useServices } from '@/hooks/useServices';
@@ -47,7 +47,8 @@ export const AgentNotRunningButton = () => {
     totalOlasStakedBalance,
     totalEthBalance,
     updateBalances,
-  } = useBalance();
+  } = useBalanceContext();
+
   const { storeState } = useStore();
 
   const {

--- a/frontend/components/MainPage/header/AgentButton/AgentNotRunningButton.tsx
+++ b/frontend/components/MainPage/header/AgentButton/AgentNotRunningButton.tsx
@@ -61,161 +61,128 @@ export const AgentNotRunningButton = (serviceConfigId: string) => {
     activeStakingProgramId,
   );
 
-  // const minStakingDeposit =
-  //   allStakingContractDetailsRecord?.[activeStakingProgram ?? defaultStakingProgram]
-  //     ?.minStakingDeposit;
-
   const requiredStakedOlas =
     service &&
     STAKING_PROGRAMS[service.home_chain_id][activeStakingProgramId]
-      ?.stakingRequirements[TokenSymbol.OLAS]; // TODO: fix activeStakingProgramId
+      ?.stakingRequirements[TokenSymbol.OLAS];
 
-  const safeOlasBalance = serviceSafeBalances.find((walletBalanceResult) => {
-    return walletBalanceResult.symbol === TokenSymbol.OLAS;
-  })?.balance;
+  const safeOlasBalance = serviceSafeBalances.find(
+    (walletBalanceResult) => walletBalanceResult.symbol === TokenSymbol.OLAS,
+  )?.balance;
 
   const safeOlasBalanceWithStaked =
     safeOlasBalance === undefined || totalStakedOlasBalance === undefined
       ? undefined
       : safeOlasBalance + totalStakedOlasBalance;
 
-  const handleStart = useCallback(async () => {
-    // Must have a wallet to start the agent
-    if (!wallets?.[0]) return;
-
-    // Paused to stop overlapping service poll while wallet is created or service is built
+  const pauseAllPolling = useCallback(() => {
     setIsServicePollingPaused(true);
-
-    // Paused to stop confusing balance transitions while starting the agent
     setIsBalancePollingPaused(true);
-
-    // Paused to stop overlapping staking contract info poll while starting the agent
     setIsStakingContractInfoPollingPaused(true);
-
-    // Mock "DEPLOYING" status (service polling will update this once resumed)
-    setDeploymentStatus(MiddlewareDeploymentStatus.DEPLOYING);
-
-    // Create master safe if it doesn't exist
-    try {
-      if (
-        !service?.chain_configs[service.home_chain_id]?.chain_data?.multisig
-      ) {
-        await WalletService.createSafe(MiddlewareChain.OPTIMISM);
-      }
-    } catch (error) {
-      console.error(error);
-      // setServiceStatus(undefined); // TODO: reimplement state if it is missing
-      showNotification?.('Some error occurred while creating safe');
-      setIsStakingContractInfoPollingPaused(false);
-      setIsServicePollingPaused(false);
-      setIsBalancePollingPaused(false);
-      return;
-    }
-
-    // Then create / deploy the service
-    try {
-      await ServicesService.createService({
-        stakingProgramId: activeStakingProgramId,
-        serviceTemplate,
-        deploy: true,
-        useMechMarketplace: false,
-      });
-
-      await ServicesService.startService(serviceConfigId);
-    } catch (error) {
-      console.error(error);
-      // setServiceStatus(undefined); TODO: reimplement state if it is missing
-      showNotification?.('Some error occurred while deploying service');
-      setIsServicePollingPaused(false);
-      setIsBalancePollingPaused(false);
-      setIsStakingContractInfoPollingPaused(false);
-      return;
-    }
-
-    // Show success notification based on whether there was a service prior to starting
-    try {
-      showNotification?.(`Your agent is running!`);
-    } catch (error) {
-      console.error(error);
-      showNotification?.(
-        'Some error occurred while showing "running" notification',
-      );
-    }
-
-    // Can assume successful deployment
-    setDeploymentStatus(MiddlewareDeploymentStatus.DEPLOYED);
-
-    // TODO: remove this workaround, middleware should respond when agent is staked & confirmed running after `createService` call
-    await delayInSeconds(5);
-
-    // update provider states sequentially
-    // service id is required before activeStakingContractDetails & balances can be updated
-    try {
-      await updateServicesState?.(); // reload the available services
-      await refetchActiveStakingContractDetails(); // reload active staking contract with new service
-      await updateBalances(); // reload the balances
-    } catch (error) {
-      console.error(error);
-    } finally {
-      // resume polling
-      setIsServicePollingPaused(false);
-      setIsStakingContractInfoPollingPaused(false);
-      setIsBalancePollingPaused(false);
-    }
   }, [
-    wallets,
     setIsServicePollingPaused,
     setIsBalancePollingPaused,
     setIsStakingContractInfoPollingPaused,
-    setDeploymentStatus,
-    service?.chain_configs,
-    service?.home_chain_id,
-    showNotification,
-    activeStakingProgramId,
-    serviceTemplate,
-    serviceConfigId,
+  ]);
+
+  const resumeAllPolling = useCallback(() => {
+    setIsServicePollingPaused(false);
+    setIsBalancePollingPaused(false);
+    setIsStakingContractInfoPollingPaused(false);
+  }, [
+    setIsServicePollingPaused,
+    setIsBalancePollingPaused,
+    setIsStakingContractInfoPollingPaused,
+  ]);
+
+  const createSafeIfNeeded = useCallback(async () => {
+    if (!service?.chain_configs[service.home_chain_id]?.chain_data?.multisig) {
+      await WalletService.createSafe(MiddlewareChain.OPTIMISM);
+    }
+  }, [service]);
+
+  const deployAndStartService = useCallback(async () => {
+    await ServicesService.createService({
+      stakingProgramId: activeStakingProgramId,
+      serviceTemplate,
+      deploy: true,
+      useMechMarketplace: false,
+    });
+
+    await ServicesService.startService(serviceConfigId);
+  }, [activeStakingProgramId, serviceTemplate, serviceConfigId]);
+
+  const updateStatesSequentially = useCallback(async () => {
+    await updateServicesState?.();
+    await refetchActiveStakingContractDetails();
+    await updateBalances();
+  }, [
     updateServicesState,
     refetchActiveStakingContractDetails,
     updateBalances,
   ]);
 
+  const handleStart = useCallback(async () => {
+    if (!wallets?.[0]) return;
+
+    pauseAllPolling();
+    setDeploymentStatus(MiddlewareDeploymentStatus.DEPLOYING);
+
+    try {
+      await createSafeIfNeeded();
+      await deployAndStartService();
+      showNotification?.(`Your agent is running!`);
+      setDeploymentStatus(MiddlewareDeploymentStatus.DEPLOYED);
+
+      await delayInSeconds(5);
+      await updateStatesSequentially();
+    } catch (error) {
+      console.error('Error while starting the agent:', error);
+      showNotification?.('Some error occurred. Please try again.');
+    } finally {
+      resumeAllPolling();
+    }
+  }, [
+    wallets,
+    pauseAllPolling,
+    resumeAllPolling,
+    setDeploymentStatus,
+    createSafeIfNeeded,
+    deployAndStartService,
+    showNotification,
+    updateStatesSequentially,
+  ]);
+
   const isDeployable = useMemo(() => {
     if (!isAllStakingContractDetailsRecordLoaded) return false;
 
-    // if the agent is NOT running and the balance is too low,
-    // user should not be able to start the agent
     const isServiceInactive =
       deploymentStatus === MiddlewareDeploymentStatus.BUILT ||
       deploymentStatus === MiddlewareDeploymentStatus.STOPPED;
-    if (isServiceInactive && isLowBalance) {
+    if (isServiceInactive && isLowBalance) return false;
+
+    if (
+      [
+        MiddlewareDeploymentStatus.DEPLOYED,
+        MiddlewareDeploymentStatus.DEPLOYING,
+        MiddlewareDeploymentStatus.STOPPING,
+      ].some((runningStatus) => deploymentStatus === runningStatus)
+    )
       return false;
-    }
 
-    if (deploymentStatus === MiddlewareDeploymentStatus.DEPLOYED) return false;
-    if (deploymentStatus === MiddlewareDeploymentStatus.DEPLOYING) return false;
-    if (deploymentStatus === MiddlewareDeploymentStatus.STOPPING) return false;
+    if (!requiredStakedOlas || (!hasEnoughServiceSlots && !isServiceStaked))
+      return false;
 
-    if (!requiredStakedOlas) return false;
-
-    // If no slots available, agent cannot be started
-    if (!hasEnoughServiceSlots && !isServiceStaked) return false;
-
-    // case where service exists & user has initial funded
     if (service && storeState?.isInitialFunded) {
-      if (!safeOlasBalanceWithStaked) return false;
-      // at present agent will always require staked/bonded OLAS (or the ability to stake/bond)
-      return safeOlasBalanceWithStaked >= requiredStakedOlas;
+      return (safeOlasBalanceWithStaked ?? 0) >= requiredStakedOlas;
     }
 
-    // case if agent is evicted and user has met the staking criteria
     if (isEligibleForStaking && isAgentEvicted) return true;
 
-    const hasEnoughOlas =
-      (safeOlasBalanceWithStaked ?? 0) >= requiredStakedOlas;
-
-    const hasEnoughEth = (totalEthBalance ?? 0) > LOW_MASTER_SAFE_BALANCE; // TODO: refactor to be dynamic to services cross-chain
-
-    return hasEnoughOlas && hasEnoughEth;
+    return (
+      (safeOlasBalanceWithStaked ?? 0) >= requiredStakedOlas &&
+      (totalEthBalance ?? 0) > LOW_MASTER_SAFE_BALANCE
+    );
   }, [
     isAllStakingContractDetailsRecordLoaded,
     deploymentStatus,

--- a/frontend/components/MainPage/header/index.tsx
+++ b/frontend/components/MainPage/header/index.tsx
@@ -2,7 +2,7 @@ import { Flex } from 'antd';
 import { useCallback, useEffect, useState } from 'react';
 
 import { MiddlewareDeploymentStatus } from '@/client';
-import { useBalance } from '@/hooks/useBalance';
+import { useBalanceContext } from '@/hooks/useBalanceContext';
 import { useElectronApi } from '@/hooks/useElectronApi';
 import { useService } from '@/hooks/useService';
 import { useServices } from '@/hooks/useServices';
@@ -12,7 +12,7 @@ import { AgentButton } from './AgentButton/AgentButton';
 import { AgentHead } from './AgentHead';
 
 const useSetupTrayIcon = () => {
-  const { isLowBalance } = useBalance();
+  const { lowBalances } = useBalanceContext();
   const { selectedService } = useServices();
   const { deploymentStatus } = useService({
     serviceConfigId: selectedService?.service_config_id,

--- a/frontend/components/MainPage/index.tsx
+++ b/frontend/components/MainPage/index.tsx
@@ -1,18 +1,10 @@
 import { QuestionCircleOutlined, SettingOutlined } from '@ant-design/icons';
 import { Button, Card, Flex } from 'antd';
-import { useEffect } from 'react';
 
 import { Pages } from '@/enums/Pages';
 // import { StakingProgramId } from '@/enums/StakingProgram';
-import { useBalanceContext } from '@/hooks/useBalanceContext';
 // import { useMasterSafe } from '@/hooks/useMasterSafe';
 import { usePageState } from '@/hooks/usePageState';
-import { useServices } from '@/hooks/useServices';
-import {
-  useStakingContractContext,
-  useStakingContractDetails,
-} from '@/hooks/useStakingContractDetails';
-import { useStakingProgram } from '@/hooks/useStakingProgram';
 
 // import { useStakingProgram } from '@/hooks/useStakingProgram';
 import { MainHeader } from './header';
@@ -28,41 +20,43 @@ import { RewardsSection } from './sections/RewardsSection';
 export const Main = () => {
   const { goto } = usePageState();
   // const { backupSafeAddress } = useMasterSafe();
-  const { refetch: updateServicesState } = useServices();
-  const {
-    updateBalances,
-    isLoaded: isBalanceLoaded,
-    setIsLoaded: setIsBalanceLoaded,
-  } = useBalanceContext();
-  const { activeStakingProgramId } = useStakingProgram();
+  // const { refetch: updateServicesState } = useServices();
+  // const {
+  //   updateBalances,
+  //   isLoaded: isBalanceLoaded,
+  //   setIsLoaded: setIsBalanceLoaded,
+  // } = useBalanceContext();
+  // const { activeStakingProgramId } = useStakingProgram();
 
-  const { isAllStakingContractDetailsRecordLoaded } =
-    useStakingContractContext();
+  // TODO: reintroduce later,  non critical
+  // const { isAllStakingContractDetailsRecordLoaded } =
+  //   useStakingContractContext();
 
-  const { hasEnoughServiceSlots } = useStakingContractDetails(
-    activeStakingProgramId ?? INITIAL_DEFAULT_STAKING_PROGRAM_ID,
-  );
+  // const { hasEnoughServiceSlots } = useStakingContractDetails(
+  //   activeStakingProgramId,
+  // );
 
-  /**
-   * @todo fix this isLoaded logic
-   */
-  useEffect(() => {
-    if (!isBalanceLoaded) {
-      updateServicesState().then(() => updateBalances());
-      setIsBalanceLoaded(true);
-    }
-  }, [
-    isBalanceLoaded,
-    setIsBalanceLoaded,
-    updateBalances,
-    updateServicesState,
-  ]);
+  // TODO: reintroduce later,  non critical
 
-  const hideMainOlasBalanceTopBorder = [
-    !backupSafeAddress, // TODO: update this condition to check backup safe relative to selectedService
-    activeStakingProgramId === StakingProgramId.Alpha,
-    isAllStakingContractDetailsRecordLoaded && !hasEnoughServiceSlots,
-  ].some((condition) => !!condition);
+  // useEffect(() => {
+  //   if (!isBalanceLoaded) {
+  //     updateServicesState?.().then(() => updateBalances());
+  //     setIsBalanceLoaded(true);
+  //   }
+  // }, [
+  //   isBalanceLoaded,
+  //   setIsBalanceLoaded,
+  //   updateBalances,
+  //   updateServicesState,
+  // ]);
+
+  // TODO: reintroduce later,  non critical
+
+  // const hideMainOlasBalanceTopBorder = [
+  //   !backupSafeAddress, // TODO: update this condition to check backup safe relative to selectedService
+  //   activeStakingProgramId === StakingProgramId.Alpha,
+  //   isAllStakingContractDetailsRecordLoaded && !hasEnoughServiceSlots,
+  // ].some((condition) => !!condition);
 
   return (
     <Card

--- a/frontend/components/MainPage/index.tsx
+++ b/frontend/components/MainPage/index.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 
 import { Pages } from '@/enums/Pages';
 // import { StakingProgramId } from '@/enums/StakingProgram';
-import { useBalance } from '@/hooks/useBalance';
+import { useBalanceContext } from '@/hooks/useBalanceContext';
 // import { useMasterSafe } from '@/hooks/useMasterSafe';
 import { usePageState } from '@/hooks/usePageState';
 import { useServices } from '@/hooks/useServices';
@@ -33,7 +33,7 @@ export const Main = () => {
     updateBalances,
     isLoaded: isBalanceLoaded,
     setIsLoaded: setIsBalanceLoaded,
-  } = useBalance();
+  } = useBalanceContext();
   const { activeStakingProgramId, defaultStakingProgramId } =
     useStakingProgram();
 
@@ -60,7 +60,7 @@ export const Main = () => {
   ]);
 
   const hideMainOlasBalanceTopBorder = [
-    !backupSafeAddress,
+    !backupSafeAddress, // TODO: update this condition to check backup safe relative to selectedService
     activeStakingProgramId === StakingProgramId.Alpha,
     isAllStakingContractDetailsRecordLoaded && !hasEnoughServiceSlots,
   ].some((condition) => !!condition);

--- a/frontend/components/MainPage/index.tsx
+++ b/frontend/components/MainPage/index.tsx
@@ -28,20 +28,19 @@ import { RewardsSection } from './sections/RewardsSection';
 export const Main = () => {
   const { goto } = usePageState();
   // const { backupSafeAddress } = useMasterSafe();
-  const { updateServicesState } = useServices();
+  const { refetch: updateServicesState } = useServices();
   const {
     updateBalances,
     isLoaded: isBalanceLoaded,
     setIsLoaded: setIsBalanceLoaded,
   } = useBalanceContext();
-  const { activeStakingProgramId, defaultStakingProgramId } =
-    useStakingProgram();
+  const { activeStakingProgramId } = useStakingProgram();
 
   const { isAllStakingContractDetailsRecordLoaded } =
     useStakingContractContext();
 
   const { hasEnoughServiceSlots } = useStakingContractDetails(
-    activeStakingProgramId ?? defaultStakingProgramId,
+    activeStakingProgramId ?? INITIAL_DEFAULT_STAKING_PROGRAM_ID,
   );
 
   /**

--- a/frontend/components/MainPage/sections/AlertSections/LowTradingBalanceAlert.tsx
+++ b/frontend/components/MainPage/sections/AlertSections/LowTradingBalanceAlert.tsx
@@ -2,13 +2,13 @@ import { Flex, Typography } from 'antd';
 
 import { CustomAlert } from '@/components/Alert';
 import { LOW_MASTER_SAFE_BALANCE } from '@/constants/thresholds';
-import { useBalance } from '@/hooks/useBalance';
+import { useBalanceContext } from '@/hooks/useBalanceContext';
 import { useStore } from '@/hooks/useStore';
 
 const { Text, Title } = Typography;
 
 export const LowTradingBalanceAlert = () => {
-  const { isBalanceLoaded, isLowBalance } = useBalance();
+  const { isBalanceLoaded, isLowBalance } = useBalanceContext();
   const { storeState } = useStore();
 
   if (!isBalanceLoaded) return null;

--- a/frontend/components/MainPage/sections/GasBalanceSection.tsx
+++ b/frontend/components/MainPage/sections/GasBalanceSection.tsx
@@ -7,7 +7,7 @@ import styled from 'styled-components';
 import { MiddlewareChain } from '@/client';
 import { COLOR } from '@/constants/colors';
 import { EXPLORER_URL } from '@/constants/urls';
-import { useBalance } from '@/hooks/useBalance';
+import { useBalanceContext } from '@/hooks/useBalanceContext';
 import { useElectronApi } from '@/hooks/useElectronApi';
 import { useStore } from '@/hooks/useStore';
 import { useWallet } from '@/hooks/useWallet';
@@ -36,7 +36,7 @@ const FineDot = styled(Dot)`
 `;
 
 const BalanceStatus = () => {
-  const { isBalanceLoaded, isLowBalance } = useBalance();
+  const { isBalanceLoaded, isLowBalance } = useBalanceContext();
   const { storeState } = useStore();
   const { showNotification } = useElectronApi();
 
@@ -98,7 +98,7 @@ const TooltipContent = styled.div`
 
 export const GasBalanceSection = () => {
   const { masterSafeAddress } = useWallet();
-  const { isBalanceLoaded } = useBalance();
+  const { isBalanceLoaded } = useBalanceContext();
 
   return (
     <CardSection

--- a/frontend/components/MainPage/sections/OlasBalanceSection.tsx
+++ b/frontend/components/MainPage/sections/OlasBalanceSection.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import { UNICODE_SYMBOLS } from '@/constants/symbols';
 // import { Pages } from '@/enums/PageState';
-import { useBalance } from '@/hooks/useBalance';
+import { useBalanceContext } from '@/hooks/useBalanceContext';
 // import { usePageState } from '@/hooks/usePageState';
 import { balanceFormat } from '@/utils/numberFormatters';
 
@@ -22,7 +22,7 @@ type MainOlasBalanceProps = { isBorderTopVisible?: boolean };
 export const MainOlasBalance = ({
   isBorderTopVisible = true,
 }: MainOlasBalanceProps) => {
-  const { isBalanceLoaded, totalOlasBalance } = useBalance();
+  const { isBalanceLoaded, totalOlasBalance } = useBalanceContext();
   // const { goto } = usePageState();
 
   const balance = useMemo(() => {

--- a/frontend/components/MainPage/sections/RewardsSection/NotifyRewardsModal.tsx
+++ b/frontend/components/MainPage/sections/RewardsSection/NotifyRewardsModal.tsx
@@ -2,7 +2,7 @@ import { Button, Flex, Modal, Typography } from 'antd';
 import Image from 'next/image';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { useBalance } from '@/hooks/useBalance';
+import { useBalanceContext } from '@/hooks/useBalanceContext';
 import { useElectronApi } from '@/hooks/useElectronApi';
 import { useReward } from '@/hooks/useReward';
 import { useStore } from '@/hooks/useStore';
@@ -20,7 +20,7 @@ const OPERATE_URL = 'https://olas.network/operate?pearl=first-reward';
 
 export const NotifyRewardsModal = () => {
   const { isEligibleForRewards, availableRewardsForEpochEth } = useReward();
-  const { totalOlasBalance } = useBalance();
+  const { totalOlasBalance } = useBalanceContext();
   const { showNotification, store } = useElectronApi();
   const { storeState } = useStore();
 

--- a/frontend/components/MainPage/sections/RewardsSection/RewardsStreak.tsx
+++ b/frontend/components/MainPage/sections/RewardsSection/RewardsStreak.tsx
@@ -7,7 +7,7 @@ import { FireStreak } from '@/components/custom-icons/FireStreak';
 import { COLOR } from '@/constants/colors';
 import { NA } from '@/constants/symbols';
 import { Pages } from '@/enums/PageState';
-import { useBalance } from '@/hooks/useBalance';
+import { useBalanceContext } from '@/hooks/useBalanceContext';
 import { usePageState } from '@/hooks/usePageState';
 import { useReward } from '@/hooks/useReward';
 import { useRewardsHistory } from '@/hooks/useRewardsHistory';
@@ -22,7 +22,7 @@ const RewardsStreakFlex = styled(Flex)`
 `;
 
 const Streak = () => {
-  const { isBalanceLoaded } = useBalance();
+  const { isBalanceLoaded } = useBalanceContext();
   const { isEligibleForRewards } = useReward();
   const {
     latestRewardStreak: streak,

--- a/frontend/components/MainPage/sections/RewardsSection/index.tsx
+++ b/frontend/components/MainPage/sections/RewardsSection/index.tsx
@@ -1,6 +1,6 @@
 import { Flex, Skeleton, Tag, Typography } from 'antd';
 
-import { useBalance } from '@/hooks/useBalance';
+import { useBalanceContext } from '@/hooks/useBalanceContext';
 import { useReward } from '@/hooks/useReward';
 import { balanceFormat } from '@/utils/numberFormatters';
 
@@ -23,7 +23,7 @@ const getFormattedReward = (reward: number | undefined) =>
 
 const DisplayRewards = () => {
   const { availableRewardsForEpochEth, isEligibleForRewards } = useReward();
-  const { isBalanceLoaded } = useBalance();
+  const { isBalanceLoaded } = useBalanceContext();
 
   const reward = getFormattedReward(availableRewardsForEpochEth);
 

--- a/frontend/components/ManageStakingPage/StakingContractSection/CantMigrateAlert.tsx
+++ b/frontend/components/ManageStakingPage/StakingContractSection/CantMigrateAlert.tsx
@@ -4,7 +4,7 @@ import { isNil } from 'lodash';
 import { CustomAlert } from '@/components/Alert';
 import { LOW_MASTER_SAFE_BALANCE } from '@/constants/thresholds';
 import { StakingProgramId } from '@/enums/StakingProgram';
-import { useBalance } from '@/hooks/useBalance';
+import { useBalanceContext } from '@/hooks/useBalanceContext';
 import { useNeedsFunds } from '@/hooks/useNeedsFunds';
 import { useServiceTemplates } from '@/hooks/useServiceTemplates';
 import {
@@ -27,7 +27,7 @@ const AlertInsufficientMigrationFunds = ({
     useStakingContractContext();
   const { isServiceStaked } = useActiveStakingContractInfo();
   const { masterSafeBalance: safeBalance, totalOlasStakedBalance } =
-    useBalance();
+    useBalanceContext();
   const { serviceFundRequirements, isInitialFunded } = useNeedsFunds();
 
   const totalOlasRequiredForStaking = getMinimumStakedAmountRequired(

--- a/frontend/components/ManageStakingPage/StakingContractSection/MigrateButton.tsx
+++ b/frontend/components/ManageStakingPage/StakingContractSection/MigrateButton.tsx
@@ -5,7 +5,7 @@ import { useMemo } from 'react';
 import { MiddlewareDeploymentStatus } from '@/client';
 import { Pages } from '@/enums/Pages';
 import { StakingProgramId } from '@/enums/StakingProgram';
-import { useBalance } from '@/hooks/useBalance';
+import { useBalanceContext } from '@/hooks/useBalanceContext';
 import { useModals } from '@/hooks/useModals';
 import { usePageState } from '@/hooks/usePageState';
 import { useService } from '@/hooks/useService';
@@ -41,7 +41,7 @@ export const MigrateButton = ({
         : '',
   });
 
-  const { setIsPaused: setIsBalancePollingPaused } = useBalance();
+  const { setIsPaused: setIsBalancePollingPaused } = useBalanceContext();
 
   const { activeStakingContractDetails, isActiveStakingContractDetailsLoaded } =
     useActiveStakingContractInfo();

--- a/frontend/components/ManageStakingPage/StakingContractSection/useMigrate.tsx
+++ b/frontend/components/ManageStakingPage/StakingContractSection/useMigrate.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 
 import { MiddlewareDeploymentStatus } from '@/client';
 import { StakingProgramId } from '@/enums/StakingProgram';
-import { useBalance } from '@/hooks/useBalance';
+import { useBalanceContext } from '@/hooks/useBalanceContext';
 import { useNeedsFunds } from '@/hooks/useNeedsFunds';
 import { useServices } from '@/hooks/useServices';
 import { useServiceTemplates } from '@/hooks/useServiceTemplates';
@@ -46,7 +46,7 @@ export const useMigrate = (stakingProgramId: StakingProgramId) => {
     masterSafeBalance: safeBalance,
     totalOlasStakedBalance,
     isLowBalance,
-  } = useBalance();
+  } = useBalanceContext();
   const { activeStakingProgramId, activeStakingProgramMeta } =
     useStakingProgram();
   const { needsInitialFunding } = useNeedsFunds();

--- a/frontend/components/SettingsPage/AddBackupWalletPage.tsx
+++ b/frontend/components/SettingsPage/AddBackupWalletPage.tsx
@@ -5,14 +5,14 @@ import { useMemo } from 'react';
 import { MiddlewareChain } from '@/client';
 import { MIN_ETH_BALANCE_THRESHOLDS } from '@/constants/thresholds';
 import { SettingsScreen } from '@/enums/SettingsScreen';
-import { useBalance } from '@/hooks/useBalance';
+import { useBalanceContext } from '@/hooks/useBalanceContext';
 import { useSettings } from '@/hooks/useSettings';
 
 import { CardTitle } from '../Card/CardTitle';
 import { CardFlex } from '../styled/CardFlex';
 
 export const AddBackupWalletPage = () => {
-  const { masterEoaBalance: eoaBalance } = useBalance();
+  const { masterEoaBalance: eoaBalance } = useBalanceContext();
   const { goto } = useSettings();
 
   const [form] = Form.useForm();

--- a/frontend/components/SettingsPage/DebugInfoSection.tsx
+++ b/frontend/components/SettingsPage/DebugInfoSection.tsx
@@ -19,7 +19,7 @@ import { EXPLORER_URL } from '@/constants/urls';
 import { MODAL_WIDTH } from '@/constants/width';
 import { TokenSymbol } from '@/enums/Token';
 import { useAddress } from '@/hooks/useAddress';
-import { useBalance } from '@/hooks/useBalance';
+import { useBalanceContext } from '@/hooks/useBalanceContext';
 import { useWallet } from '@/hooks/useWallet';
 import { WalletAddressNumberRecord } from '@/types/Records';
 import { copyToClipboard } from '@/utils/copyToClipboard';
@@ -119,7 +119,7 @@ const DebugItem = ({
 export const DebugInfoSection = () => {
   const { wallets, masterEoaAddress, masterSafeAddress } = useWallet();
   const { instanceAddress, multisigAddress } = useAddress();
-  const { walletBalances } = useBalance();
+  const { walletBalances } = useBalanceContext();
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const showModal = useCallback(() => setIsModalOpen(true), []);

--- a/frontend/components/SetupPage/SetupWelcome.tsx
+++ b/frontend/components/SetupPage/SetupWelcome.tsx
@@ -14,7 +14,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { MiddlewareAccountIsSetup } from '@/client';
 import { Pages } from '@/enums/Pages';
 import { SetupScreen } from '@/enums/SetupScreen';
-import { useBalance } from '@/hooks/useBalance';
+import { useBalanceContext } from '@/hooks/useBalanceContext';
 import { useElectronApi } from '@/hooks/useElectronApi';
 import { usePageState } from '@/hooks/usePageState';
 import { useSetup } from '@/hooks/useSetup';
@@ -130,7 +130,7 @@ export const SetupWelcomeLogin = () => {
   const { goto: gotoPage } = usePageState();
 
   const { masterSafeAddress, wallets } = useWallet();
-  const { isBalanceLoaded, masterEoaBalance: eoaBalance } = useBalance();
+  const { isBalanceLoaded, masterEoaBalance: eoaBalance } = useBalanceContext();
 
   const [isLoggingIn, setIsLoggingIn] = useState(false);
   const [canNavigate, setCanNavigate] = useState(false);

--- a/frontend/components/YourWalletPage/YourAgent.tsx
+++ b/frontend/components/YourWalletPage/YourAgent.tsx
@@ -7,7 +7,7 @@ import { MiddlewareChain } from '@/client';
 import { SERVICE_REGISTRY_L2_CONTRACT_ADDRESS } from '@/config/olasContracts';
 import { UNICODE_SYMBOLS } from '@/constants/symbols';
 import { useAddress } from '@/hooks/useAddress';
-import { useBalance } from '@/hooks/useBalance';
+import { useBalanceContext } from '@/hooks/useBalanceContext';
 import { useReward } from '@/hooks/useReward';
 import { useServices } from '@/hooks/useServices';
 import { generateName } from '@/utils/agentName';
@@ -149,7 +149,7 @@ const ServiceAndNftDetails = () => {
 };
 
 export const YourAgentWallet = () => {
-  const { isBalanceLoaded, agentSafeBalance, agentEoaBalance } = useBalance();
+  const { isBalanceLoaded, agentSafeBalance, agentEoaBalance } = useBalanceContext();
   const {
     availableRewardsForEpochEth,
     isEligibleForRewards,

--- a/frontend/components/YourWalletPage/index.tsx
+++ b/frontend/components/YourWalletPage/index.tsx
@@ -7,7 +7,7 @@ import { CardTitle } from '@/components/Card/CardTitle';
 import { InfoBreakdownList } from '@/components/InfoBreakdown';
 import { CardFlex } from '@/components/styled/CardFlex';
 import { Pages } from '@/enums/Pages';
-import { useBalance } from '@/hooks/useBalance';
+import { useBalanceContext } from '@/hooks/useBalanceContext';
 import { usePageState } from '@/hooks/usePageState';
 import { useServices } from '@/hooks/useServices';
 import { useWallet } from '@/hooks/useWallet';
@@ -49,7 +49,7 @@ const Address = () => {
 
 const OlasBalance = () => {
   const { masterSafeBalance: safeBalance, totalOlasStakedBalance } =
-    useBalance();
+    useBalanceContext();
   const olasBalances = useMemo(() => {
     return [
       {
@@ -79,7 +79,7 @@ const OlasBalance = () => {
 };
 
 const XdaiBalance = () => {
-  const { masterSafeBalance: safeBalance } = useBalance();
+  const { masterSafeBalance: safeBalance } = useBalanceContext();
 
   return (
     <Flex vertical gap={8}>
@@ -99,7 +99,7 @@ const XdaiBalance = () => {
 
 const Signer = () => {
   const { masterEoaAddress } = useWallet();
-  const { masterEoaBalance: eoaBalance } = useBalance();
+  const { masterEoaBalance: eoaBalance } = useBalanceContext();
 
   return (
     <Flex vertical gap={8}>

--- a/frontend/constants/serviceTemplates.ts
+++ b/frontend/constants/serviceTemplates.ts
@@ -12,8 +12,8 @@ export const SERVICE_TEMPLATES: ServiceTemplate[] = [
     service_version: 'v0.18.4',
     home_chain_id: ChainId.Gnosis.toString(),
     configurations: {
-      [ChainId.Optimism]: {
-        staking_program_id: StakingProgramId.OptimusAlpha, // default, may be overwritten
+      [ChainId.Gnosis]: {
+        staking_program_id: StakingProgramId.PearlBeta, // default, may be overwritten
         nft: 'bafybeig64atqaladigoc3ds4arltdu63wkdrk3gesjfvnfdmz35amv7faq',
         rpc: 'http://localhost:8545',
         agent_id: 14,

--- a/frontend/constants/thresholds.ts
+++ b/frontend/constants/thresholds.ts
@@ -23,4 +23,5 @@ export const MIN_ETH_BALANCE_THRESHOLDS = {
 };
 
 export const LOW_AGENT_SAFE_BALANCE = 0.5;
+
 export const LOW_MASTER_SAFE_BALANCE = 2;

--- a/frontend/context/BalanceProvider.tsx
+++ b/frontend/context/BalanceProvider.tsx
@@ -38,6 +38,7 @@ type CrossChainStakedBalances = Array<{
   chainId: number;
   olasBondBalance: number;
   olasDepositBalance: number;
+  walletAddress: Address;
 }>;
 
 export const BalanceContext = createContext<{
@@ -250,7 +251,7 @@ export const BalanceProvider = ({ children }: PropsWithChildren) => {
   );
 };
 
-type WalletBalanceResult = {
+export type WalletBalanceResult = {
   walletAddress: Address;
   chainId: ChainId;
   symbol: TokenSymbol;
@@ -369,6 +370,8 @@ const getCrossChainStakedBalances = async (
           olasDepositBalance: depositValue,
           serviceState,
         }),
+        walletAddress:
+          services[idx].chain_configs[chainId].chain_data.multisig!, // multisig must exist if registry info is fetched
       });
     } else {
       console.error(

--- a/frontend/context/BalanceProvider.tsx
+++ b/frontend/context/BalanceProvider.tsx
@@ -38,10 +38,7 @@ type CrossChainStakedBalances = Array<{
   chainId: number;
   olasBondBalance: number;
   olasDepositBalance: number;
-<<<<<<< HEAD
   walletAddress: Address;
-=======
->>>>>>> refactor/balance-provider-hooks
 }>;
 
 export const BalanceContext = createContext<{
@@ -373,11 +370,8 @@ const getCrossChainStakedBalances = async (
           olasDepositBalance: depositValue,
           serviceState,
         }),
-<<<<<<< HEAD
         walletAddress:
           services[idx].chain_configs[chainId].chain_data.multisig!, // multisig must exist if registry info is fetched
-=======
->>>>>>> refactor/balance-provider-hooks
       });
     } else {
       console.error(

--- a/frontend/context/StakingProgramProvider.tsx
+++ b/frontend/context/StakingProgramProvider.tsx
@@ -1,5 +1,4 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Maybe } from 'graphql/jsutils/Maybe';
 import { createContext, PropsWithChildren, useCallback } from 'react';
 
 import { FIVE_SECONDS_INTERVAL } from '@/constants/intervals';
@@ -13,10 +12,10 @@ const INITIAL_DEFAULT_STAKING_PROGRAM_ID = StakingProgramId.PearlBeta;
 
 export const StakingProgramContext = createContext<{
   isActiveStakingProgramLoaded: boolean;
-  activeStakingProgramId: Maybe<StakingProgramId>;
+  activeStakingProgramId: StakingProgramId;
 }>({
   isActiveStakingProgramLoaded: false,
-  activeStakingProgramId: null,
+  activeStakingProgramId: INITIAL_DEFAULT_STAKING_PROGRAM_ID,
 });
 
 /**
@@ -73,7 +72,8 @@ export const StakingProgramProvider = ({ children }: PropsWithChildren) => {
       value={{
         isActiveStakingProgramLoaded:
           !isStakingProgramsLoading && !!activeStakingProgramId,
-        activeStakingProgramId,
+        activeStakingProgramId:
+          activeStakingProgramId || INITIAL_DEFAULT_STAKING_PROGRAM_ID,
       }}
     >
       {children}

--- a/frontend/hooks/useBalance.ts
+++ b/frontend/hooks/useBalance.ts
@@ -1,5 +1,0 @@
-import { useContext } from 'react';
-
-import { BalanceContext } from '@/context/BalanceProvider';
-
-export const useBalance = () => useContext(BalanceContext);

--- a/frontend/hooks/useBalanceContext.ts
+++ b/frontend/hooks/useBalanceContext.ts
@@ -1,0 +1,35 @@
+import { useContext, useMemo } from 'react';
+
+import { BalanceContext } from '@/context/BalanceProvider';
+
+import { useService } from './useService';
+
+export const useBalanceContext = () => useContext(BalanceContext);
+
+export const useServiceBalances = (serviceConfigId: string) => {
+  const { flatAddresses } = useService({ serviceConfigId });
+  const { walletBalances, lowBalances, stakedBalances } = useBalanceContext();
+
+  const serviceWalletBalances = useMemo(
+    () =>
+      walletBalances?.filter((balance) =>
+        flatAddresses.includes(balance.walletAddress),
+      ),
+    [flatAddresses, walletBalances],
+  );
+
+  const serviceStakedBalances = useMemo(
+    () =>
+      stakedBalances?.filter((balance) =>
+        flatAddresses.includes(balance.walletAddress),
+      ),
+    [flatAddresses, stakedBalances],
+  );
+
+  const serviceLowBalances = useMemo(
+    () => lowBalances?.filter((balance) => balance.walletAddress),
+    [lowBalances],
+  );
+
+  return { serviceWalletBalances, serviceLowBalances };
+};

--- a/frontend/hooks/useBalanceContext.ts
+++ b/frontend/hooks/useBalanceContext.ts
@@ -1,6 +1,6 @@
 import { useContext, useMemo } from 'react';
 
-import { BalanceContext } from '@/context/BalanceProvider';
+import { BalanceContext, WalletBalanceResult } from '@/context/BalanceProvider';
 
 import { useService } from './useService';
 
@@ -31,5 +31,24 @@ export const useServiceBalances = (serviceConfigId: string) => {
     [lowBalances],
   );
 
-  return { serviceWalletBalances, serviceLowBalances };
+  const isLowBalance = useMemo(
+    () => serviceLowBalances?.length > 0,
+    [serviceLowBalances],
+  );
+
+  const serviceSafeBalances = useMemo<WalletBalanceResult[]>(
+    () =>
+      walletBalances?.filter((balance) =>
+        flatAddresses.includes(balance.walletAddress),
+      ),
+    [flatAddresses, walletBalances],
+  );
+
+  return {
+    serviceWalletBalances,
+    serviceStakedBalances,
+    serviceSafeBalances,
+    serviceLowBalances,
+    isLowBalance,
+  };
 };

--- a/frontend/hooks/useLogs.ts
+++ b/frontend/hooks/useLogs.ts
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 
 import { REACT_QUERY_KEYS } from '@/constants/react-query-keys';
 
-import { useBalance } from './useBalance';
+import { useBalanceContext } from './useBalanceContext';
 import { useMasterSafe } from './useMasterSafe';
 import { useServices } from './useServices';
 import { useStore } from './useStore';
@@ -33,7 +33,7 @@ const useBalancesLogs = () => {
     wallets,
     walletBalances,
     totalOlasStakedBalance,
-  } = useBalance();
+  } = useBalanceContext();
 
   return {
     isLoaded: isBalanceLoaded,

--- a/frontend/hooks/useNeedsFunds.ts
+++ b/frontend/hooks/useNeedsFunds.ts
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 
 import { CHAIN_CONFIG } from '@/config/chains';
 
-import { useBalance } from './useBalance';
+import { useBalanceContext } from './useBalanceContext';
 import { useServiceTemplates } from './useServiceTemplates';
 import { useStore } from './useStore';
 
@@ -22,7 +22,7 @@ export const useNeedsFunds = () => {
     isBalanceLoaded,
     masterSafeBalance: safeBalance,
     totalOlasStakedBalance,
-  } = useBalance();
+  } = useBalanceContext();
 
   const serviceFundRequirements = useMemo(() => {
     const gasEstimate =

--- a/frontend/hooks/useService.ts
+++ b/frontend/hooks/useService.ts
@@ -58,6 +58,14 @@ export const useService = ({
     return addressesByChainId;
   }, [service]);
 
+  const flatAddresses = useMemo(() => {
+    return Object.values(addresses).reduce((acc, { agentSafe, agentEoas }) => {
+      if (agentSafe) acc.push(agentSafe);
+      if (agentEoas) acc.push(...agentEoas);
+      return acc;
+    }, [] as Address[]);
+  }, [addresses]);
+
   /**
    * Overrides the deployment status of the service in the cache.
    * @note Overwrite is only temporary if ServicesContext is polling
@@ -75,6 +83,7 @@ export const useService = ({
   return {
     service,
     addresses,
+    flatAddresses,
     isLoaded,
     deploymentStatus,
     setDeploymentStatus,

--- a/frontend/hooks/useServiceTemplates.ts
+++ b/frontend/hooks/useServiceTemplates.ts
@@ -4,11 +4,9 @@ import { SERVICE_TEMPLATES } from '@/constants/serviceTemplates';
 export const useServiceTemplates = () => {
   const getServiceTemplates = (): ServiceTemplate[] => SERVICE_TEMPLATES;
   const getServiceTemplate = (
-    serviceUuid: string,
+    templateHash: string,
   ): ServiceTemplate | undefined =>
-    SERVICE_TEMPLATES.find(
-      (template) => template.service_config_id === serviceUuid,
-    );
+    SERVICE_TEMPLATES.find((template) => template.hash === templateHash);
 
   return {
     getServiceTemplate,


### PR DESCRIPTION
## Proposed changes

- Support balance provider updates via useBalance hook
- Fix other imports i.e. service templates, createService
- Remove hardcoded Optimus enums in service template
- Add useServiceBalances for balances/ranges relative to a single service
- Flattened some objects, as they're a nightmare to work with
- Refactor AgentNotRunning button as `handleStart` is way too big

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
