### PR TITLE
chore: bump agents.fun to v2.2.0

### DIFF
--- a/frontend/constants/serviceTemplates/serviceTemplates.ts
+++ b/frontend/constants/serviceTemplates/serviceTemplates.ts
@@ -22,17 +22,17 @@ const AGENTS_FUN_COMMON_TEMPLATE: Pick<
   | 'service_version'
   | 'agent_release'
 > = {
-  hash: 'bafybeiawqqwkoeovm453mscwkxvmtnvaanhatlqh52cf5sdqavz6ldybae',
+  hash: 'bafybeihxteouggsunhb4ylbq2brhjtq4em7rpyywvbdcqt7kkhpe7mnbxq',
   image:
     'https://gateway.autonolas.tech/ipfs/QmQYDGMg8m91QQkTWSSmANs5tZwKrmvUCawXZfXVVWQPcu',
   description: `${KPI_DESC_PREFIX} Agents.Fun @twitter_handle`, // NOTE: @twitter_handle to be replaced with twitter username
-  service_version: 'v2.1.1',
+  service_version: 'v2.2.0',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'meme-ooorr',
-      version: 'v2.1.1',
+      version: 'v2.2.0',
     },
   },
   env_variables: {


### PR DESCRIPTION
## Proposed changes

Bumps agents.fun to [v2.2.0](https://github.com/valory-xyz/meme-ooorr/releases/tag/v2.2.0)
