### PR TITLE
feat (OPE-971): Unable to start using Optimus in Pearl v1

### DIFF
--- a/frontend/components/MainPageV1/Sidebar.tsx
+++ b/frontend/components/MainPageV1/Sidebar.tsx
@@ -38,7 +38,7 @@ import {
   useServices,
   useSetup,
 } from '@/hooks';
-import { AgentConfig } from '@/types/Agent';
+import { AgentConfig } from '@/types';
 
 import { BackupSeedPhraseAlert } from './BackupSeedPhraseAlert';
 import { UpdateAvailableAlert } from './UpdateAvailableAlert/UpdateAvailableAlert';
@@ -240,6 +240,16 @@ export const Sidebar = () => {
     return [selectedAgentType];
   }, [pageState, selectedAgentType]);
 
+  const canAddNewAgents = useMemo(() => {
+    const availableAgents = myAgents.filter((agent) => {
+      return AVAILABLE_FOR_ADDING_AGENTS.some(
+        ([agentType]) => agentType === agent.agentType,
+      );
+    });
+
+    return availableAgents.length < AVAILABLE_FOR_ADDING_AGENTS.length;
+  }, [myAgents]);
+
   return (
     <SiderContainer>
       <Sider breakpoint={SIDEBAR_BREAKPOINT} theme="light" width={SIDER_WIDTH}>
@@ -259,7 +269,7 @@ export const Sidebar = () => {
                 />
               ) : null}
 
-              {myAgents.length < AVAILABLE_FOR_ADDING_AGENTS.length && (
+              {canAddNewAgents && (
                 <ResponsiveButton
                   size="large"
                   className="flex mx-auto"


### PR DESCRIPTION
## Proposed changes

- The “Add New Agent” button will remain visible even if at least one of the non–under-construction agents hasn’t been added by the user.

<img width="327" height="329" alt="S2M" src="https://github.com/user-attachments/assets/f948caa3-3d78-4e63-9ca3-9bd7598e323b" />


## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
