### PR TITLE
ci: merge per-arch latest-mac.yml on all release paths

### DIFF
--- a/.github/workflows/create-feature-release.yml
+++ b/.github/workflows/create-feature-release.yml
@@ -47,8 +47,15 @@ jobs:
       tag: ${{ needs.calculate-version.outputs.new_tag }}
     secrets: inherit
 
+  merge-latest-mac-yml:
+    needs: [calculate-version, run-release]
+    uses: ./.github/workflows/merge-latest-mac-yml.yml
+    with:
+      tag: ${{ needs.calculate-version.outputs.new_tag }}
+    secrets: inherit
+
   summary:
-    needs: [calculate-version, run-release, run-release-win, run-release-linux]
+    needs: [calculate-version, run-release, run-release-win, run-release-linux, merge-latest-mac-yml]
     runs-on: ubuntu-latest
     steps:
       - name: Create summary

--- a/.github/workflows/merge-latest-mac-yml.yml
+++ b/.github/workflows/merge-latest-mac-yml.yml
@@ -1,0 +1,50 @@
+# Reusable: merges the per-arch latest-mac.yml artifacts uploaded by
+# release_mac.yml into a single latest-mac.yml and replaces the asset on
+# the release. Without this, each arch's mac runner overwrites the other's
+# latest-mac.yml on the release — breaking OTA for whichever arch runs first.
+
+name: Merge latest-mac.yml
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Release tag whose latest-mac.yml should be replaced'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Download arm64 yml
+        uses: actions/download-artifact@v4
+        with:
+          name: latest-mac-yml-arm64
+          path: yml-arm64
+        continue-on-error: true
+
+      - name: Download x64 yml
+        uses: actions/download-artifact@v4
+        with:
+          name: latest-mac-yml-x64
+          path: yml-x64
+        continue-on-error: true
+
+      - name: Merge latest-mac.yml
+        run: bash scripts/merge-latest-mac-yml.sh yml-arm64/latest-mac.yml yml-x64/latest-mac.yml latest-mac.yml
+
+      - name: Upload merged latest-mac.yml to release
+        if: hashFiles('latest-mac.yml') != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release delete-asset "${{ inputs.tag }}" latest-mac.yml --yes 2>/dev/null || true
+          gh release upload "${{ inputs.tag }}" latest-mac.yml --clobber

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -60,8 +60,16 @@ jobs:
       tag: ${{ needs.calculate-version.outputs.new_tag }}
     secrets: inherit
 
+  merge-latest-mac-yml:
+    needs: [calculate-version, run-release]
+    if: ${{ github.actor != 'github-actions[bot]' && !contains(github.event.head_commit.message, '[skip release]') }}
+    uses: ./.github/workflows/merge-latest-mac-yml.yml
+    with:
+      tag: ${{ needs.calculate-version.outputs.new_tag }}
+    secrets: inherit
+
   summary:
