### PR TITLE
chore: bump trader

### DIFF
--- a/frontend/constants/serviceTemplates.ts
+++ b/frontend/constants/serviceTemplates.ts
@@ -22,17 +22,17 @@ export const KPI_DESC_PREFIX = '[Pearl service]';
 export const PREDICT_SERVICE_TEMPLATE: ServiceTemplate = {
   agentType: AgentMap.PredictTrader,
   name: 'Trader Agent', // should be unique across all services and not be updated
-  hash: 'bafybeibw46xqqqpzfiw5if7aoknstlxc4bmraiqyj7v3w7a3kzcybpsbou',
+  hash: 'bafybeigonvbjopwetgadk3s2gbrar6xade3wpjpkrrkd27l6np4og2eizq',
   description: `${KPI_DESC_PREFIX} Trader agent for omen prediction markets`,
   image:
     'https://operate.olas.network/_next/image?url=%2Fimages%2Fprediction-agent.png&w=3840&q=75',
-  service_version: 'v0.27.7',
+  service_version: 'v0.28.0-rc4',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'trader',
-      version: 'v0.27.7',
+      version: 'v0.28.0-rc4',
     },
   },
   home_chain: MiddlewareChainMap.GNOSIS,


### PR DESCRIPTION
Trader release: https://github.com/valory-xyz/trader/releases/tag/v0.28.0-rc4

Changelog: 
- Trader open autonomy bumped to `v0.21.3`
