### PR TITLE
chore: [OPE-1005] Windows logs not anonymizing user paths in debug_data.json

### DIFF
--- a/electron/utils/sanitizers.js
+++ b/electron/utils/sanitizers.js
@@ -26,8 +26,23 @@ function sanitizeLogs({
 
   const logs = filePath ? fs.readFileSync(filePath, 'utf-8') : data;
 
-  const usernameRegex = /\/(Users|home)\/([^/]+)/g;
-  const sanitizedData = logs.replace(usernameRegex, '/$1/*****');
+  // Sanitize Unix-style paths: /Users/username or /home/username
+  const unixUsernameRegex = /\/(Users|home)\/([^/\\]+)/g;
+  let sanitizedData = logs.replace(unixUsernameRegex, '/$1/*******');
+
+  // Sanitize Windows-style paths (JSON strings)
+  const windowsEscapedRegex = /([A-Za-z]:)\\\\Users\\\\([^\\\\]+)/g;
+  sanitizedData = sanitizedData.replace(
+    windowsEscapedRegex,
+    '$1\\\\Users\\\\*******',
+  );
+
+  // Windows single backslashes: C:\Users\username
+  const windowsBackslashRegex = /([A-Za-z]:)\\Users\\([^\\]+)/g;
+  sanitizedData = sanitizedData.replace(
+    windowsBackslashRegex,
+    '$1\\Users\\*******',
+  );
   const sanitizedLogsFilePath = path.join(destPath, name);
 
   if (!fs.existsSync(destPath)) {


### PR DESCRIPTION
## Proposed changes

Should anonymize STORE_DATA for Windows users.

Result:
```
{
  "STORE_PATH": {
    "name": "Store path",
    "description": "",
    "value": "C:\\Users\\*******\\.operate\\services\\sc-fb1167c7-1ade-4508-bb43-f40511be1bc2\\persistent_data",
    "provision_type": "computed"
  }
}
```

Screenshot of log:
<img width="1536" height="194" alt="image" src="https://github.com/user-attachments/assets/a1d8f835-79c3-4569-90d9-b49d498a16e6" />


## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