-    needs: [calculate-version, run-release, run-release-win, run-release-linux]
+    needs: [calculate-version, run-release, run-release-win, run-release-linux, merge-latest-mac-yml]
     if: ${{ github.actor != 'github-actions[bot]' && !contains(github.event.head_commit.message, '[skip release]') }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-to-production.yml
+++ b/.github/workflows/release-to-production.yml
@@ -69,8 +69,15 @@ jobs:
       tag: ${{ needs.calculate-version.outputs.new_tag }}
     secrets: inherit
 
+  merge-latest-mac-yml:
+    needs: [check-label, calculate-version, run-release]
+    uses: ./.github/workflows/merge-latest-mac-yml.yml
+    with:
+      tag: ${{ needs.calculate-version.outputs.new_tag }}
+    secrets: inherit
+
   summary:
-    needs: [check-label, calculate-version, run-release, run-release-win, run-release-linux]
+    needs: [check-label, calculate-version, run-release, run-release-win, run-release-linux, merge-latest-mac-yml]
     runs-on: ubuntu-latest
     steps:
       - name: Create summary

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -323,3 +323,10 @@ jobs:
           export GITHUB_REF_NAME="${RELEASE_TAG}"
           export GITHUB_REF="refs/tags/${RELEASE_TAG}"
           node build.js
+
+      - name: Save latest-mac.yml as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: latest-mac-yml-${{ env.OS_ARCH }}
+          path: dist/latest-mac.yml
+          if-no-files-found: warn

--- a/scripts/merge-latest-mac-yml.sh
+++ b/scripts/merge-latest-mac-yml.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Merge two arch-specific latest-mac.yml files into one.
+#
+# electron-builder generates latest-mac.yml per build. When arm64 and x64
+# are built on separate CI runners, the second upload overwrites the first.
+# This script merges both into a single file with entries for all architectures.
+#
+# Usage: ./merge-latest-mac-yml.sh <arm64_yml> <x64_yml> <output>
+
+set -euo pipefail
+
+ARM64_YML="$1"
+X64_YML="$2"
+OUTPUT="$3"
+
+if [ ! -f "$ARM64_YML" ] && [ ! -f "$X64_YML" ]; then
+  echo "ERROR: No yml files found" >&2
+  exit 1
+fi
+
+# Strip releaseNotes so electron-updater reads them from GitHub Atom feed instead
+strip_release_notes() {
+  sed '/^releaseNotes:/,/^[a-zA-Z]/{ /^releaseNotes:/d; /^[a-zA-Z]/!d; }' "$1"
+}
+
+# If only one exists, use it directly (strip releaseNotes)
+if [ ! -f "$ARM64_YML" ]; then
+  strip_release_notes "$X64_YML" > "$OUTPUT"
+  echo "Only x64 yml found, using as-is"
+  exit 0
+fi
+if [ ! -f "$X64_YML" ]; then
+  strip_release_notes "$ARM64_YML" > "$OUTPUT"
+  echo "Only arm64 yml found, using as-is"
+  exit 0
+fi
+
+# Extract version and releaseDate from arm64 (arbitrary choice)
+VERSION=$(grep '^version:' "$ARM64_YML" | head -1 | sed 's/version: //')
+RELEASE_DATE=$(grep '^releaseDate:' "$ARM64_YML" | head -1 | sed "s/releaseDate: //")
+
+# Extract file entries (lines starting with "  -" or "    " after "files:")
+extract_files() {
+  awk '/^files:/{found=1; next} found && /^[a-zA-Z]/{found=0} found{print}' "$1"
+}
+
+ARM64_FILES=$(extract_files "$ARM64_YML")
+X64_FILES=$(extract_files "$X64_YML")
+
+# Get arm64 zip entry for the default path/sha512
+ARM64_PATH=$(awk '/url:.*arm64.*\.zip/{gsub(/.*url: /,""); print; exit}' "$ARM64_YML")
+ARM64_SHA=$(awk '/url:.*arm64.*\.zip/{found=1; next} found && /sha512:/{gsub(/.*sha512: /,""); print; exit}' "$ARM64_YML")
+
+cat > "$OUTPUT" << YAML
+version: ${VERSION}
+files:
+${ARM64_FILES}
+${X64_FILES}
+path: ${ARM64_PATH}
+sha512: ${ARM64_SHA}
+releaseDate: ${RELEASE_DATE}
+YAML
+
+echo "Merged latest-mac.yml:"
+cat "$OUTPUT"


### PR DESCRIPTION
## Summary
- Extracts the per-arch \`latest-mac.yml\` merge job into a reusable workflow (\`merge-latest-mac-yml.yml\`) so all three release paths share one source of truth.
- Wires the reusable workflow into \`create-feature-release\`, \`production-release\`, and \`release-to-production\`.
- Adds the accompanying merge script (\`scripts/merge-latest-mac-yml.sh\`) so \`main\` is self-contained — previously the script lived only on the OTA branch.

## Why
\`electron-builder\` writes \`latest-mac.yml\` per build. arm64 and x64 run on separate mac runners; whichever finishes second clobbers the other's \`latest-mac.yml\` on the release. Result: only one arch can OTA-update. This job merges both into a single file with entries for both archs.

Until now the merge job only existed on \`create-feature-release.yml\` (feature/alpha releases). \`production-release.yml\` and \`release-to-production.yml\` were missing it — so GA and prod RCs shipped with a broken \`latest-mac.yml\`.

## Test plan
- [ ] Label an existing release PR with \"Release to production\" and confirm the new \`merge-latest-mac-yml\` job runs and uploads a merged file containing both arm64 and x64 entries.
- [ ] Trigger \`create-feature-release\` and confirm behavior is unchanged (same outputs as before the refactor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)