### PR TITLE
fix: Fix 1 day discrepancy in streak

### DIFF
--- a/frontend/components/RewardsHistory/RewardsHistory.tsx
+++ b/frontend/components/RewardsHistory/RewardsHistory.tsx
@@ -82,7 +82,7 @@ const NotEarnedTag = () => (
 
 const NotYetEarnedTag = () => (
   <Tag color="processing" className="m-0">
-    To be earned
+    Not yet earned
   </Tag>
 );
 


### PR DESCRIPTION
## Proposed changes

- Today’s reward is added at the top of the rewards history (a new tag “To be earned” is displayed if today’s rewards haven’t been earned yet).

<img width="448" alt="Screenshot" src="https://github.com/user-attachments/assets/f5a5b59f-43b3-466d-9d9c-1c3ec9f4fcf2" />

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
