### PR TITLE
fix: update service with correct description

### DIFF
--- a/frontend/client/types.ts
+++ b/frontend/client/types.ts
@@ -44,9 +44,17 @@ export type ChainData = {
   };
 };
 
+export type EnvVariableAttributes = {
+  name: string;
+  description: string;
+  value: string;
+  provision_type: EnvProvisionType;
+};
+
 export type MiddlewareServiceResponse = {
   service_config_id: string; // TODO: update with uuid once middleware integrated
   name: string;
+  description: string;
   hash: string;
   hash_history: {
     [block: string]: string;
@@ -61,13 +69,7 @@ export type MiddlewareServiceResponse = {
       chain_data: ChainData;
     };
   };
-};
-
-export type EnvVariableAttributes = {
-  name: string;
-  description: string;
-  value: string;
-  provision_type: EnvProvisionType;
+  env_variables: { [key: string]: EnvVariableAttributes };
 };
 
 export type ServiceTemplate = {

--- a/frontend/components/MainPage/header/AgentButton/AgentNotRunningButton.tsx
+++ b/frontend/components/MainPage/header/AgentButton/AgentNotRunningButton.tsx
@@ -7,6 +7,7 @@ import { CHAIN_CONFIG } from '@/config/chains';
 import { MechType } from '@/config/mechs';
 import { STAKING_PROGRAMS } from '@/config/stakingPrograms';
 import { SERVICE_TEMPLATES } from '@/constants/serviceTemplates';
+import { AgentType } from '@/enums/Agent';
 import { Pages } from '@/enums/Pages';
 import { TokenSymbol } from '@/enums/Token';
 import {
@@ -257,7 +258,13 @@ const useServiceDeployment = () => {
     }
 
     // Temporary: update the service if it has the default description
-    if (service && service.description === 'Memeooorr @twitter_handle') {
+    if (
+      service &&
+      service.description ===
+        SERVICE_TEMPLATES.find(
+          (template) => template.agentType === AgentType.Memeooorr,
+        )?.description
+    ) {
       const xUsername = service.env_variables?.TWIKIT_USERNAME?.value;
       if (xUsername) {
         await ServicesService.updateService({

--- a/frontend/components/MainPage/header/AgentButton/AgentNotRunningButton.tsx
+++ b/frontend/components/MainPage/header/AgentButton/AgentNotRunningButton.tsx
@@ -228,7 +228,7 @@ const useServiceDeployment = () => {
     let middlewareServiceResponse;
     if (!service) {
       try {
-        return ServicesService.createService({
+        middlewareServiceResponse = await ServicesService.createService({
           stakingProgramId: selectedStakingProgramId,
           serviceTemplate,
           deploy: false, // TODO: deprecated will remove
@@ -251,6 +251,19 @@ const useServiceDeployment = () => {
           serviceConfigId: service.service_config_id,
           partialServiceTemplate: {
             hash: serviceTemplate.hash,
+          },
+        });
+      }
+    }
+
+    // Temporary: update the service if it has the default description
+    if (service && service.description === 'Memeooorr @twitter_handle') {
+      const xUsername = service.env_variables?.TWIKIT_USERNAME?.value;
+      if (xUsername) {
+        await ServicesService.updateService({
+          serviceConfigId: service.service_config_id,
+          partialServiceTemplate: {
+            description: `Memeooorr @${xUsername}`,
           },
         });
       }


### PR DESCRIPTION
## Proposed changes

for a short period of time we had a bug when the service hash has changed we updated the service with a service template leading to that the description was updated to the default one. there are services now that have default description, we should update them with the right one

old code:
<img width="517" alt="image" src="https://github.com/user-attachments/assets/69f1e840-9aa2-4ae3-b750-0a0014c59672" />


## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
