### PR TITLE
fix: make isInitialFunded by agent type

### DIFF
--- a/electron/store.js
+++ b/electron/store.js
@@ -1,7 +1,7 @@
 const Store = require('electron-store');
+
 // set schema to validate store data
 const schema = {
-  isInitialFunded: { type: 'boolean', default: false }, // TODO: reconsider this default, can be problematic if user has already funded prior to implementation
   firstStakingRewardAchieved: { type: 'boolean', default: false },
   firstRewardNotificationShown: { type: 'boolean', default: false },
   agentEvictionAlertShown: { type: 'boolean', default: false },
@@ -11,6 +11,8 @@ const schema = {
 
   // agent settings
   lastSelectedAgentType: { type: 'string', default: 'trader' },
+  isInitialFunded_trader: { type: 'boolean', default: false },
+  isInitialFunded_memeooorr: { type: 'boolean', default: false },
 };
 
 /**
@@ -21,6 +23,17 @@ const schema = {
  */
 const setupStoreIpc = (ipcMain, mainWindow) => {
   const store = new Store({ schema });
+
+  /**
+   * isInitialFunded Migration
+   *
+   * Writes the old isInitialFunded value to the new isInitialFunded_trader
+   * And removes it from the store afterward
+   */
+  if (store.has('isInitialFunded')) {
+    store.set('isInitialFunded_trader', store.get('isInitialFunded'));
+    store.delete('isInitialFunded');
+  }
 
   store.onDidAnyChange((data) => {
     if (mainWindow?.webContents)

--- a/frontend/components/MainPage/header/AgentButton/AgentNotRunningButton.tsx
+++ b/frontend/components/MainPage/header/AgentButton/AgentNotRunningButton.tsx
@@ -114,7 +114,11 @@ export const AgentNotRunningButton = () => {
         walletBalanceResult.evmChainId === selectedAgentConfig.evmHomeChainId,
     )?.balance;
 
-    if (service && storeState?.isInitialFunded && isServiceStaked) {
+    if (
+      service &&
+      storeState?.[`isInitialFunded_${selectedAgentType}`] &&
+      isServiceStaked
+    ) {
       return (serviceTotalStakedOlas ?? 0) >= requiredStakedOlas;
     }
 

--- a/frontend/components/MainPage/sections/AlertSections/LowFunds/LowFunds.tsx
+++ b/frontend/components/MainPage/sections/AlertSections/LowFunds/LowFunds.tsx
@@ -17,7 +17,7 @@ import { MainNeedsFunds } from './MainNeedsFunds';
 export const LowFunds = () => {
   const { storeState } = useStore();
 
-  const { selectedAgentConfig } = useServices();
+  const { selectedAgentConfig, selectedAgentType } = useServices();
   const { selectedStakingProgramId } = useStakingProgram();
   const { isLoaded: isBalanceLoaded, masterEoaNativeGasBalance } =
     useMasterBalances();
@@ -31,7 +31,7 @@ export const LowFunds = () => {
   const isSafeSignerBalanceLow = useMemo(() => {
     if (!isBalanceLoaded) return false;
     if (!masterEoaNativeGasBalance) return false;
-    if (!storeState?.isInitialFunded) return false;
+    if (!storeState?.[`isInitialFunded_${selectedAgentType}`]) return false;
 
     return (
       masterEoaNativeGasBalance <
@@ -44,7 +44,8 @@ export const LowFunds = () => {
     masterEoaNativeGasBalance,
     selectedAgentConfig.evmHomeChainId,
     selectedAgentConfig.operatingThresholds,
-    storeState?.isInitialFunded,
+    selectedAgentType,
+    storeState,
   ]);
 
   // Show the empty funds alert if the agent is not funded

--- a/frontend/components/MainPage/sections/AlertSections/LowFunds/LowOperatingBalanceAlert.tsx
+++ b/frontend/components/MainPage/sections/AlertSections/LowFunds/LowOperatingBalanceAlert.tsx
@@ -15,7 +15,7 @@ const { Text, Title } = Typography;
 
 export const LowOperatingBalanceAlert = () => {
   const { storeState } = useStore();
-  const { selectedAgentConfig } = useServices();
+  const { selectedAgentConfig, selectedAgentType } = useServices();
   const { isLoaded: isBalanceLoaded, masterSafeNativeGasBalance } =
     useMasterBalances();
 
@@ -36,7 +36,7 @@ export const LowOperatingBalanceAlert = () => {
   ]);
 
   if (!isBalanceLoaded) return null;
-  if (!storeState?.isInitialFunded) return;
+  if (!storeState?.[`isInitialFunded_${selectedAgentType}`]) return;
   if (!isLowBalance) return null;
 
   return (

--- a/frontend/components/MainPage/sections/AlertSections/LowFunds/MainNeedsFunds.tsx
+++ b/frontend/components/MainPage/sections/AlertSections/LowFunds/MainNeedsFunds.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import { CustomAlert } from '@/components/Alert';
 import { useElectronApi } from '@/hooks/useElectronApi';
 import { useNeedsFunds } from '@/hooks/useNeedsFunds';
+import { useServices } from '@/hooks/useServices';
 import { useStakingProgram } from '@/hooks/useStakingProgram';
 
 import { FundsToActivate } from './FundsToActivate';
@@ -11,6 +12,7 @@ import { FundsToActivate } from './FundsToActivate';
 const { Title } = Typography;
 
 export const MainNeedsFunds = () => {
+  const { selectedAgentType } = useServices();
   const { selectedStakingProgramId } = useStakingProgram();
 
   const {
@@ -28,10 +30,11 @@ export const MainNeedsFunds = () => {
       hasEnoughOlasForInitialFunding &&
       !isInitialFunded
     ) {
-      electronApi.store?.set?.('isInitialFunded', true);
+      electronApi.store?.set?.(`isInitialFunded_${selectedAgentType}`, true);
     }
   }, [
     electronApi.store,
+    selectedAgentType,
     hasEnoughEthForInitialFunding,
     hasEnoughOlasForInitialFunding,
     isInitialFunded,

--- a/frontend/components/MainPage/sections/GasBalanceSection.tsx
+++ b/frontend/components/MainPage/sections/GasBalanceSection.tsx
@@ -41,7 +41,7 @@ const FineDot = styled(Dot)`
 
 const BalanceStatus = () => {
   const { isLoaded: isBalanceLoaded } = useBalanceContext();
-  const { isFetched: isServicesLoaded } = useServices();
+  const { isFetched: isServicesLoaded, selectedAgentType } = useServices();
 
   const { storeState } = useStore();
   const { showNotification } = useElectronApi();
@@ -55,7 +55,7 @@ const BalanceStatus = () => {
   useEffect(() => {
     if (!isBalanceLoaded || !isServicesLoaded) return;
     if (!showNotification) return;
-    if (!storeState?.isInitialFunded) return;
+    if (!storeState?.[`isInitialFunded_${selectedAgentType}`]) return;
 
     if (isMasterSafeLowOnNativeGas && !isLowBalanceNotificationShown) {
       showNotification('Operating balance is too low.');
@@ -73,7 +73,8 @@ const BalanceStatus = () => {
     isLowBalanceNotificationShown,
     isMasterSafeLowOnNativeGas,
     showNotification,
-    storeState?.isInitialFunded,
+    storeState,
+    selectedAgentType,
   ]);
 
   const status = useMemo(() => {

--- a/frontend/config/stakingPrograms/base.ts
+++ b/frontend/config/stakingPrograms/base.ts
@@ -19,7 +19,7 @@ export const BASE_STAKING_PROGRAMS_CONTRACT_ADDRESSES: Record<string, Address> =
 export const BASE_STAKING_PROGRAMS: StakingProgramMap = {
   [StakingProgramId.MemeBaseAlpha2]: {
     chainId: EvmChainId.Base,
-    name: 'MemeBase Alpha',
+    name: 'MemeBase Alpha II',
     agentsSupported: [AgentType.Memeooorr],
     stakingRequirements: {
       [TokenSymbol.OLAS]: 100,

--- a/frontend/hooks/useNeedsFunds.ts
+++ b/frontend/hooks/useNeedsFunds.ts
@@ -27,7 +27,7 @@ export const useNeedsFunds = (stakingProgramId: Maybe<StakingProgramId>) => {
   const { isLoaded: isBalanceLoaded } = useBalanceContext();
   const { masterSafeBalances } = useMasterBalances();
 
-  const isInitialFunded = storeState?.isInitialFunded;
+  const isInitialFunded = storeState?.[`isInitialFunded_${selectedAgentType}`];
 
   const serviceFundRequirements = useMemo<{
     [chainId: number]: {

--- a/frontend/types/ElectronApi.ts
+++ b/frontend/types/ElectronApi.ts
@@ -2,7 +2,8 @@ import { AgentType } from '@/enums/Agent';
 
 export type ElectronStore = {
   environmentName?: string;
-  isInitialFunded?: boolean;
+  isInitialFunded_trader?: boolean;
+  isInitialFunded_memeooorr?: boolean;
   firstStakingRewardAchieved?: boolean;
   firstRewardNotificationShown?: boolean;
   agentEvictionAlertShown?: boolean;


### PR DESCRIPTION
## Proposed changes

separate isInitialFunded into two variables by agent type

didn't support backward compatibility since we agreed to advice users not to switch back to old versions (due to BE will break) - but should think how to do it next time

this didn't work for me, too many issues (see "important" note): https://www.npmjs.com/package/electron-store#migrations


## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
