### PR TITLE
fix(ota): check for updates while Pearl is minimized

### DIFF
--- a/frontend/components/MainPage/UpdateAvailableAlert/useAppStatus.ts
+++ b/frontend/components/MainPage/UpdateAvailableAlert/useAppStatus.ts
@@ -77,6 +77,7 @@ export const useAppStatus = () => {
       });
     },
     refetchInterval: SIXTY_MINUTE_INTERVAL,
+    refetchIntervalInBackground: true,
     staleTime: SIXTY_MINUTE_INTERVAL,
     refetchOnWindowFocus: false,
   });


### PR DESCRIPTION
## Summary
- React Query's \`refetchInterval\` pauses on \`visibilitychange\` by default, so users who minimize Pearl (or \`Cmd+H\` the app) stop receiving update checks until they bring the window back.
- Setting \`refetchIntervalInBackground: true\` keeps the 60-minute timer ticking regardless of visibility.
- Cost: one anonymous GitHub Atom-feed request per hour per backgrounded client. Trivial.

## Why not also \`refetchOnWindowFocus: true\`?
Redundant once the interval never pauses — cached data is always at most ~60 min old. A focus refetch would find fresh data (within \`staleTime\`) and no-op.

## Stacked PR
Base is #1837 (staging sync). Will auto-retarget to \`staging\` when that merges.

## Test plan
- [ ] Minimize Pearl for >1h, bring it back, confirm a check ran while minimized (log \`[OTA] Checking for updates...\` in electron.log).
- [ ] Run \`yarn test:frontend -- useAppStatus\` — existing 12 tests still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)