### PR TITLE
Fix Olas total balance in rewards modal

### DIFF
--- a/frontend/components/MainPage/sections/RewardsSection/NotifyRewardsModal.tsx
+++ b/frontend/components/MainPage/sections/RewardsSection/NotifyRewardsModal.tsx
@@ -1,7 +1,7 @@
 import { Button, Flex, Modal, Typography } from 'antd';
 import sum from 'lodash/sum';
 import Image from 'next/image';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { NA } from '@/constants/symbols';
 import { OPERATE_URL } from '@/constants/urls';
@@ -30,6 +30,15 @@ export const NotifyRewardsModal = () => {
   const [canShowNotification, setCanShowNotification] = useState(false);
 
   const firstRewardRef = useRef<number>();
+
+  const formattedCurrentOlasBalance = useMemo(
+    () => balanceFormat(sum([totalOlasBalance, totalStakedOlasBalance]), 2),
+    [totalOlasBalance, totalStakedOlasBalance],
+  );
+  const formattedEarnedRewards = useMemo(
+    () => balanceFormat(availableRewardsForEpochEth, 2),
+    [availableRewardsForEpochEth],
+  );
 
   // hook to set the flag to show the notification
   useEffect(() => {
@@ -116,17 +125,13 @@ export const NotifyRewardsModal = () => {
       <Flex vertical gap={16}>
         <Text>
           Congratulations! Your agent just earned the first
-          <Text strong>
-            {` ${balanceFormat(availableRewardsForEpochEth, 2)} OLAS `}
-          </Text>
+          <Text strong>{` ${formattedEarnedRewards} OLAS `}</Text>
           for you!
         </Text>
 
         <Text>
           Your current balance:
-          <Text
-            strong
-          >{` ${balanceFormat(sum([totalOlasBalance, totalStakedOlasBalance]), 2)} OLAS `}</Text>
+          <Text strong>{` ${formattedCurrentOlasBalance} OLAS `}</Text>
         </Text>
 
         <Text>Keep it running to get even more!</Text>

--- a/frontend/components/MainPage/sections/RewardsSection/NotifyRewardsModal.tsx
+++ b/frontend/components/MainPage/sections/RewardsSection/NotifyRewardsModal.tsx
@@ -1,4 +1,5 @@
 import { Button, Flex, Modal, Typography } from 'antd';
+import sum from 'lodash/sum';
 import Image from 'next/image';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -22,7 +23,7 @@ const SHARE_TEXT = `I just earned my first reward through the Operate app powere
 export const NotifyRewardsModal = () => {
   const { isEligibleForRewards, availableRewardsForEpochEth } =
     useRewardContext();
-  const { totalOlasBalance } = useBalanceContext();
+  const { totalOlasBalance, totalStakedOlasBalance } = useBalanceContext();
   const { showNotification, store } = useElectronApi();
   const { storeState } = useStore();
 
@@ -123,7 +124,9 @@ export const NotifyRewardsModal = () => {
 
         <Text>
           Your current balance:
-          <Text strong>{` ${balanceFormat(totalOlasBalance, 2)} OLAS `}</Text>
+          <Text
+            strong
+          >{` ${balanceFormat(sum([totalOlasBalance, totalStakedOlasBalance]), 2)} OLAS `}</Text>
         </Text>
 
         <Text>Keep it running to get even more!</Text>

--- a/frontend/components/MainPage/sections/RewardsSection/NotifyRewardsModal.tsx
+++ b/frontend/components/MainPage/sections/RewardsSection/NotifyRewardsModal.tsx
@@ -1,11 +1,10 @@
 import { Button, Flex, Modal, Typography } from 'antd';
-import sum from 'lodash/sum';
 import Image from 'next/image';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { NA } from '@/constants/symbols';
 import { OPERATE_URL } from '@/constants/urls';
-import { useBalanceContext } from '@/hooks/useBalanceContext';
+import { useMainOlasBalance } from '@/context/SharedProvider/useMainOlasBalance';
 import { useElectronApi } from '@/hooks/useElectronApi';
 import { useRewardContext } from '@/hooks/useRewardContext';
 import { useStore } from '@/hooks/useStore';
@@ -23,7 +22,7 @@ const SHARE_TEXT = `I just earned my first reward through the Operate app powere
 export const NotifyRewardsModal = () => {
   const { isEligibleForRewards, availableRewardsForEpochEth } =
     useRewardContext();
-  const { totalOlasBalance, totalStakedOlasBalance } = useBalanceContext();
+  const { mainOlasBalance } = useMainOlasBalance();
   const { showNotification, store } = useElectronApi();
   const { storeState } = useStore();
 
@@ -31,9 +30,9 @@ export const NotifyRewardsModal = () => {
 
   const firstRewardRef = useRef<number>();
 
-  const formattedCurrentOlasBalance = useMemo(
-    () => balanceFormat(sum([totalOlasBalance, totalStakedOlasBalance]), 2),
-    [totalOlasBalance, totalStakedOlasBalance],
+  const formattedMainOlasBalance = useMemo(
+    () => balanceFormat(mainOlasBalance, 2),
+    [mainOlasBalance],
   );
   const formattedEarnedRewards = useMemo(
     () => balanceFormat(availableRewardsForEpochEth, 2),
@@ -131,7 +130,7 @@ export const NotifyRewardsModal = () => {
 
         <Text>
           Your current balance:
-          <Text strong>{` ${formattedCurrentOlasBalance} OLAS `}</Text>
+          <Text strong>{` ${formattedMainOlasBalance} OLAS `}</Text>
         </Text>
 
         <Text>Keep it running to get even more!</Text>


### PR DESCRIPTION
## Proposed changes

sum total olas in wallets and staked when displaying reward modal

(missing staked olas here)
![image](https://github.com/user-attachments/assets/2ad9ff42-c3c1-438d-86ae-b61f24ce57ce)


## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
