### PR TITLE
fix: incomplete account setup - backup wallet not set

### DIFF
--- a/frontend/components/SetupPage/Create/SetupBackupSigner/BackupWalletManual.tsx
+++ b/frontend/components/SetupPage/Create/SetupBackupSigner/BackupWalletManual.tsx
@@ -43,11 +43,11 @@ export const BackupWalletManual = () => {
     }
 
     setBackupSigner({ address: checksummedAddress, type: 'manual' });
-    goto(SetupScreen.AgentSelection);
+    goto(SetupScreen.AgentOnboarding);
   };
 
   const handleWeb3AuthSetupFinish = () => {
-    goto(SetupScreen.AgentSelection);
+    goto(SetupScreen.AgentOnboarding);
   };
 
   const { openWeb3AuthModel } = useWeb3AuthBackupWallet({

--- a/frontend/components/SetupPage/Create/SetupBackupSigner/BackupWalletWeb3Auth.tsx
+++ b/frontend/components/SetupPage/Create/SetupBackupSigner/BackupWalletWeb3Auth.tsx
@@ -50,7 +50,7 @@ export const BackupWalletWeb3Auth = ({
   const { goto } = useSetup();
 
   const handleWeb3AuthSetupFinish = () => {
-    goto(SetupScreen.AgentSelection);
+    goto(SetupScreen.AgentOnboarding);
   };
 
   const { openWeb3AuthModel } = useWeb3AuthBackupWallet({

--- a/frontend/components/SetupPage/Create/SetupCreateHeader.tsx
+++ b/frontend/components/SetupPage/Create/SetupCreateHeader.tsx
@@ -17,17 +17,19 @@ type SetupCreateHeaderProps = {
  * @deprecated Use `AgentHeader` instead.
  */
 export const SetupCreateHeader = ({ prev }: SetupCreateHeaderProps) => {
-  const { goto } = useSetup();
+  const { goto, prevState } = useSetup();
   const handleBack = useCallback(() => {
     if (!prev) return;
 
     isFunction(prev) ? prev() : goto(prev);
   }, [goto, prev]);
 
+  // If the user killed the app before saving the backup wallet and reopend
+  const showBackButton = prev && prevState !== SetupScreen.Welcome;
   return (
     <Row>
       <Col span={8}>
-        {prev && (
+        {showBackButton && (
           <Button
             onClick={handleBack}
             icon={<ArrowLeftOutlined />}

--- a/frontend/components/SetupPage/SetupWelcome.tsx
+++ b/frontend/components/SetupPage/SetupWelcome.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useMessageApi } from '@/context/MessageProvider';
 import { Pages } from '@/enums/Pages';
 import { SetupScreen } from '@/enums/SetupScreen';
+import { useBackupSigner } from '@/hooks';
 import {
   useBalanceContext,
   useMasterBalances,
@@ -78,6 +79,7 @@ const SetupWelcomeLogin = () => {
   } = useMasterWalletContext();
   const { isLoaded: isBalanceLoaded, updateBalances } = useBalanceContext();
   const { masterWalletBalances } = useMasterBalances();
+  const backupSignerAddress = useBackupSigner();
 
   const selectedServiceOrAgentChainId = selectedService?.home_chain
     ? asEvmChainId(selectedService?.home_chain)
@@ -140,6 +142,12 @@ const SetupWelcomeLogin = () => {
 
     if (!selectedAgentConfig) return;
 
+    // If no services are created and backup wallet is not set as well.
+    if (!services?.length && !backupSignerAddress) {
+      goto(SetupScreen.SetupBackupSigner);
+      return;
+    }
+
     // If the agent is disabled then redirect to agent selection,
     // if the disabled agent was previously selected.
     if (!selectedAgentConfig.isAgentEnabled) {
@@ -183,6 +191,8 @@ const SetupWelcomeLogin = () => {
     selectedAgentConfig,
     selectedAgentType,
     isOnline,
+    services?.length,
+    backupSignerAddress,
   ]);
 
   return (


### PR DESCRIPTION
## Proposed changes
Redirect the user to the backup wallet screen (instead of agent onboarding, currently) if they kill the app without setting the backup signer address.

https://linear.app/valory-xyz/issue/OPE-197

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
