### PR TITLE
feat (OPE-970): Move tooltip on available funds when Funding Agent, not when funding Pearl Wallet

### DIFF
--- a/frontend/components/AgentWallet/FundAgent/FundAgent.tsx
+++ b/frontend/components/AgentWallet/FundAgent/FundAgent.tsx
@@ -35,6 +35,18 @@ const FundAgentTitle = () => (
   </Flex>
 );
 
+const DepositInputInfo = () => (
+  <Flex vertical gap={4}>
+    <Text className="text-sm">Why it’s different from your Pearl Wallet</Text>
+    <Text className="text-sm text-neutral-secondary">
+      This number shows only the amount you can use to fund agents.
+    </Text>
+    <Text className="text-sm text-neutral-secondary">
+      The Pearl Wallet balance also includes funds reserved to pay for gas fees.
+    </Text>
+  </Flex>
+);
+
 const PearlWalletToAgentWallet = () => {
   const { agentName, agentImgSrc } = useAgentWallet();
   return (
@@ -179,6 +191,7 @@ export const FundAgent = ({ onBack }: { onBack: () => void }) => {
                     totalAmount={amount}
                     onChange={(x) => onAmountChange(symbol, { amount: x ?? 0 })}
                     hasError={hasError}
+                    tooltipInfo={<DepositInputInfo />}
                   />
                   {hasError && <FundPearlWallet />}
                 </Flex>

--- a/frontend/components/PearlDeposit/Deposit/Deposit.tsx
+++ b/frontend/components/PearlDeposit/Deposit/Deposit.tsx
@@ -20,18 +20,6 @@ import {
 
 const { Title, Text } = Typography;
 
-const DepositInputInfo = () => (
-  <Flex vertical gap={4}>
-    <Text className="text-sm">Why it’s different from your Pearl Wallet</Text>
-    <Text className="text-sm text-neutral-secondary">
-      This number shows only the amount you can use to fund agents.
-    </Text>
-    <Text className="text-sm text-neutral-secondary">
-      The Pearl Wallet balance also includes funds reserved to pay for gas fees.
-    </Text>
-  </Flex>
-);
-
 const DepositTitle = () => (
   <Flex vertical justify="space-between" gap={12}>
     <Title level={4} className="m-0">
@@ -132,7 +120,6 @@ export const Deposit = ({ onBack, onContinue }: DepositProps) => {
                   onDepositAmountChange(symbol, { amount: x ?? 0 })
                 }
                 showQuickSelects={false}
-                tooltipInfo={<DepositInputInfo />}
               />
             ))}
           </Flex>


### PR DESCRIPTION
## Proposed changes

<img width="1115" height="787" alt="Scr2M" src="https://github.com/user-attachments/assets/111a9567-6a24-4c7f-a28c-1579dfc701bf" />

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
