### PR TITLE
fix: remove old discord url

### DIFF
--- a/frontend/components/SettingsPage/YourFundsAtRiskAlert.tsx
+++ b/frontend/components/SettingsPage/YourFundsAtRiskAlert.tsx
@@ -5,7 +5,7 @@ import { useToggle } from 'usehooks-ts';
 import { Alert, Modal } from '@/components/ui';
 import {
   AllEvmChainIdMap,
-  DISCORD_TICKET_URL,
+  COMMUNITY_ASSISTANCE_URL,
   EvmChainIdMap,
 } from '@/constants';
 import { useMasterWalletContext, useServices } from '@/hooks';
@@ -73,7 +73,7 @@ const AddBackupWalletAlert = ({
               <a
                 target="_blank"
                 className="flex align-center"
-                href={DISCORD_TICKET_URL}
+                href={COMMUNITY_ASSISTANCE_URL}
               >
                 Get community assistance via Discord{' '}
                 <TbExternalLink className="ml-4" />

--- a/frontend/constants/urls.ts
+++ b/frontend/constants/urls.ts
@@ -27,8 +27,6 @@ export const REWARDS_HISTORY_SUBGRAPH_URLS_BY_EVM_CHAIN: Record<
 // discord
 export const SUPPORT_URL: Url =
   'https://discord.com/channels/899649805582737479/1244588374736502847';
-export const DISCORD_TICKET_URL: Url =
-  'https://discord.com/channels/899649805582737479/1245674435160178712/1263815577240076308';
 export const COMMUNITY_ASSISTANCE_URL: Url =
   'https://discord.com/channels/899649805582737479/1335000001797034044';
 


### PR DESCRIPTION
## Proposed changes

Old one was not working and I noticed there's another, correct one

<img width="368" height="159" alt="image" src="https://github.com/user-attachments/assets/715216d2-ed66-4f75-9d3c-4c25c4969008" />


## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
