### PR TITLE
fix: service not created when switching between agents

### DIFF
--- a/frontend/context/ServicesProvider.tsx
+++ b/frontend/context/ServicesProvider.tsx
@@ -222,7 +222,10 @@ export const ServicesProvider = ({ children }: PropsWithChildren) => {
       ({ home_chain }) =>
         home_chain === selectedAgentConfig.middlewareHomeChainId,
     );
-    if (!currentService) return;
+    if (!currentService) {
+      setSelectedServiceConfigId(null);
+      return;
+    }
 
     setSelectedServiceConfigId(currentService.service_config_id);
   }, [


### PR DESCRIPTION
## Proposed changes

I've had only modius service created, and when I switched to trader and tried to start it, it didn't create the service because the `selectedServiceConfigId` had old modius value

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
