### PR TITLE
Allow update metadata fields (description)

### DIFF
--- a/operate/services/manage.py
+++ b/operate/services/manage.py
@@ -411,6 +411,7 @@ class ServiceManager:
                     token=(
                         OLAS[ledger_config.chain] if user_params.use_staking else None
                     ),
+                    metadata_description=service.description,
                 ).get("token"),
             )
             chain_data.on_chain_state = OnChainState.PRE_REGISTRATION
@@ -665,6 +666,7 @@ class ServiceManager:
                                 if user_params.use_staking
                                 else None
                             ),
+                            metadata_description=service.description,
                         )
                     )
                     .settle()
@@ -714,6 +716,7 @@ class ServiceManager:
                             if user_params.use_staking
                             else None
                         ),
+                        metadata_description=service.description,
                     )
                 )
                 .settle()

--- a/operate/services/manage.py
+++ b/operate/services/manage.py
@@ -608,6 +608,12 @@ class ServiceManager:
             self._get_on_chain_state(service=service, chain=chain)
             == OnChainState.NON_EXISTENT
         )
+
+        # TODO Determine if the mint metadata hash changed - if so, it requires
+        # an on-chain update.
+        # This has to be implemented. Temporarily added as a placeholder (ignored).
+        has_metadata_changed = False
+
         is_update = (
             (not is_first_mint)
             and (on_chain_hash is not None)
@@ -616,8 +622,9 @@ class ServiceManager:
                 # on_chain_hash != service.hash or  # noqa
                 current_agent_id
                 != staking_params["agent_ids"][0]
-                # TODO Temporary removed for Optimus. Needs to be put back!
-                # or current_agent_bond != staking_params["min_staking_deposit"]
+                # TODO This has to be removed for Optimus (needs to be properly implemented). Needs to be put back for Trader!
+                or current_agent_bond != staking_params["min_staking_deposit"]
+                or has_metadata_changed
             )
         )
         current_staking_program = self._get_current_staking_program(

--- a/operate/services/protocol.py
+++ b/operate/services/protocol.py
@@ -30,7 +30,7 @@ import typing as t
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional, Union, cast
 
 from aea.configurations.data_types import PackageType
 from aea.crypto.base import Crypto, LedgerApi
@@ -43,6 +43,7 @@ from autonomy.chain.constants import (
     GNOSIS_SAFE_SAME_ADDRESS_MULTISIG_CONTRACT,
     MULTISEND_CONTRACT,
 )
+from autonomy.chain.metadata import publish_metadata
 from autonomy.chain.service import (
     get_agent_instances,
     get_delployment_payload,
@@ -51,8 +52,7 @@ from autonomy.chain.service import (
     get_token_deposit_amount,
 )
 from autonomy.chain.tx import TxSettler
-from autonomy.cli.helpers.chain import MintHelper as MintManager
-from autonomy.cli.helpers.chain import OnChainHelper
+from autonomy.cli.helpers.chain import MintHelper, OnChainHelper
 from autonomy.cli.helpers.chain import ServiceHelper as ServiceManager
 from eth_utils import to_bytes
 from hexbytes import HexBytes
@@ -491,6 +491,51 @@ class StakingManager(OnChainHelper):
         )
 
 
+# TODO Backport this to Open Autonomy MintHelper class
+# MintHelper should support passing custom 'description', 'name' and 'attributes'.
+# If some of these fields are not defined, then it can take the current default values.
+# (Version is included as an attribute.)
+# The current code here is a workaround and just addresses the description,
+# because modifying the name and attributes requires touching lower-level code.
+# A proper refactor of this should be done in Open Autonomy.
+class MintManager(MintHelper):
+    """MintManager"""
+
+    metadata_description: t.Optional[str] = None
+    metadata_name: t.Optional[str] = None
+    metadata_attributes: t.Optional[t.Dict[str, str]] = None
+
+    def set_metadata_fields(
+        self,
+        name: t.Optional[str] = None,
+        description: t.Optional[str] = None,
+        attributes: t.Optional[t.Dict[str, str]] = None,
+    ) -> "MintManager":
+        """Set metadata fields."""
+        self.metadata_name = (
+            name  # Not used currently, just an indication for the OA refactor
+        )
+        self.metadata_description = description
+        self.metadata_attributes = (
+            attributes  # Not used currently, just an indication for the OA refactor
+        )
+        return self
+
+    def publish_metadata(self) -> "MintManager":
+        """Publish metadata."""
+        self.metadata_hash, self.metadata_string = publish_metadata(
+            package_id=self.package_configuration.package_id,
+            package_path=self.package_path,
+            nft=cast(str, self.nft),
+            description=self.metadata_description
+            or self.package_configuration.description,
+        )
+        return self
+
+
+# End Backport
+
+
 class _ChainUtil:
     """On chain service management."""
 
@@ -840,6 +885,7 @@ class OnChainManager(_ChainUtil):
         nft: Optional[Union[Path, IPFSHash]],
         update_token: t.Optional[int] = None,
         token: t.Optional[str] = None,
+        metadata_description: t.Optional[str] = None,
     ) -> t.Dict:
         """Mint service."""
         # TODO: Support for update
@@ -860,6 +906,7 @@ class OnChainManager(_ChainUtil):
                 package_path=package_path, package_type=PackageType.SERVICE
             )
             .load_metadata()
+            .set_metadata_fields(description=metadata_description)
             .verify_nft(nft=nft)
             .verify_service_dependencies(agent_id=agent_id)
             .publish_metadata()
@@ -1061,6 +1108,7 @@ class EthSafeTxBuilder(_ChainUtil):
         nft: Optional[Union[Path, IPFSHash]],
         update_token: t.Optional[int] = None,
         token: t.Optional[str] = None,
+        metadata_description: t.Optional[str] = None,
     ) -> t.Dict:
         """Build mint transaction."""
         # TODO: Support for update
@@ -1080,6 +1128,7 @@ class EthSafeTxBuilder(_ChainUtil):
                 package_path=package_path, package_type=PackageType.SERVICE
             )
             .load_metadata()
+            .set_metadata_fields(description=metadata_description)
             .verify_nft(nft=nft)
             .verify_service_dependencies(agent_id=agent_id)
             .publish_metadata()


### PR DESCRIPTION
## Proposed changes

Allow update metadata fields. Namely, it allows update the description of the metadata file when minting a service to match the description passed in the service template.

This PR is a temporary solution for some refactor needed on Open Autonomy, and documented in a comment on the source code.

Important: this PR only allows updates in the description. However, placeholder values have been put for `name` and `attributes` to be properly implemented in OpenAutonomy.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
