### PR TITLE
chore: removed alert for predict agent withdrawal

### DIFF
--- a/frontend/components/AgentWallet/BalancesAndAssets/BalancesAndAssets.tsx
+++ b/frontend/components/AgentWallet/BalancesAndAssets/BalancesAndAssets.tsx
@@ -2,7 +2,6 @@ import { Button, Flex, Modal, Typography } from 'antd';
 import { useState } from 'react';
 
 import { CardFlex } from '@/components/ui';
-import { AgentMap } from '@/constants/agent';
 import { Pages } from '@/enums/Pages';
 import { usePageState, useServices } from '@/hooks';
 
@@ -89,13 +88,12 @@ export const BalancesAndAssets = ({
   onLockedFundsWithdrawn,
 }: BalancesAndAssetsProps) => {
   const [isWithdrawModalVisible, setWithdrawModalVisible] = useState(false);
-  const { selectedAgentType, selectedAgentConfig } = useServices();
+  const { selectedAgentConfig } = useServices();
 
   const handleWithdraw = () => {
-    const isPredictTrader = selectedAgentType === AgentMap.PredictTrader;
     const hasExternalFunds = selectedAgentConfig?.hasExternalFunds;
 
-    if (!isPredictTrader || hasExternalFunds) {
+    if (hasExternalFunds) {
       setWithdrawModalVisible(true);
       return;
     }


### PR DESCRIPTION
## Proposed changes

For predict trader, withdrawal from agent wallet removes modal pop-up and leads immediately to withdraw page.

https://github.com/user-attachments/assets/744ec7ca-e8df-49fe-b619-4127dd8aec0d

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
