### PR TITLE
fix: navigation on agent switch and other edge-cases (on closing app)

### DIFF
--- a/frontend/components/AgentSelection.tsx
+++ b/frontend/components/AgentSelection.tsx
@@ -43,8 +43,14 @@ const EachAgent = memo(
   ({ showSelected, agentType, agentConfig }: EachAgentProps) => {
     const { goto: gotoSetup } = useSetup();
     const { goto: gotoPage } = usePageState();
-    const { services, selectedAgentType, updateAgentType } = useServices();
-    const { masterSafes, isLoading } = useMasterWalletContext();
+    const {
+      isLoading: isServicesLoading,
+      services,
+      selectedAgentType,
+      updateAgentType,
+    } = useServices();
+    const { masterSafes, isLoading: isMasterWalletLoading } =
+      useMasterWalletContext();
 
     const isCurrentAgent = showSelected
       ? selectedAgentType === agentType
@@ -124,7 +130,7 @@ const EachAgent = memo(
               <Button
                 type="primary"
                 onClick={handleSelectAgent}
-                disabled={isLoading}
+                disabled={isServicesLoading || isMasterWalletLoading}
               >
                 Select
               </Button>

--- a/frontend/components/SetupPage/SetupWelcome.tsx
+++ b/frontend/components/SetupPage/SetupWelcome.tsx
@@ -143,7 +143,6 @@ export const SetupWelcomeLogin = () => {
   } = useServices();
   const {
     masterSafes,
-    masterWallets: wallets,
     masterEoa,
     isFetched: isWalletsFetched,
   } = useMasterWalletContext();
@@ -201,8 +200,9 @@ export const SetupWelcomeLogin = () => {
 
   useEffect(() => {
     if (!canNavigate) return;
-    if (!isBalanceLoaded) return;
+    if (!isServicesFetched) return;
     if (!isWalletsFetched) return;
+    if (!isBalanceLoaded) return;
 
     setIsLoggingIn(false);
 
@@ -229,14 +229,14 @@ export const SetupWelcomeLogin = () => {
 
     gotoPage(Pages.Main);
   }, [
-    isBalanceLoaded,
-    isWalletsFetched,
-    isServiceCreatedForAgent,
     canNavigate,
+    isServicesFetched,
+    isWalletsFetched,
+    isBalanceLoaded,
+    isServiceCreatedForAgent,
     eoaBalanceEth,
     masterSafe?.address,
     selectedServiceOrAgentChainId,
-    wallets?.length,
     goto,
     gotoPage,
   ]);


### PR DESCRIPTION
## Proposed changes

- If the user selects memeooorr, views the form, and closes the app—after reopening, they should see the form again on selecting memeooorr.
- If the user selects memeooorr, completes the form, views the funding page, and then closes the app—after reopening, they should see the funding page when memeooorr is selected.
- If the user selects memeooorr, completes the form, initiates funding to BASE, and closes the app before the safe is created—after reopening, the user should see the “main page.” However, if they switch back to memeooorr after agent selection, the “Create safe” screen should be displayed.
- If the user selects memeooorr, completes everything, switches agents to Gnosis, and closes the app—on reopening, the user should see the Switch Agent modal. After selecting the agent:
  - For Gnosis: If funding is not completed, the user should see the Funding page.
  - For memeooorr: The user should see the Main page.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
