### PR TITLE
feat: Add Memora (Memory Weaver) agent to Pearl

### DIFF
--- a/frontend/constants/agent.ts
+++ b/frontend/constants/agent.ts
@@ -5,6 +5,7 @@ export const AgentMap = {
   Optimus: 'optimus',
   PettAi: 'pett_ai',
   Polystrat: 'polymarket_trader',
+  Memora: 'memora',
 } as const;
 
 export type AgentType = (typeof AgentMap)[keyof typeof AgentMap];

--- a/frontend/constants/serviceTemplates/service/memora.ts
+++ b/frontend/constants/serviceTemplates/service/memora.ts
@@ -1,0 +1,63 @@
+import { ethers } from 'ethers';
+
+import { AgentMap, EnvProvisionMap as EnvProvisionType } from '@/constants';
+import { ServiceTemplate } from '@/types';
+import { parseEther } from '@/utils';
+
+import { MiddlewareChainMap } from '../../chains';
+import { STAKING_PROGRAM_IDS } from '../../stakingProgram';
+import { KPI_DESC_PREFIX } from '../constants';
+
+export const MEMORA_SERVICE_TEMPLATE: ServiceTemplate = {
+  hash: 'bafybei0000000000000000000000000000000000000000000000000000000000', // TODO: replace with actual IPFS hash after push-all
+  service_version: 'v1.0.0',
+  agent_release: {
+    is_aea: false, // Olas SDK (Node.js agent, not Open Autonomy FSM)
+    repository: {
+      owner: 'khusna-memora',
+      name: 'memora',
+      version: 'v1.0.0',
+    },
+  },
+  agentType: AgentMap.Memora,
+  name: 'Memora — Memory Weaver', // unique name
+  description: `${KPI_DESC_PREFIX} Memora is the shared memory layer for Pearl agents. It weaves, stores, and recalls verifiable memory across every agent using on-chain attestation (ERC-8004). One memory. All your agents. Forever on-chain.`,
+  image:
+    'https://memora-production-bfc4.up.railway.app/logo.jpg',
+  home_chain: MiddlewareChainMap.GNOSIS,
+  configurations: {
+    [MiddlewareChainMap.GNOSIS]: {
+      staking_program_id: STAKING_PROGRAM_IDS.MemoraMemoryWeaver,
+      nft: 'bafybei0000000000000000000000000000000000000000000000000000000000', // TODO: replace with NFT IPFS hash
+      rpc: '', // overwritten by Pearl
+      agent_id: 37,
+      cost_of_bond: parseEther(1),
+      fund_requirements: {
+        [ethers.constants.AddressZero]: {
+          agent: parseEther(0.5),
+          safe: parseEther(1),
+        },
+      },
+    },
+  },
+  env_variables: {
+    SAFE_CONTRACT_ADDRESSES: {
+      name: 'Safe contract addresses',
+      description: '',
+      value: '',
+      provision_type: EnvProvisionType.COMPUTED,
+    },
+    ALL_PARTICIPANTS: {
+      name: 'All participants',
+      description: '',
+      value: '',
+      provision_type: EnvProvisionType.COMPUTED,
+    },
+    MEMORA_DB_PATH: {
+      name: 'Database path',
+      description: 'Path to SQLite database for memory storage',
+      value: '',
+      provision_type: EnvProvisionType.COMPUTED,
+    },
+  },
+};

--- a/frontend/constants/stakingProgram.ts
+++ b/frontend/constants/stakingProgram.ts
@@ -13,6 +13,7 @@ const GNOSIS_STAKING_PROGRAM_IDS = {
   PearlBetaMechMarketplace2: 'pearl_beta_mech_marketplace_2',
   PearlBetaMechMarketplace3: 'pearl_beta_mech_marketplace_3',
   PearlBetaMechMarketplace4: 'pearl_beta_mech_marketplace_4',
+  MemoraMemoryWeaver: 'memora_memory_weaver',
 } as const;
 
 const BASE_STAKING_PROGRAM_IDS = {


### PR DESCRIPTION
## Summary
Adds Memora — the first inter-agent shared memory layer — to Pearl's agent catalog.

## What is Memora?
**Memora** weaves, stores, and recalls verifiable memory across every Pearl agent using on-chain attestation (ERC-8004).

**Tagline:** One memory. All your agents. Forever on-chain.

### Core Operations
- 🧠 **Weave** — Store verifiable memories with ERC-8004 proof
- 🔍 **Recall** — Semantic search with on-chain verification
- 🗑️ **Forget** — Privacy-first memory deletion

## Changes
- `agent.ts` — Added `Memora: 'memora'` to AgentMap
- `stakingProgram.ts` — Added `MemoraMemoryWeaver` staking program
- `serviceTemplates/service/memora.ts` — Full service template for Gnosis

## Agent Details
| Field | Value |
|-------|-------|
| Chain | Gnosis |
| Mech Contract | `0xbf8B2E2A0C0b5ccede9F9D3943aC8B3C4CDa4835` |
| Service Token | 2986 |
| ERC-8004 (Gnosis) | Agent #3259 |
| ERC-8004 (Base) | Agent #35755 |
| 8004scan | https://www.8004scan.io/agents/gnosis/3259 |

## Pearl QA Checklist
- [x] Healthcheck at `:8716/healthcheck`
- [x] Agent UI at `:8716/` (HTML)
- [x] `/funds-status` endpoint
- [x] `agent_performance.json` reporting
- [x] `log.txt` Pearl format
- [x] `run.sh` ENTRYPOINT with `--password` arg
- [x] `ethereum_private_key.txt` keystore support
- [x] `CONNECTION_CONFIGS_CONFIG_STORE_PATH` storage
- [x] `CONNECTION_CONFIGS_CONFIG_SAFE_CONTRACT_ADDRESSES` env var
- [x] SIGTERM graceful shutdown
- [x] GitHub Actions binary builds (linux/macOS/windows)

## Links
- 🌐 Website: https://memora.codes
- 📦 GitHub: https://github.com/khusna-memora/memora
- ❤️ Healthcheck: https://memora-production-bfc4.up.railway.app/healthcheck
- 🤖 A2A Card: https://memora-production-bfc4.up.railway.app/.well-known/agent-card.json
- 📊 Middleware PR: https://github.com/valory-xyz/olas-operate-middleware/pull/402

## Note
Service hash and NFT IPFS hash are placeholders. Will update before merge.

**Synthesis Hackathon — Pearl Integration (Track 1)**