### PR TITLE
fix: agentsfun alert shown for other agents

### DIFF
--- a/frontend/components/AgentForms/MemeooorrAgentForm/MemeooorrAgentForm.tsx
+++ b/frontend/components/AgentForms/MemeooorrAgentForm/MemeooorrAgentForm.tsx
@@ -78,7 +78,7 @@ export const MemeooorrAgentForm = ({
 }: MemeooorrAgentFormProps) => {
   const [formState] = Form.useForm<MemeooorrFormValues>();
 
-  const { isMemeooorrFieldUpdateCompleted } = useSharedContext();
+  const { isMemeooorrFieldUpdateRequired } = useSharedContext();
   const form = useMemo(
     () => formInstance || formState,
     [formInstance, formState],
@@ -158,7 +158,7 @@ export const MemeooorrAgentForm = ({
       <Divider style={{ margin: '8px 0' }} />
       <XAccountApiTokens
         showTokensRequiredMessage={
-          !isMemeooorrFieldUpdateCompleted && agentFormType !== 'create'
+          isMemeooorrFieldUpdateRequired && agentFormType !== 'create'
         }
       />
 

--- a/frontend/components/MainPage/header/AgentButton/AgentNotRunningButton.tsx
+++ b/frontend/components/MainPage/header/AgentButton/AgentNotRunningButton.tsx
@@ -34,7 +34,7 @@ import { updateServiceIfNeeded } from '@/utils/service';
  */
 const useServiceDeployment = () => {
   const { showNotification } = useElectronApi();
-  const { isMemeooorrFieldUpdateCompleted } = useSharedContext();
+  const { isMemeooorrFieldUpdateRequired } = useSharedContext();
 
   const { goto: gotoPage } = usePageState();
   const { masterWallets, masterSafes, masterEoa } = useMasterWalletContext();
@@ -100,7 +100,7 @@ const useServiceDeployment = () => {
 
     // agent specific checks
     // If the memeooorr field update is not completed, can't start the agent
-    if (!isMemeooorrFieldUpdateCompleted) return false;
+    if (isMemeooorrFieldUpdateRequired) return false;
 
     // allow starting based on refill requirements
     return canStartAgent;
@@ -118,7 +118,7 @@ const useServiceDeployment = () => {
     needsInitialFunding,
     selectedStakingProgramMeta?.deprecated,
     canStartAgent,
-    isMemeooorrFieldUpdateCompleted,
+    isMemeooorrFieldUpdateRequired,
   ]);
 
   const pauseAllPolling = useCallback(() => {

--- a/frontend/components/MainPage/sections/AlertSections/UpdateAgentConfiguration.tsx
+++ b/frontend/components/MainPage/sections/AlertSections/UpdateAgentConfiguration.tsx
@@ -9,9 +9,9 @@ const { Text } = Typography;
 
 export const UpdateAgentConfiguration = () => {
   const { goto } = usePageState();
-  const { isMemeooorrFieldUpdateCompleted } = useSharedContext();
+  const { isMemeooorrFieldUpdateRequired } = useSharedContext();
 
-  if (isMemeooorrFieldUpdateCompleted) return null;
+  if (!isMemeooorrFieldUpdateRequired) return null;
 
   return (
     <CustomAlert

--- a/frontend/context/SharedProvider/SharedProvider.tsx
+++ b/frontend/context/SharedProvider/SharedProvider.tsx
@@ -25,7 +25,7 @@ export const SharedContext = createContext<{
   updateOnboardingStep: (step: number) => void;
 
   // agent specific checks
-  isMemeooorrFieldUpdateCompleted: boolean;
+  isMemeooorrFieldUpdateRequired: boolean;
 
   // others
 }>({
@@ -39,7 +39,7 @@ export const SharedContext = createContext<{
   updateOnboardingStep: () => {},
 
   // agent specific checks
-  isMemeooorrFieldUpdateCompleted: false,
+  isMemeooorrFieldUpdateRequired: false,
 
   // others
 });
@@ -67,14 +67,17 @@ export const SharedProvider = ({ children }: PropsWithChildren) => {
 
   // agent specific checks
   const { selectedAgentType, selectedService } = useServices();
-  const [isMemeooorrFieldUpdateCompleted, setIsMemeooorrFieldUpdateCompleted] =
-    useState(true); // default to true to avoid showing the alert on first load
+  const [isMemeooorrFieldUpdateRequired, setIsMemeooorrFieldUpdateRequired] =
+    useState(false);
 
   // Users with the Memeooorr agent type are required to update their
   // agent configurations to run the latest version of the agent.
   useEffect(() => {
     if (!selectedAgentType) return;
-    if (selectedAgentType !== AgentType.Memeooorr) return;
+    if (selectedAgentType !== AgentType.Memeooorr) {
+      setIsMemeooorrFieldUpdateRequired(false);
+      return;
+    }
     if (!selectedService) return;
 
     const areFieldsUpdated = [
@@ -85,7 +88,7 @@ export const SharedProvider = ({ children }: PropsWithChildren) => {
       'TWEEPY_ACCESS_TOKEN_SECRET',
     ].every((key) => selectedService.env_variables?.[key]?.value);
 
-    setIsMemeooorrFieldUpdateCompleted(areFieldsUpdated);
+    setIsMemeooorrFieldUpdateRequired(!areFieldsUpdated);
   }, [selectedAgentType, selectedService]);
 
   return (
@@ -100,7 +103,7 @@ export const SharedProvider = ({ children }: PropsWithChildren) => {
         updateOnboardingStep,
 
         // agent specific checks
-        isMemeooorrFieldUpdateCompleted,
+        isMemeooorrFieldUpdateRequired,
       }}
     >
       {children}


### PR DESCRIPTION
## Proposed changes

The issue is probably happening when changing between agents.fun agent (when it's required to update env. variables) to any other agent - the state remains set to true.

I choose to rename it so that:
1) there's no discrepancy b/w default context value (which is false) and default use state value (which is true - I found it a bit confusing at first)
2) it's logically correct to do `setIsMemeooorrFieldUpdateRequired(false);` when the selected agent is not memeooorr (rather than saying complete=true, which may not be true, or, as another approach, checking both `isMemeooorrFieldUpdateCompleted` state and `selectedAgentType` when displaying the alert)

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
