### PR TITLE
Feat/staking progarms tech debt

### DIFF
--- a/operate/cli.py
+++ b/operate/cli.py
@@ -111,7 +111,6 @@ class OperateApp:
             wallet_manager=self.wallet_manager,
             logger=self.logger,
         )
-        self.logger.info(f"Created service manager. Config file present: {manager.config_file is not None}")
         return manager
 
     @property

--- a/operate/cli.py
+++ b/operate/cli.py
@@ -105,12 +105,14 @@ class OperateApp:
 
     def service_manager(self) -> services.manage.ServiceManager:
         """Load service manager."""
-        return services.manage.ServiceManager(
+        manager = services.manage.ServiceManager(
             path=self._services,
             keys_manager=self.keys_manager,
             wallet_manager=self.wallet_manager,
             logger=self.logger,
         )
+        self.logger.info(f"Created service manager. Config file present: {manager.config_file is not None}")
+        return manager
 
     @property
     def user_account(self) -> t.Optional[UserAccount]:

--- a/operate/quickstart/run_service.py
+++ b/operate/quickstart/run_service.py
@@ -439,13 +439,13 @@ def run_service(operate: "OperateApp", config_path: str) -> None:
     service = get_service(manager, template)
 
     # Set config in manager
-    manager.config_file = template  # Add this line
+    manager.config_file = template
 
     ask_password_if_needed(operate, config)
 
-    # Reload with config to ensure it persists
+    # reload manger and config after setting operate.password
     manager = operate.service_manager()
-    manager.config_file = template  # Add this line again to ensure it persists
+    manager.config_file = template
 
     config = load_local_config()
     ensure_enough_funds(operate, service)

--- a/operate/quickstart/run_service.py
+++ b/operate/quickstart/run_service.py
@@ -430,7 +430,6 @@ def ensure_enough_funds(operate: "OperateApp", service: Service) -> None:
 
 def run_service(operate: "OperateApp", config_path: str) -> None:
     """Run service."""
-
     with open(config_path, "r") as config_file:
         template = json.load(config_file)
 
@@ -438,16 +437,23 @@ def run_service(operate: "OperateApp", config_path: str) -> None:
     config = configure_local_config(template)
     manager = operate.service_manager()
     service = get_service(manager, template)
+
+    # Set config in manager
+    manager.config_file = template  # Add this line
+
     ask_password_if_needed(operate, config)
 
-    # reload manger and config after setting operate.password
+    # Reload with config to ensure it persists
     manager = operate.service_manager()
+    manager.config_file = template  # Add this line again to ensure it persists
+
     config = load_local_config()
     ensure_enough_funds(operate, service)
 
     print_box("PLEASE, DO NOT INTERRUPT THIS PROCESS.")
     print_section(f"Deploying on-chain service on {config.principal_chain}...")
     print("Cancelling the on-chain service update prematurely could lead to an inconsistent state of the Safe or the on-chain service state, which may require manual intervention to resolve.\n")
+
     manager.deploy_service_onchain_from_safe(service_config_id=service.service_config_id)
 
     print_section("Funding the service")

--- a/operate/services/manage.py
+++ b/operate/services/manage.py
@@ -97,6 +97,13 @@ class ServiceManager:
         config_file: t.Optional[dict] = None,
         logger: t.Optional[logging.Logger] = None,
     ) -> None:
+        """
+        Initialze service manager
+        :param path: Path to service storage.
+        :param keys_manager: Keys manager.
+        :param wallet_manager: Wallet manager instance.
+        :param logger: logging.Logger object.
+        """
         self.path = path
         self.keys_manager = keys_manager
         self.wallet_manager = wallet_manager
@@ -1227,22 +1234,18 @@ class ServiceManager:
             raise ValueError("Config file missing staking programs")
 
         staking_programs = {k: v for k, v in config_file["staking_programs"].items() if k != "no_staking"}
-        logger.info(f"Searching staking programs: {staking_programs.keys()}")
         current_staking_program = None
         
         for staking_program in staking_programs:
-            logger.info(f"Checking staking status for program {staking_program}")
             state = sftxb.staking_status(
                 service_id=chain_data.token,
                 staking_contract=config_file["staking_programs"][staking_program]
             )
-            logger.info(f"Program {staking_program} state: {state}")
             if state in (StakingState.STAKED, StakingState.EVICTED):
                 current_staking_program = staking_program
                 logger.info(f"Found active staking program: {staking_program}")
                 break
                 
-        logger.info(f"Returning staking program: {current_staking_program}")
         return current_staking_program
 
     def unbond_service_on_chain(


### PR DESCRIPTION
# Staking Contract Configuration Refactor [Tech Debt]

> To be continued after `feat/multi-agent-middleware` is merged into `fix/meme-staging`

Major refactoring of staking contract management:

- Moves staking contracts from STAKING constant to config file
- Adds config validation and error handling
- Renames methods for clarity and adds slot counting functionality  
- Improves deployment validation for staking availability
- Filters out "no_staking" option from staking programs
