### PR TITLE
fix(OPE-716): events are sometimes not tracke din iframes

### DIFF
--- a/frontend/components/OnRampIframe/OnRampIframe.tsx
+++ b/frontend/components/OnRampIframe/OnRampIframe.tsx
@@ -30,9 +30,8 @@ export const OnRampIframe = ({ usdAmountToPay }: OnRampIframeProps) => {
   const ref = useRef<HTMLIFrameElement>(null);
 
   useEffect(() => {
-    const transakIframe = ref.current?.contentWindow;
-
     const handleMessage = (event: MessageEvent) => {
+      const transakIframe = ref.current?.contentWindow;
       if (event.source !== transakIframe) return;
 
       const eventDetails = event as unknown as TransakEvent;

--- a/frontend/components/Web3AuthIframe/Web3AuthIframe.tsx
+++ b/frontend/components/Web3AuthIframe/Web3AuthIframe.tsx
@@ -61,9 +61,8 @@ export const Web3AuthIframe = () => {
   const ref = useRef<HTMLIFrameElement>(null);
 
   useEffect(() => {
-    const web3authIframe = ref.current?.contentWindow;
-
     const handleMessage = (event: MessageEvent) => {
+      const web3authIframe = ref.current?.contentWindow;
       if (event.source !== web3authIframe) return;
 
       const eventDetails = event as unknown as Web3AuthEvent;


### PR DESCRIPTION
## Proposed changes

Sometimes transak windows wasn't close on error or success, it seems it happened due to `transakIframe` variable was initialised earlier than the iframe was ready, hence it was null and the events were skipped.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
