### PR TITLE
ci: fix mac signing and latest-mac.yml upload on label-triggered releases

### DIFF
--- a/.github/workflows/merge-latest-mac-yml.yml
+++ b/.github/workflows/merge-latest-mac-yml.yml
@@ -45,6 +45,12 @@ jobs:
         if: hashFiles('latest-mac.yml') != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
         run: |
-          gh release delete-asset "${{ inputs.tag }}" latest-mac.yml --yes 2>/dev/null || true
-          gh release upload "${{ inputs.tag }}" latest-mac.yml --clobber
+          # The signing workflow tags the commit with a `-signed` suffix for
+          # audit purposes (e.g. v1.5.0-signed), but electron-builder publishes
+          # the GitHub Release at the unsuffixed tag (v1.5.0). Strip the suffix
+          # so the release asset is uploaded to the correct release.
+          RELEASE_TAG="${TAG%-signed}"
+          gh release delete-asset "$RELEASE_TAG" latest-mac.yml --yes 2>/dev/null || true
+          gh release upload "$RELEASE_TAG" latest-mac.yml --clobber

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -297,6 +297,12 @@ jobs:
           GH_TOKEN: ${{ secrets.github_token }}
           GITHUB_TOKEN: ${{ secrets.github_token }}
           PUBLISH_FOR_PULL_REQUEST: true
+          # When the workflow is triggered by a pull_request event (e.g. the
+          # "Release to production" label flow), electron-builder detects the
+          # PR context via GITHUB_BASE_REF and skips code signing by default
+          # (see app-builder-lib's macCodeSign.isSignAllowed). Opt in explicitly
+          # so label-triggered releases are signed and notarized.
+          CSC_FOR_PULL_REQUEST: true
           RELEASE_TAG: ${{ inputs.tag }}
           NODE_ENV: ${{ matrix.env }}
           ARCH: ${{ env.OS_ARCH }}


### PR DESCRIPTION
Fixes two bugs that surfaced during the first \"Release to production\" run for v1.5.0:

## 1. Mac signing skipped on \`pull_request\` triggers (`release_mac.yml`)
\`electron-builder\` detects PR context via \`GITHUB_BASE_REF\` and skips code signing by default (see \`app-builder-lib/codeSign/macCodeSign.js:isSignAllowed\`). Our \`release-to-production.yml\` is triggered by \`pull_request: [labeled]\`, so **label-triggered releases shipped unsigned** while \`production-release.yml\` (push-triggered) signed correctly.

Fix: add \`CSC_FOR_PULL_REQUEST: true\` alongside the existing \`PUBLISH_FOR_PULL_REQUEST: true\`. The two flags are independent — one gates publishing, the other gates signing.

**Evidence** — from the failed v1.5.0 mac build log:
> \`Current build is a part of pull request, code signing will be skipped. Set env CSC_FOR_PULL_REQUEST to true to force code signing.\`

## 2. \`latest-mac.yml\` upload targeting the wrong tag (\`merge-latest-mac-yml.yml\`)
For \`production-release\` and \`production-rc\` strategies, \`calculate-and-update-version.yml\` creates a git tag with a \`-signed\` suffix (audit marker for the signing pipeline). But \`electron-builder\` publishes the GitHub Release at the **unsuffixed** tag (derived from \`package.json\` version). The merge job was calling \`gh release upload v1.5.0-signed ...\` which 404'd because no release exists at the audit tag.

Fix: strip \`-signed\` from \`inputs.tag\` before uploading.
- Unsigned feature releases (alpha/rc via \`create-feature-release.yml\`): no suffix → no-op.
- Signed production releases: correctly targets \`v1.5.0\` instead of \`v1.5.0-signed\`.

## Test plan
- [ ] Re-label a release PR with \"Release to production\"; confirm both mac arm64 and x64 assets are codesigned (\`Developer ID Application: Valory AG\`) and that \`latest-mac.yml\` lands on the release with both architectures listed.
- [ ] Trigger \`create-feature-release.yml\` and confirm feature-release merge behavior is unchanged (alpha/rc path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)