### PR TITLE
updated staked_duration calc from python timestamp to ledger timestamp

### DIFF
--- a/operate/services/protocol.py
+++ b/operate/services/protocol.py
@@ -385,7 +385,9 @@ class StakingManager(OnChainHelper):
                 self.ledger_api, staking_contract
             ).get("data"),
         )
-        staked_duration = time.time() - ts_start
+        current_block = self.ledger_api.api.eth.get_block('latest')
+        current_timestamp = current_block.timestamp
+        staked_duration = current_timestamp - ts_start
         if staked_duration < minimum_staking_duration and available_rewards > 0:
             raise ValueError("Service cannot be unstaked yet.")
 


### PR DESCRIPTION
PR: Fix staking duration calculation to use blockchain timestamp

Updates the staking duration calculation to use the blockchain's timestamp instead of local system time. This fixes potential time synchronization issues and ensures consistent validation across all nodes.

Before:
- Used local system time (`time.time()`)
- Could lead to inconsistent validation results

After:
- Uses on-chain block timestamp
- Guarantees consistent behavior across the network