### PR TITLE
ci: fix publish skipped when triggered from pull request, add Linux

### DIFF
--- a/.github/workflows/release-to-production.yml
+++ b/.github/workflows/release-to-production.yml
@@ -62,8 +62,15 @@ jobs:
       tag: ${{ needs.calculate-version.outputs.new_tag }}
     secrets: inherit
 
+  run-release-linux:
+    needs: [check-label, calculate-version]
+    uses: ./.github/workflows/release_linux.yml
+    with:
+      tag: ${{ needs.calculate-version.outputs.new_tag }}
+    secrets: inherit
+
   summary:
-    needs: [check-label, calculate-version, run-release, run-release-win]
+    needs: [check-label, calculate-version, run-release, run-release-win, run-release-linux]
     runs-on: ubuntu-latest
     steps:
       - name: Create summary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,6 +274,7 @@ jobs:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           GH_TOKEN: ${{ secrets.github_token }}
           GITHUB_TOKEN: ${{ secrets.github_token }}
+          PUBLISH_FOR_PULL_REQUEST: true
           RELEASE_TAG: ${{ inputs.tag }}
           NODE_ENV: ${{ matrix.env }}
           ARCH: ${{ env.OS_ARCH }}

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -248,6 +248,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.github_token }}
           GITHUB_TOKEN: ${{ secrets.github_token }}
+          PUBLISH_FOR_PULL_REQUEST: true
           RELEASE_TAG: ${{ inputs.tag }}
           NODE_ENV: ${{ matrix.env }}
           ARCH: ${{ env.OS_ARCH }}

--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -172,6 +172,7 @@ jobs:
       - run: rm -rf /dist
       - name: "Build, notarize, publish"
         env:
+          PUBLISH_FOR_PULL_REQUEST: true
           RELEASE_TAG: ${{ inputs.tag }}
         run: |
           export GITHUB_REF_TYPE="tag"


### PR DESCRIPTION
## Summary

- Add `PUBLISH_FOR_PULL_REQUEST=true` to electron-builder steps in Mac, Windows, and Linux release workflows so binaries are uploaded to the release when the workflow is triggered via a PR label
- Add Linux (`release_linux.yml`) to the `release-to-production` workflow — Linux was previously excluded from production releases entirely

## Root cause

`electron-builder` detects `GITHUB_EVENT_NAME=pull_request` and skips publishing by default, even when `GITHUB_REF` is manually overridden to point to a tag. Setting `PUBLISH_FOR_PULL_REQUEST=true` bypasses this check. The security concern this flag warns about (untrusted fork PRs) does not apply here since releases are always triggered from internal `release/*` branches.

## Test plan

- [x] Verified fix on `release/v0.0.99` test branch — all three platforms (Mac arm64, Mac x64, Windows) successfully uploaded binaries to draft release
- [ ] Confirm Linux build also uploads after this PR is merged and a release is triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)