### PR TITLE
fix: hide "Fund your agent" alert after bridging

### DIFF
--- a/frontend/components/SetupPage/Create/SetupBridgeOnboarding/BridgeInProgress/useMasterSafeCreationAndTransfer.ts
+++ b/frontend/components/SetupPage/Create/SetupBridgeOnboarding/BridgeInProgress/useMasterSafeCreationAndTransfer.ts
@@ -49,6 +49,7 @@ export const useMasterSafeCreationAndTransfer = (
     onSuccess: () => {
       // Since the master safe is created and the transfer is completed,
       // we can update the store to indicate that the agent is initially funded.
+      // TODO: logic to be moved to BE in the future.
       electronApi.store?.set?.(`${selectedAgentType}.isInitialFunded`, true);
     },
   });


### PR DESCRIPTION
## Proposed changes

- Decided to manually set `isInitialFunded` to suppress the “Fund your agent” (purple) alert for now after safe creation, and the BE team to eventually move this logic to middleware-side.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
