### PR TITLE
chore: agent staking streak icon is active 

### DIFF
--- a/frontend/components/AgentStaking/AgentStaking.tsx
+++ b/frontend/components/AgentStaking/AgentStaking.tsx
@@ -3,7 +3,6 @@ import { Flex, Image, Skeleton, Typography } from 'antd';
 import { useState } from 'react';
 
 import { ContractSvg } from '@/components/custom-icons/Contract';
-import { FireNoStreak } from '@/components/custom-icons/FireNoStreak';
 import { FireV1 } from '@/components/custom-icons/FireV1';
 import { BackButton } from '@/components/ui/BackButton';
 import { CardFlex } from '@/components/ui/CardFlex';
@@ -11,9 +10,12 @@ import { Segmented } from '@/components/ui/Segmented';
 import { COLOR } from '@/constants/colors';
 import { MAIN_CONTENT_MAX_WIDTH } from '@/constants/width';
 import { Pages } from '@/enums/Pages';
-import { usePageState } from '@/hooks/usePageState';
-import { useServiceOnlyRewardsHistory } from '@/hooks/useRewardsHistory';
-import { useStakingDetails } from '@/hooks/useStakingDetails';
+import {
+  usePageState,
+  useRewardContext,
+  useServiceOnlyRewardsHistory,
+  useStakingDetails,
+} from '@/hooks';
 
 import { RewardsHistory } from './RewardsHistory';
 import { StakingContractDetails } from './StakingContractDetails';
@@ -24,11 +26,11 @@ const StatsSkeleton = () => <Skeleton.Input active size="small" />;
 
 const StakingStats = () => {
   const { optimisticStreak, isStreakLoading } = useStakingDetails();
+  const { isEligibleForRewards } = useRewardContext();
   const { isLoading: isTotalRewardsLoading } = useServiceOnlyRewardsHistory();
   const { totalRewards } = useServiceOnlyRewardsHistory();
 
-  const fireIcon =
-    optimisticStreak > 0 ? <FireV1 isActive /> : <FireNoStreak />;
+  const isFlameActive = optimisticStreak > 0 && isEligibleForRewards;
 
   return (
     <CardFlex $noBorder $newStyles>
@@ -59,7 +61,7 @@ const StakingStats = () => {
             <StatsSkeleton />
           ) : (
             <Flex>
-              {fireIcon}
+              <FireV1 isActive={isFlameActive} />
               <Title level={5} className="mt-0 mb-0 ml-8">
                 {optimisticStreak}
               </Title>


### PR DESCRIPTION
## Proposed changes

Addressing issue raised [here](https://linear.app/valory-xyz/issue/OPE-794#comment-c45850cc). For agent staking to match streak icon isActive on homepage staking section.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
