### PR TITLE
feat: improve error logging for SSR and runtime errors

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -66,6 +66,19 @@ const { pki } = require('node-forge');
 // Register IPC handlers for logs
 require('./features/logs');
 
+// Global error handlers to catch unhandled errors
+process.on('unhandledRejection', (reason, promise) => {
+  const message = reason instanceof Error ? reason.message : String(reason);
+  const stack = reason instanceof Error ? reason.stack : 'No stack trace';
+  logger.next(`[Unhandled Rejection] ${message}`);
+  logger.next(`Stack: ${stack}`);
+});
+
+process.on('uncaughtException', (error) => {
+  logger.next(`[Uncaught Exception] ${error.message}`);
+  logger.next(`Stack: ${error.stack}`);
+});
+
 // Validates environment variables required for Pearl
 // kills the app/process if required environment variables are unavailable
 // mostly RPC URLs and NODE_ENV
@@ -684,15 +697,45 @@ async function launchDaemonDev() {
 async function launchNextApp() {
   logger.electron('Launching Next App');
 
-  logger.electron('Preparing Next App');
-  await nextApp.prepare();
+  try {
+    logger.electron('Preparing Next App');
+    await nextApp.prepare();
+  } catch (err) {
+    logger.next(`[Next.js Prepare Error] ${err.message}`);
+    logger.next(`Stack: ${err.stack}`);
+    throw err;
+  }
 
   logger.electron('Getting Next App Handler');
   const handle = nextApp.getRequestHandler();
 
   logger.electron('Creating Next App Server');
-  const server = http.createServer((req, res) => {
-    handle(req, res); // Handle requests using the Next.js request handler
+  const server = http.createServer(async (req, res) => {
+    // Intercept response to log errors
+    const originalEnd = res.end.bind(res);
+    res.end = function (...args) {
+      if (res.statusCode >= 500) {
+        logger.next(`[HTTP ${res.statusCode}] ${req.method} ${req.url}`);
+      }
+      return originalEnd(...args);
+    };
+
+    try {
+      await handle(req, res);
+    } catch (err) {
+      logger.next(`[Request Error] ${req.method} ${req.url}: ${err.message}`);
+      logger.next(`Stack: ${err.stack}`);
+      if (!res.headersSent) {
+        res.statusCode = 500;
+        res.setHeader('Content-Type', 'text/html');
+        res.end('Internal Server Error');
+      }
+    }
+  });
+
+  server.on('error', (err) => {
+    logger.next(`[Server Error] ${err.message}`);
+    logger.next(`Stack: ${err.stack}`);
   });
 
   logger.electron('Listening on Next App Server');

--- a/frontend/pages/_error.tsx
+++ b/frontend/pages/_error.tsx
@@ -1,0 +1,113 @@
+import { Button, Flex, Image, Typography } from 'antd';
+import { NextPageContext } from 'next';
+import { useState } from 'react';
+import { styled } from 'styled-components';
+
+import { SupportModal } from '@/components/SupportModal/SupportModal';
+
+const { Text, Title } = Typography;
+
+const ErrorContainer = styled(Flex)`
+  min-height: 100vh;
+  background-color: white;
+`;
+
+interface ErrorProps {
+  statusCode: number;
+  errorMessage?: string;
+}
+
+const ErrorPage = ({ statusCode, errorMessage }: ErrorProps) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  return (
+    <ErrorContainer vertical align="center" justify="center">
+      <Flex
+        vertical
+        align="center"
+        gap={12}
+        style={{ maxWidth: 500, textAlign: 'center' }}
+      >
+        <div className="mb-24">
+          <Image
+            src="/pearl-with-gradient.png"
+            alt="Pearl Logo"
+            width={80}
+            height={80}
+            preview={false}
+          />
+        </div>
+        <Title level={3} className="m-0">
+          {statusCode === 404
+            ? 'Page not found'
+            : 'An unexpected error occurred'}
+        </Title>
+        <Text type="secondary" className="text-sm">
+          {statusCode === 404 ? (
+            'The page you are looking for does not exist.'
+          ) : (
+            <>
+              We encountered an unexpected error ({statusCode}).
+              {errorMessage && (
+                <>
+                  <br />
+                  <code style={{ fontSize: '12px' }}>{errorMessage}</code>
+                </>
+              )}
+              <br />
+              Please try restarting the application. If the problem persists,
+              please contact support.
+            </>
+          )}
+        </Text>
+
+        <Button
+          type="primary"
+          size="large"
+          onClick={() => setIsModalOpen(true)}
+          className="mt-12"
+        >
+          Contact Support
+        </Button>
+      </Flex>
+
+      <SupportModal
+        open={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        shouldUseFallbackLogs
+      />
+    </ErrorContainer>
+  );
+};
+
+ErrorPage.getInitialProps = async ({
+  res,
+  err,
+}: NextPageContext): Promise<ErrorProps> => {
+  const statusCode = res?.statusCode ?? err?.statusCode ?? 500;
+  const errorMessage = err?.message;
+
+  // Server-side logging (runs during SSR errors)
+  if (typeof window === 'undefined' && err) {
+    console.error(`[SSR Error] ${statusCode}: ${err.message}`);
+    console.error(`Stack: ${err.stack}`);
+  }
+
+  // Client-side logging via Electron API
+  if (typeof window !== 'undefined' && err) {
+    try {
+      const electronAPI = (window as Window & { electronAPI?: { nextLogError?: (error: Error, errorInfo: unknown) => void } }).electronAPI;
+      electronAPI?.nextLogError?.(err, {
+        type: 'page-error',
+        statusCode,
+        url: window.location.href,
+      });
+    } catch (e) {
+      // Silently fail if electron API is not available
+    }
+  }
+
+  return { statusCode, errorMessage };
+};
+
+export default ErrorPage;


### PR DESCRIPTION
## Summary

- Add global error handlers (`unhandledRejection`, `uncaughtException`) in electron/main.js to catch unhandled errors
- Add response interception to log all HTTP 500+ errors with request URL
- Add try/catch around Next.js `prepare()` and request handling
- Create custom `_error.tsx` page that matches ErrorBoundary UI and logs errors both server-side and client-side

## Error Coverage

| Error Type | Where Caught | Log Location |
|------------|--------------|--------------|
| SSR error (e.g., browser-only code) | `_error.tsx` + response interception | `next.log` |
| Client render error | ErrorBoundary | via `nextLogError` |
| Unhandled promise rejection | Global handler | `next.log` |
| Uncaught exception | Global handler | `next.log` |
| HTTP 500 response | Response interception | `next.log` |

## Test plan

- [ ] Trigger an SSR error (e.g., use browser-only API without dynamic import) and verify it's logged to `next.log`
- [ ] Verify `_error.tsx` page displays with same UI as ErrorBoundary
- [ ] Verify client-side errors are still caught by ErrorBoundary
- [ ] Verify 500 errors show `[HTTP 500] GET /path` in logs

🤖 Generated with [Claude Code](https://claude.ai/code)