### PR TITLE
fix (PREDICT-638): On switching error modal the close icon doesn’t work

### DIFF
--- a/frontend/components/ConfirmSwitch/components/SwitchingContractModal.tsx
+++ b/frontend/components/ConfirmSwitch/components/SwitchingContractModal.tsx
@@ -42,7 +42,7 @@ export const SwitchingContractModal = ({
     selectedService?.service_config_id,
   );
 
-  const onCancel = useCallback(() => {
+  const handleContactSupport = useCallback(() => {
     onClose();
     toggleSupportModal();
   }, [onClose, toggleSupportModal]);
@@ -89,7 +89,7 @@ export const SwitchingContractModal = ({
         closable: true,
         onCancel: onClose,
         action: (
-          <Button className="mt-16" onClick={onCancel}>
+          <Button className="mt-16" onClick={handleContactSupport}>
             Contact support
           </Button>
         ),
@@ -103,7 +103,7 @@ export const SwitchingContractModal = ({
     stakingProgramIdToMigrateTo,
     status,
     onClose,
-    onCancel,
+    handleContactSupport,
   ]);
 
   return <Modal header={<ModalHeader status={status} />} {...modalProps} />;


### PR DESCRIPTION
## Proposed changes

https://github.com/user-attachments/assets/b0e24b6a-ac2c-471c-80d0-4c379930b646

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
