### PR TITLE
Reduce logging amount

### DIFF
--- a/electron/logger.js
+++ b/electron/logger.js
@@ -48,7 +48,7 @@ const logger = winston.createLogger({
       level: 'cli',
       format: combine(levelFilter('cli'), timestamp(), logFormat),
       maxsize: TEN_MEGABYTES,
-      maxFiles: 1000,
+      maxFiles: 5,
     }),
     new winston.transports.File({
       filename: 'electron.log',


### PR DESCRIPTION
## Proposed changes

Reduce logging amount for backend from 1000 files (10Gb) to 5 files (50Mb).

Note that with the current configuration of `winston.transports.File` the file rotation will only keep the latest `maxFiles` named `cli<N>.log ... cli<N+maxFiles-1>.log` for some N. The counter is always increasing. When space runs out, it will increase N and delete the oldest file.

If we include the option `tailable: true` it will always keep `cli.log ... cli<maxFiles-1>.log`, but in reverse order. The issue is that this will not delete already existing logs `>= maxFiles` for users that already have been running Pearl. 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
