### PR TITLE
fix: allow creating safe when there is no backup wallet

### DIFF
--- a/frontend/components/SetupPage/Create/SetupCreateSafe.tsx
+++ b/frontend/components/SetupPage/Create/SetupCreateSafe.tsx
@@ -66,7 +66,8 @@ export const SetupCreateSafe = () => {
     isFetched: isWalletsFetched,
   } = useMasterWalletContext();
 
-  const { allBackupAddresses } = useMultisigs(masterSafes);
+  const { allBackupAddresses, masterSafesOwnersIsLoading } =
+    useMultisigs(masterSafes);
 
   const { backupSigner } = useSetup();
 
@@ -132,7 +133,7 @@ export const SetupCreateSafe = () => {
       // backup address is not loaded yet.
       // Note: the only case when it can be null forever is when the user closed the app
       // after entering the backup wallet but before creating a first safe
-      !backupSignerAddress
+      masterSafesOwnersIsLoading
     )
       return;
 
@@ -179,6 +180,7 @@ export const SetupCreateSafe = () => {
     isFailed,
     isWalletsFetched,
     masterSafes,
+    masterSafesOwnersIsLoading,
     serviceTemplate,
     setUserLoggedIn,
   ]);

--- a/frontend/constants/serviceTemplates.ts
+++ b/frontend/constants/serviceTemplates.ts
@@ -246,7 +246,7 @@ export const AGENTS_FUN_CELO_TEMPLATE: ServiceTemplate = {
 export const MODIUS_SERVICE_TEMPLATE: ServiceTemplate = {
   agentType: AgentType.Modius,
   name: 'Optimus', // Should be unique across all services and not be updated
-  hash: 'bafybeicmohtqkz5nkswwcu2uqj6julngc3d5daljjvhfab4z2x6rfroogi',
+  hash: 'bafybeiefvkhutqcaw4h6bhzok7pc25hmcyvgce6oqel7mj5ro6nqm2x55q',
   description: 'Optimus',
   image:
     'https://gateway.autonolas.tech/ipfs/bafybeiaakdeconw7j5z76fgghfdjmsr6tzejotxcwnvmp3nroaw3glgyve',
@@ -371,7 +371,7 @@ export const MODIUS_SERVICE_TEMPLATE: ServiceTemplate = {
       description: '',
       value: '',
       provision_type: EnvProvisionType.COMPUTED,
-    },    
+    },
   },
 } as const;
 

--- a/frontend/hooks/useMultisig.ts
+++ b/frontend/hooks/useMultisig.ts
@@ -66,6 +66,7 @@ export const useMultisigs = (safes?: Safe[]) => {
     data: masterSafesOwners,
     isFetched: masterSafesOwnersIsFetched,
     isPending: masterSafesOwnersIsPending,
+    isLoading: masterSafesOwnersIsLoading,
   } = useQuery<MultisigOwners[]>({
     enabled: !isNil(safes) && !isEmpty(safes),
     queryKey: safes ? REACT_QUERY_KEYS.MULTISIGS_GET_OWNERS_KEY(safes) : [],
@@ -171,5 +172,6 @@ export const useMultisigs = (safes?: Safe[]) => {
     masterSafesOwners,
     masterSafesOwnersIsFetched,
     masterSafesOwnersIsPending,
+    masterSafesOwnersIsLoading,
   };
 };

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "0.2.0-rc134",
+  "version": "0.2.0-rc136",
   "engine": {
     "node": ">=20",
     "yarn": ">=1.22.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "olas-operate-middleware"
-version = "0.2.0-rc134"
+version = "0.2.0-rc136"
 description = ""
 authors = ["David Vilela <dvilelaf@gmail.com>", "Viraj Patel <vptl185@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Proposed changes

1) allow users to create a safe without backup wallet (we'll implement changing the backup wallet later using `PUT /api/wallet/safe` instead of referring to safe app)
2) update modius hash

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
