### PR TITLE
fix(store): store migration logic 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,7 @@ leak_report
 
 # logs
 *.log
-logs/
+/.logs/
 
 # custom script for development
 .scripts/
@@ -60,4 +60,4 @@ logs/
 frontend/coverage
 
 # local plans
-/plans/
+/.plans/

--- a/electron/store.js
+++ b/electron/store.js
@@ -14,6 +14,11 @@ const schema = {
   knownVersion: { type: 'string', default: '' },
   // Stores the latest app version for which the "update available" modal was dismissed.
   updateAvailableKnownVersion: { type: 'string', default: '' },
+  // Set to true once the authoritative Electron→pearl_store migration is done.
+  // Must be in the schema so electron-store persists it.
+  pearlStoreMigrationComplete: { type: 'boolean', default: false },
+  // Set to true once the autoRun.enabled repair has been checked.
+  pearlStoreAutoRunRepaired: { type: 'boolean', default: false },
 };
 
 /**

--- a/electron/store.js
+++ b/electron/store.js
@@ -4,6 +4,11 @@ const Store = require('electron-store');
 // All other persistence (agent settings, auto-run, backup wallet, etc.) lives in
 // .operate/pearl_store.json served by the backend HTTP API, so it migrates with
 // the .operate folder when a user moves to a new machine.
+//
+// Legacy keys (trader, autoRun, etc.) are NOT in this schema but are still readable
+// via store.get() — electron-store returns existing values for keys not in the schema.
+// The frontend migration in StoreProvider reads them on first launch and copies to
+// pearl_store.json.
 const schema = {
   environmentName: { type: 'string', default: '' },
   knownVersion: { type: 'string', default: '' },

--- a/frontend/context/AutoRunProvider/AutoRunProvider.tsx
+++ b/frontend/context/AutoRunProvider/AutoRunProvider.tsx
@@ -60,6 +60,7 @@ export const AutoRunProvider = ({ children }: PropsWithChildren) => {
   const configuredAgents = useConfiguredAgents(services);
 
   const {
+    storeLoaded,
     enabled,
     includedInstances,
     isInitialized,
@@ -177,7 +178,9 @@ export const AutoRunProvider = ({ children }: PropsWithChildren) => {
   ]);
 
   // Seed the included list once from eligible instances. After that, empty is intentional.
+  // Must wait for storeLoaded so we read the real isInitialized value, not the default.
   useEffect(() => {
+    if (!storeLoaded) return;
     if (!services) return;
     if (isInitialized) return;
     if (eligibleInstances.length === 0) return;
@@ -187,7 +190,7 @@ export const AutoRunProvider = ({ children }: PropsWithChildren) => {
       order: index,
     }));
     updateAutoRun({ includedInstances: instances, isInitialized: true });
-  }, [eligibleInstances, isInitialized, services, updateAutoRun]);
+  }, [storeLoaded, eligibleInstances, isInitialized, services, updateAutoRun]);
 
   // Auto-append newly onboarded instances unless explicitly excluded by the user.
   useEffect(() => {

--- a/frontend/context/AutoRunProvider/hooks/useAutoRunStore.ts
+++ b/frontend/context/AutoRunProvider/hooks/useAutoRunStore.ts
@@ -33,6 +33,10 @@ export const useAutoRunStore = () => {
   const autoRunRef = useRef(DEFAULT_AUTO_RUN);
   const hasMigratedRef = useRef(false);
 
+  // Only read from storeState after hydration (storeState is defined).
+  // Before hydration, autoRunRef keeps DEFAULT_AUTO_RUN with isInitialized=false,
+  // but storeLoaded=false prevents any write-back that would overwrite real data.
+  const storeLoaded = storeState !== undefined;
   const autoRun = storeState?.autoRun;
   if (autoRun) {
     // Always read from the current store fields
@@ -111,6 +115,7 @@ export const useAutoRunStore = () => {
   );
 
   return {
+    storeLoaded,
     enabled,
     includedInstances,
     isInitialized,

--- a/frontend/context/ServicesProvider.tsx
+++ b/frontend/context/ServicesProvider.tsx
@@ -417,6 +417,7 @@ export const ServicesProvider = ({ children }: PropsWithChildren) => {
   // Also migrates to the new store fields, in case they have the deprecated
   // `lastSelectedAgentType` field in their electron store.
   useEffect(() => {
+    if (storeState === undefined) return; // Wait for store hydration
     if (isNilOrEmpty(services)) return;
     if (pendingAgentType) return;
 

--- a/frontend/context/StoreProvider.tsx
+++ b/frontend/context/StoreProvider.tsx
@@ -160,6 +160,7 @@ export const StoreProvider = ({ children }: PropsWithChildren) => {
           isHydratedRef.current = true;
           setStoreState(finalState);
 
+          // Report raw backend key count (before draining pending ops).
           const keyCount = Object.keys(data).length;
           if (keyCount === 0) {
             log(`Hydrated on attempt ${attempt} (empty store)`);
@@ -247,6 +248,11 @@ export const StoreProvider = ({ children }: PropsWithChildren) => {
       storeGet('pearlStoreAutoRunRepaired'),
     ])
       .then(async ([migrationDone, autoRunRepaired]) => {
+        if (migrationDone && autoRunRepaired) {
+          log('Migration already complete (flags set)');
+          return;
+        }
+
         let didWrite = false;
 
         // Phase 1: Copy missing keys from Electron → backend
@@ -294,23 +300,20 @@ export const StoreProvider = ({ children }: PropsWithChildren) => {
             !backendAutoRun.enabled
           ) {
             log('Repairing autoRun.enabled (was lost during migration)');
-            await StoreService.setStoreKey('autoRun', electronAutoRun);
+            // Use dot-notation to set only the enabled flag — preserves any
+            // backend-side fields (includedAgentInstances, etc.) that may
+            // have been written after the race.
+            await StoreService.setStoreKey('autoRun.enabled', true);
             didWrite = true;
           }
 
           await storeSet('pearlStoreAutoRunRepaired', true);
         }
 
-        if (migrationDone && autoRunRepaired) {
-          log('Migration already complete (flags set)');
-          return;
-        }
-
         // Refresh storeState from backend if any writes were made
         if (didWrite) {
           const data = await StoreService.getStore();
           const finalState = drainPendingOps(data);
-          isHydratedRef.current = true;
           setStoreState(finalState);
         }
 

--- a/frontend/context/StoreProvider.tsx
+++ b/frontend/context/StoreProvider.tsx
@@ -270,21 +270,50 @@ export const StoreProvider = ({ children }: PropsWithChildren) => {
               (snapshot as Record<string, unknown>)[key] === undefined,
           );
 
+          let allMigrationWritesSucceeded = true;
+
           if (toMigrate.length > 0) {
             log(
               `Migrating ${toMigrate.length} keys: ${toMigrate.map((e) => e.key).join(', ')}`,
             );
-            await Promise.all(
+
+            const results = await Promise.allSettled(
               toMigrate.map(({ key, value }) =>
                 StoreService.setStoreKey(key, value),
               ),
             );
-            didWrite = true;
+
+            const successfulWrites = results.filter(
+              (result) => result.status === 'fulfilled',
+            ).length;
+            const failedKeys = results
+              .map((result, index) =>
+                result.status === 'rejected'
+                  ? toMigrate[index]?.key
+                  : undefined,
+              )
+              .filter((key): key is keyof PearlStore => key !== undefined);
+
+            if (successfulWrites > 0) {
+              didWrite = true;
+            }
+
+            allMigrationWritesSucceeded = failedKeys.length === 0;
+
+            if (!allMigrationWritesSucceeded) {
+              log(
+                `Migration partially failed for keys: ${failedKeys.join(', ')}`,
+              );
+            }
           } else {
             log('No Electron store keys to migrate');
           }
 
-          await storeSet('pearlStoreMigrationComplete', true);
+          // Only set the flag when all writes succeeded — partial failures
+          // will re-migrate the missing keys on next launch.
+          if (allMigrationWritesSucceeded) {
+            await storeSet('pearlStoreMigrationComplete', true);
+          }
         }
 
         // Phase 2: Repair autoRun if Electron had enabled=true but backend has enabled=false

--- a/frontend/context/StoreProvider.tsx
+++ b/frontend/context/StoreProvider.tsx
@@ -349,7 +349,8 @@ export const StoreProvider = ({ children }: PropsWithChildren) => {
         log('Migration complete');
       })
       .catch((error) => {
-        log(`Migration failed: ${error}`);
+        const msg = error instanceof Error ? error.message : String(error);
+        log(`Migration failed: ${msg}`);
         console.error('[StoreProvider] Migration failed:', error);
       });
   }, [store, storeState]);

--- a/frontend/context/StoreProvider.tsx
+++ b/frontend/context/StoreProvider.tsx
@@ -217,55 +217,104 @@ export const StoreProvider = ({ children }: PropsWithChildren) => {
   }, []);
 
   // Migration: copy backend-bound keys from Electron store to pearl_store.json.
-  // Runs when the Electron store has keys that the backend store is missing.
-  // Handles first upgrade, .operate folder swaps, and partial migrations.
-  // Compares against the hydration snapshot (not live storeState) to avoid
-  // races with hooks that write defaults before migration runs.
+  //
+  // Two phases, each gated by its own persistent flag in the Electron store:
+  //
+  // Phase 1 (pearlStoreMigrationComplete): Copy any Electron store key that is
+  //   MISSING from the backend. Safe — never overwrites existing backend data.
+  //   Handles first upgrade and partial migrations.
+  //
+  // Phase 2 (pearlStoreAutoRunRepaired): One-time repair for users hit by the
+  //   autoRun race bug where useAutoRunStore wrote {enabled: false} before
+  //   migration could copy the real value. If Electron has autoRun.enabled=true
+  //   but backend has autoRun.enabled=false, overwrite backend with Electron.
+  //
+  // Both phases compare against hydrationSnapshotRef (not live storeState) to
+  // avoid races with hooks that write during initialization.
   const migrationAttempted = useRef(false);
   useEffect(() => {
     const storeGet = store?.get;
-    if (!storeGet) return;
+    const storeSet = store?.set;
+    if (!storeGet || !storeSet) return;
     if (!isHydratedRef.current) return;
     if (migrationAttempted.current) return;
     migrationAttempted.current = true;
 
     const snapshot = hydrationSnapshotRef.current;
 
-    // Read all backend-bound keys from Electron store, then migrate any
-    // that are present in Electron but missing from the hydration snapshot.
-    Promise.all(
-      BACKEND_BOUND_KEYS.map((key) =>
-        storeGet(key).then((value) => ({ key, value })),
-      ),
-    )
-      .then((entries) => {
-        const toMigrate = entries.filter(
-          ({ key, value }) =>
-            value !== undefined &&
-            value !== null &&
-            (snapshot as Record<string, unknown>)[key] === undefined,
-        );
-        if (toMigrate.length === 0) {
-          log('No Electron store keys to migrate');
+    Promise.all([
+      storeGet('pearlStoreMigrationComplete'),
+      storeGet('pearlStoreAutoRunRepaired'),
+    ])
+      .then(async ([migrationDone, autoRunRepaired]) => {
+        let didWrite = false;
+
+        // Phase 1: Copy missing keys from Electron → backend
+        if (!migrationDone) {
+          const entries = await Promise.all(
+            BACKEND_BOUND_KEYS.map((key) =>
+              storeGet(key).then((value) => ({ key, value })),
+            ),
+          );
+
+          const toMigrate = entries.filter(
+            ({ key, value }) =>
+              value !== undefined &&
+              value !== null &&
+              (snapshot as Record<string, unknown>)[key] === undefined,
+          );
+
+          if (toMigrate.length > 0) {
+            log(
+              `Migrating ${toMigrate.length} keys: ${toMigrate.map((e) => e.key).join(', ')}`,
+            );
+            await Promise.all(
+              toMigrate.map(({ key, value }) =>
+                StoreService.setStoreKey(key, value),
+              ),
+            );
+            didWrite = true;
+          } else {
+            log('No Electron store keys to migrate');
+          }
+
+          await storeSet('pearlStoreMigrationComplete', true);
+        }
+
+        // Phase 2: Repair autoRun if Electron had enabled=true but backend has enabled=false
+        if (!autoRunRepaired) {
+          const electronAutoRun = (await storeGet('autoRun')) as
+            | Record<string, unknown>
+            | undefined;
+          const backendAutoRun = snapshot.autoRun;
+
+          if (
+            electronAutoRun?.enabled === true &&
+            backendAutoRun &&
+            !backendAutoRun.enabled
+          ) {
+            log('Repairing autoRun.enabled (was lost during migration)');
+            await StoreService.setStoreKey('autoRun', electronAutoRun);
+            didWrite = true;
+          }
+
+          await storeSet('pearlStoreAutoRunRepaired', true);
+        }
+
+        if (migrationDone && autoRunRepaired) {
+          log('Migration already complete (flags set)');
           return;
         }
 
-        log(
-          `Migrating ${toMigrate.length} keys: ${toMigrate.map((e) => e.key).join(', ')}`,
-        );
+        // Refresh storeState from backend if any writes were made
+        if (didWrite) {
+          const data = await StoreService.getStore();
+          const finalState = drainPendingOps(data);
+          isHydratedRef.current = true;
+          setStoreState(finalState);
+        }
 
-        return Promise.all(
-          toMigrate.map(({ key, value }) =>
-            StoreService.setStoreKey(key, value),
-          ),
-        ).then(() =>
-          StoreService.getStore().then((data) => {
-            const finalState = drainPendingOps(data);
-            isHydratedRef.current = true;
-            setStoreState(finalState);
-            log('Migration complete');
-          }),
-        );
+        log('Migration complete');
       })
       .catch((error) => {
         log(`Migration failed: ${error}`);

--- a/frontend/context/StoreProvider.tsx
+++ b/frontend/context/StoreProvider.tsx
@@ -359,6 +359,11 @@ export const StoreProvider = ({ children }: PropsWithChildren) => {
       });
   }, [store, storeState]);
 
+  // Block rendering until the store has hydrated. This prevents child hooks
+  // (e.g. useAutoRunStore) from reading default values and writing them back
+  // to the backend, overwriting the user's real settings.
+  if (storeState === undefined) return null;
+
   return (
     <StoreContext.Provider value={{ storeState }}>
       {children}

--- a/frontend/context/StoreProvider.tsx
+++ b/frontend/context/StoreProvider.tsx
@@ -86,6 +86,11 @@ export const StoreProvider = ({ children }: PropsWithChildren) => {
   const pendingOpsRef = useRef<PendingOp[]>([]);
   const isHydratedRef = useRef(false);
 
+  // Snapshot of backend store at hydration time — used by migration to decide
+  // which keys are missing. Must NOT reflect post-hydration writes from other
+  // hooks (e.g. useAutoRunStore), otherwise migration skips keys it should copy.
+  const hydrationSnapshotRef = useRef<PearlStore>({});
+
   // Apply a store operation or queue it if hydration hasn't completed yet.
   const applyOrQueue = useRef({
     set: (key: string, value: unknown) => {
@@ -150,11 +155,12 @@ export const StoreProvider = ({ children }: PropsWithChildren) => {
       StoreService.getStore()
         .then((data) => {
           if (cancelled) return;
+          hydrationSnapshotRef.current = data;
           const finalState = drainPendingOps(data);
           isHydratedRef.current = true;
           setStoreState(finalState);
 
-          const keyCount = Object.keys(finalState).length;
+          const keyCount = Object.keys(data).length;
           if (keyCount === 0) {
             log(`Hydrated on attempt ${attempt} (empty store)`);
           } else {
@@ -213,6 +219,8 @@ export const StoreProvider = ({ children }: PropsWithChildren) => {
   // Migration: copy backend-bound keys from Electron store to pearl_store.json.
   // Runs when the Electron store has keys that the backend store is missing.
   // Handles first upgrade, .operate folder swaps, and partial migrations.
+  // Compares against the hydration snapshot (not live storeState) to avoid
+  // races with hooks that write defaults before migration runs.
   const migrationAttempted = useRef(false);
   useEffect(() => {
     const storeGet = store?.get;
@@ -221,8 +229,10 @@ export const StoreProvider = ({ children }: PropsWithChildren) => {
     if (migrationAttempted.current) return;
     migrationAttempted.current = true;
 
+    const snapshot = hydrationSnapshotRef.current;
+
     // Read all backend-bound keys from Electron store, then migrate any
-    // that are present in Electron but missing from the backend store.
+    // that are present in Electron but missing from the hydration snapshot.
     Promise.all(
       BACKEND_BOUND_KEYS.map((key) =>
         storeGet(key).then((value) => ({ key, value })),
@@ -233,7 +243,7 @@ export const StoreProvider = ({ children }: PropsWithChildren) => {
           ({ key, value }) =>
             value !== undefined &&
             value !== null &&
-            (storeState as Record<string, unknown>)?.[key] === undefined,
+            (snapshot as Record<string, unknown>)[key] === undefined,
         );
         if (toMigrate.length === 0) {
           log('No Electron store keys to migrate');

--- a/frontend/context/StoreProvider.tsx
+++ b/frontend/context/StoreProvider.tsx
@@ -316,7 +316,11 @@ export const StoreProvider = ({ children }: PropsWithChildren) => {
           }
         }
 
-        // Phase 2: Repair autoRun if Electron had enabled=true but backend has enabled=false
+        // Phase 2: Repair autoRun if Electron had enabled=true but backend has enabled=false.
+        // Tradeoff: if a user saw the race-bug disable their autoRun and intentionally
+        // left it off, this one-shot repair will re-enable it. We accept this because
+        // the common case is "user wants it restored" and there's no way to distinguish
+        // "user accepted the bug" from "user didn't notice." Flag prevents re-run.
         if (!autoRunRepaired) {
           const electronAutoRun = (await storeGet('autoRun')) as
             | Record<string, unknown>

--- a/frontend/context/StoreProvider.tsx
+++ b/frontend/context/StoreProvider.tsx
@@ -359,11 +359,6 @@ export const StoreProvider = ({ children }: PropsWithChildren) => {
       });
   }, [store, storeState]);
 
-  // Block rendering until the store has hydrated. This prevents child hooks
-  // (e.g. useAutoRunStore) from reading default values and writing them back
-  // to the backend, overwriting the user's real settings.
-  if (storeState === undefined) return null;
-
   return (
     <StoreContext.Provider value={{ storeState }}>
       {children}

--- a/frontend/context/pearlStoreKeys.ts
+++ b/frontend/context/pearlStoreKeys.ts
@@ -8,6 +8,8 @@ export const ELECTRON_NATIVE_KEYS = new Set([
   'environmentName',
   'knownVersion',
   'updateAvailableKnownVersion',
+  'pearlStoreMigrationComplete',
+  'pearlStoreAutoRunRepaired',
 ]);
 
 /**

--- a/frontend/hooks/useArchivedAgents.ts
+++ b/frontend/hooks/useArchivedAgents.ts
@@ -28,6 +28,7 @@ export const useArchivedAgents = () => {
   // One-time migration: expand legacy archivedAgents → archivedInstances
   useEffect(() => {
     if (hasMigrated.current) return;
+    if (storeState === undefined) return; // Wait for store hydration
     if (!services || services.length === 0) return;
 
     const legacyArchived = storeState?.archivedAgents;

--- a/frontend/tests/context/StoreProvider.test.tsx
+++ b/frontend/tests/context/StoreProvider.test.tsx
@@ -38,7 +38,15 @@ const makeWrapper = (electronValue?: object) => {
   const Wrapper = ({ children }: PropsWithChildren) => {
     const defaultElectron = {
       store: {
-        get: jest.fn().mockResolvedValue(undefined),
+        get: jest.fn().mockImplementation((key: string) =>
+          // Migration already done — skip in most tests
+          Promise.resolve(
+            key === 'pearlStoreMigrationComplete' ||
+              key === 'pearlStoreAutoRunRepaired'
+              ? true
+              : undefined,
+          ),
+        ),
         set: jest.fn().mockResolvedValue(undefined),
       },
     };
@@ -274,6 +282,145 @@ describe('StoreProvider', () => {
     await waitFor(() => {
       expect(result.current.storeState).toEqual({
         lastSelectedServiceConfigId: 'svc-1',
+      });
+    });
+  });
+
+  describe('migration', () => {
+    const mockSetStoreKey = StoreService.setStoreKey as jest.Mock;
+
+    /** Wrapper where migration flags are NOT set and Electron store returns given data. */
+    const makeMigrationWrapper = (electronData: Record<string, unknown>) => {
+      const Wrapper = ({ children }: PropsWithChildren) => {
+        const electron = {
+          store: {
+            get: jest
+              .fn()
+              .mockImplementation((key: string) =>
+                Promise.resolve(electronData[key]),
+              ),
+            set: jest.fn().mockResolvedValue(undefined),
+          },
+        };
+        return createElement(
+          ElectronApiContext.Provider,
+          { value: electron },
+          createElement(StoreProvider, null, children),
+        );
+      };
+      return Wrapper;
+    };
+
+    beforeEach(() => {
+      mockSetStoreKey.mockResolvedValue(undefined);
+    });
+
+    it('phase 1: copies missing keys from Electron to backend', async () => {
+      // Backend has autoRun only; Electron has autoRun + trader
+      mockGetStore
+        .mockResolvedValueOnce({ autoRun: { enabled: false } })
+        .mockResolvedValueOnce({
+          autoRun: { enabled: true },
+          trader: { isInitialFunded: { 'svc-1': true } },
+        });
+
+      const { result } = renderHook(() => useContext(StoreContext), {
+        wrapper: makeMigrationWrapper({
+          autoRun: { enabled: true },
+          trader: { isInitialFunded: { 'svc-1': true } },
+        }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.storeState?.trader).toEqual({
+          isInitialFunded: { 'svc-1': true },
+        });
+      });
+
+      // trader was missing from backend → should be migrated
+      expect(mockSetStoreKey).toHaveBeenCalledWith('trader', {
+        isInitialFunded: { 'svc-1': true },
+      });
+    });
+
+    it('phase 1: does NOT overwrite existing backend keys', async () => {
+      // Backend already has trader with correct data
+      mockGetStore.mockResolvedValue({
+        trader: { isInitialFunded: { 'svc-1': true } },
+        autoRun: { enabled: true },
+      });
+
+      renderHook(() => useContext(StoreContext), {
+        wrapper: makeMigrationWrapper({
+          // Electron has DIFFERENT trader value (old boolean format)
+          trader: { isInitialFunded: true },
+          autoRun: { enabled: true },
+          pearlStoreAutoRunRepaired: true,
+        }),
+      });
+
+      // Wait for migration to complete
+      await waitFor(() => {
+        expect(mockSetStoreKey).not.toHaveBeenCalledWith(
+          'trader',
+          expect.anything(),
+        );
+      });
+    });
+
+    it('phase 2: repairs autoRun.enabled when Electron=true but backend=false', async () => {
+      mockGetStore
+        .mockResolvedValueOnce({ autoRun: { enabled: false } })
+        .mockResolvedValueOnce({ autoRun: { enabled: true } });
+
+      const { result } = renderHook(() => useContext(StoreContext), {
+        wrapper: makeMigrationWrapper({
+          autoRun: { enabled: true, isInitialized: true },
+        }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.storeState?.autoRun?.enabled).toBe(true);
+      });
+
+      expect(mockSetStoreKey).toHaveBeenCalledWith('autoRun', {
+        enabled: true,
+        isInitialized: true,
+      });
+    });
+
+    it('phase 2: does NOT touch autoRun when values already match', async () => {
+      mockGetStore.mockResolvedValue({
+        autoRun: { enabled: true, isInitialized: true },
+      });
+
+      renderHook(() => useContext(StoreContext), {
+        wrapper: makeMigrationWrapper({
+          autoRun: { enabled: true, isInitialized: true },
+          pearlStoreAutoRunRepaired: true,
+        }),
+      });
+
+      await waitFor(() => {
+        expect(mockSetStoreKey).not.toHaveBeenCalledWith(
+          'autoRun',
+          expect.anything(),
+        );
+      });
+    });
+
+    it('skips both phases when flags are already set', async () => {
+      mockGetStore.mockResolvedValue({ autoRun: { enabled: false } });
+
+      renderHook(() => useContext(StoreContext), {
+        wrapper: makeMigrationWrapper({
+          pearlStoreMigrationComplete: true,
+          pearlStoreAutoRunRepaired: true,
+        }),
+      });
+
+      await waitFor(() => {
+        expect(mockSetStoreKey).not.toHaveBeenCalled();
       });
     });
   });

--- a/frontend/tests/context/StoreProvider.test.tsx
+++ b/frontend/tests/context/StoreProvider.test.tsx
@@ -82,18 +82,26 @@ describe('StoreProvider', () => {
     expect(mockGetStore).toHaveBeenCalled();
   });
 
-  it('provides undefined storeState before StoreService.getStore() resolves', () => {
+  it('blocks children until StoreService.getStore() resolves', () => {
     // Never resolves during this test
     mockGetStore.mockReturnValue(new Promise(() => {}));
 
-    const { result } = renderHook(() => useContext(StoreContext), {
-      wrapper: makeWrapper(),
-    });
+    let rendered = false;
+    renderHook(
+      () => {
+        rendered = true;
+        return useContext(StoreContext);
+      },
+      { wrapper: makeWrapper() },
+    );
 
-    expect(result.current.storeState).toBeUndefined();
+    // Provider returns null before hydration — children do not render
+    expect(rendered).toBe(false);
   });
 
-  it('catches StoreService.getStore() rejection and logs to console.error', async () => {
+  it('catches StoreService.getStore() rejection and falls back to empty store', async () => {
+    jest.useFakeTimers();
+
     const storeError = new Error('store unavailable');
     mockGetStore.mockRejectedValue(storeError);
 
@@ -105,15 +113,26 @@ describe('StoreProvider', () => {
       wrapper: makeWrapper(),
     });
 
+    // Exhaust all retries
+    for (let i = 0; i < 3; i++) {
+      await waitFor(() => {
+        expect(mockGetStore).toHaveBeenCalledTimes(i + 1);
+      });
+      jest.advanceTimersByTime(3000);
+    }
+
+    // After all retries, falls back to empty store
     await waitFor(() => {
-      expect(consoleSpy).toHaveBeenCalledWith(
-        '[StoreProvider] Hydration attempt 1 failed:',
-        storeError,
-      );
+      expect(result.current.storeState).toEqual({});
     });
 
-    expect(result.current.storeState).toBeUndefined();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[StoreProvider] Hydration attempt 1 failed:',
+      storeError,
+    );
+
     consoleSpy.mockRestore();
+    jest.useRealTimers();
   });
 
   it('provides empty storeState when StoreService.getStore() returns {}', async () => {
@@ -165,7 +184,6 @@ describe('StoreProvider', () => {
         storeError,
       );
     });
-    expect(result.current.storeState).toBeUndefined();
 
     // Advance past retry delay (3 seconds)
     jest.advanceTimersByTime(3000);
@@ -229,18 +247,12 @@ describe('StoreProvider', () => {
       wrapper: makeWrapper(),
     });
 
-    // storeState is undefined — hydration hasn't resolved yet.
-    expect(result.current.storeState).toBeUndefined();
-
     // Simulate a write arriving before hydration via the registered event bus handler.
     const setHandler = mockRegisterSet.mock.calls[0][0] as (
       key: string,
       value: unknown,
     ) => void;
     setHandler('autoRun', { enabled: true });
-
-    // storeState is still undefined — write was queued, not dropped.
-    expect(result.current.storeState).toBeUndefined();
 
     // Now resolve hydration with backend data.
     resolveGetStore({ firstStakingRewardAchieved: true });

--- a/frontend/tests/context/StoreProvider.test.tsx
+++ b/frontend/tests/context/StoreProvider.test.tsx
@@ -350,7 +350,7 @@ describe('StoreProvider', () => {
         autoRun: { enabled: true },
       });
 
-      renderHook(() => useContext(StoreContext), {
+      const { result } = renderHook(() => useContext(StoreContext), {
         wrapper: makeMigrationWrapper({
           // Electron has DIFFERENT trader value (old boolean format)
           trader: { isInitialFunded: true },
@@ -359,13 +359,16 @@ describe('StoreProvider', () => {
         }),
       });
 
-      // Wait for migration to complete
+      // Wait for hydration + migration to complete
       await waitFor(() => {
-        expect(mockSetStoreKey).not.toHaveBeenCalledWith(
-          'trader',
-          expect.anything(),
-        );
+        expect(result.current.storeState).toBeDefined();
       });
+
+      // THEN assert trader was never written (backend already had it)
+      expect(mockSetStoreKey).not.toHaveBeenCalledWith(
+        'trader',
+        expect.anything(),
+      );
     });
 
     it('phase 2: repairs autoRun.enabled via dot-notation when Electron=true but backend=false', async () => {
@@ -432,19 +435,27 @@ describe('StoreProvider', () => {
         autoRun: { enabled: true, isInitialized: true },
       });
 
-      renderHook(() => useContext(StoreContext), {
+      const { result } = renderHook(() => useContext(StoreContext), {
         wrapper: makeMigrationWrapper({
           autoRun: { enabled: true, isInitialized: true },
           pearlStoreAutoRunRepaired: true,
         }),
       });
 
+      // Wait for hydration + migration to complete
       await waitFor(() => {
-        expect(mockSetStoreKey).not.toHaveBeenCalledWith(
-          'autoRun',
-          expect.anything(),
-        );
+        expect(result.current.storeState).toBeDefined();
       });
+
+      // THEN assert autoRun was never written
+      expect(mockSetStoreKey).not.toHaveBeenCalledWith(
+        'autoRun',
+        expect.anything(),
+      );
+      expect(mockSetStoreKey).not.toHaveBeenCalledWith(
+        'autoRun.enabled',
+        expect.anything(),
+      );
     });
 
     it('sets pearlStoreMigrationComplete flag after phase 1', async () => {
@@ -494,9 +505,6 @@ describe('StoreProvider', () => {
       mockSetStoreKey.mockRejectedValue(new Error('write failed'));
 
       const storeSet = jest.fn().mockResolvedValue(undefined);
-      const consoleSpy = jest
-        .spyOn(console, 'error')
-        .mockImplementation(() => {});
 
       const Wrapper = ({ children }: PropsWithChildren) => {
         const electron = {
@@ -520,35 +528,39 @@ describe('StoreProvider', () => {
 
       renderHook(() => useContext(StoreContext), { wrapper: Wrapper });
 
+      // Wait for migration to complete (allSettled doesn't throw)
       await waitFor(() => {
-        expect(consoleSpy).toHaveBeenCalledWith(
-          '[StoreProvider] Migration failed:',
-          expect.any(Error),
+        // autoRunRepaired flag is set (Phase 2 succeeds independently)
+        expect(storeSet).toHaveBeenCalledWith(
+          'pearlStoreAutoRunRepaired',
+          true,
         );
       });
 
-      // Flag should NOT be set — migration will retry on next launch
+      // Migration flag should NOT be set — partial failure retries next launch
       expect(storeSet).not.toHaveBeenCalledWith(
         'pearlStoreMigrationComplete',
         true,
       );
-
-      consoleSpy.mockRestore();
     });
 
     it('skips both phases when flags are already set', async () => {
       mockGetStore.mockResolvedValue({ autoRun: { enabled: false } });
 
-      renderHook(() => useContext(StoreContext), {
+      const { result } = renderHook(() => useContext(StoreContext), {
         wrapper: makeMigrationWrapper({
           pearlStoreMigrationComplete: true,
           pearlStoreAutoRunRepaired: true,
         }),
       });
 
+      // Wait for hydration to complete
       await waitFor(() => {
-        expect(mockSetStoreKey).not.toHaveBeenCalled();
+        expect(result.current.storeState).toBeDefined();
       });
+
+      // THEN assert no backend writes happened
+      expect(mockSetStoreKey).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/tests/context/StoreProvider.test.tsx
+++ b/frontend/tests/context/StoreProvider.test.tsx
@@ -368,7 +368,7 @@ describe('StoreProvider', () => {
       });
     });
 
-    it('phase 2: repairs autoRun.enabled when Electron=true but backend=false', async () => {
+    it('phase 2: repairs autoRun.enabled via dot-notation when Electron=true but backend=false', async () => {
       mockGetStore
         .mockResolvedValueOnce({ autoRun: { enabled: false } })
         .mockResolvedValueOnce({ autoRun: { enabled: true } });
@@ -383,10 +383,48 @@ describe('StoreProvider', () => {
         expect(result.current.storeState?.autoRun?.enabled).toBe(true);
       });
 
-      expect(mockSetStoreKey).toHaveBeenCalledWith('autoRun', {
-        enabled: true,
-        isInitialized: true,
+      // Must use dot-notation, NOT overwrite the entire autoRun object
+      expect(mockSetStoreKey).toHaveBeenCalledWith('autoRun.enabled', true);
+    });
+
+    it('phase 2: preserves backend autoRun fields that Electron lacks', async () => {
+      // Backend has includedAgentInstances that Electron doesn't know about
+      mockGetStore
+        .mockResolvedValueOnce({
+          autoRun: {
+            enabled: false,
+            isInitialized: true,
+            includedAgentInstances: [{ serviceConfigId: 'svc-1', order: 0 }],
+            userExcludedAgentInstances: ['svc-2'],
+          },
+        })
+        .mockResolvedValueOnce({
+          autoRun: {
+            enabled: true,
+            isInitialized: true,
+            includedAgentInstances: [{ serviceConfigId: 'svc-1', order: 0 }],
+            userExcludedAgentInstances: ['svc-2'],
+          },
+        });
+
+      const { result } = renderHook(() => useContext(StoreContext), {
+        wrapper: makeMigrationWrapper({
+          // Electron has old shape without multi-instance fields
+          autoRun: { enabled: true, isInitialized: true },
+        }),
       });
+
+      await waitFor(() => {
+        expect(result.current.storeState?.autoRun?.enabled).toBe(true);
+      });
+
+      // Dot-notation write — backend's includedAgentInstances and
+      // userExcludedAgentInstances are NOT overwritten
+      expect(mockSetStoreKey).toHaveBeenCalledWith('autoRun.enabled', true);
+      expect(mockSetStoreKey).not.toHaveBeenCalledWith(
+        'autoRun',
+        expect.anything(),
+      );
     });
 
     it('phase 2: does NOT touch autoRun when values already match', async () => {
@@ -407,6 +445,95 @@ describe('StoreProvider', () => {
           expect.anything(),
         );
       });
+    });
+
+    it('sets pearlStoreMigrationComplete flag after phase 1', async () => {
+      mockGetStore.mockResolvedValue({});
+
+      const storeSet = jest.fn().mockResolvedValue(undefined);
+      const Wrapper = ({ children }: PropsWithChildren) => {
+        const electron = {
+          store: {
+            get: jest
+              .fn()
+              .mockImplementation((key: string) =>
+                Promise.resolve(
+                  key === 'trader'
+                    ? { isInitialFunded: {} }
+                    : key === 'autoRun'
+                      ? { enabled: false }
+                      : undefined,
+                ),
+              ),
+            set: storeSet,
+          },
+        };
+        return createElement(
+          ElectronApiContext.Provider,
+          { value: electron },
+          createElement(StoreProvider, null, children),
+        );
+      };
+
+      renderHook(() => useContext(StoreContext), { wrapper: Wrapper });
+
+      await waitFor(() => {
+        expect(storeSet).toHaveBeenCalledWith(
+          'pearlStoreMigrationComplete',
+          true,
+        );
+        expect(storeSet).toHaveBeenCalledWith(
+          'pearlStoreAutoRunRepaired',
+          true,
+        );
+      });
+    });
+
+    it('does not set migration flag when setStoreKey fails (re-migrates next launch)', async () => {
+      mockGetStore.mockResolvedValue({});
+      mockSetStoreKey.mockRejectedValue(new Error('write failed'));
+
+      const storeSet = jest.fn().mockResolvedValue(undefined);
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      const Wrapper = ({ children }: PropsWithChildren) => {
+        const electron = {
+          store: {
+            get: jest
+              .fn()
+              .mockImplementation((key: string) =>
+                Promise.resolve(
+                  key === 'trader' ? { isInitialFunded: {} } : undefined,
+                ),
+              ),
+            set: storeSet,
+          },
+        };
+        return createElement(
+          ElectronApiContext.Provider,
+          { value: electron },
+          createElement(StoreProvider, null, children),
+        );
+      };
+
+      renderHook(() => useContext(StoreContext), { wrapper: Wrapper });
+
+      await waitFor(() => {
+        expect(consoleSpy).toHaveBeenCalledWith(
+          '[StoreProvider] Migration failed:',
+          expect.any(Error),
+        );
+      });
+
+      // Flag should NOT be set — migration will retry on next launch
+      expect(storeSet).not.toHaveBeenCalledWith(
+        'pearlStoreMigrationComplete',
+        true,
+      );
+
+      consoleSpy.mockRestore();
     });
 
     it('skips both phases when flags are already set', async () => {

--- a/frontend/tests/context/StoreProvider.test.tsx
+++ b/frontend/tests/context/StoreProvider.test.tsx
@@ -82,21 +82,15 @@ describe('StoreProvider', () => {
     expect(mockGetStore).toHaveBeenCalled();
   });
 
-  it('blocks children until StoreService.getStore() resolves', () => {
+  it('provides undefined storeState before StoreService.getStore() resolves', () => {
     // Never resolves during this test
     mockGetStore.mockReturnValue(new Promise(() => {}));
 
-    let rendered = false;
-    renderHook(
-      () => {
-        rendered = true;
-        return useContext(StoreContext);
-      },
-      { wrapper: makeWrapper() },
-    );
+    const { result } = renderHook(() => useContext(StoreContext), {
+      wrapper: makeWrapper(),
+    });
 
-    // Provider returns null before hydration — children do not render
-    expect(rendered).toBe(false);
+    expect(result.current.storeState).toBeUndefined();
   });
 
   it('catches StoreService.getStore() rejection and falls back to empty store', async () => {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.5.0-rc5",
+  "version": "1.5.0-rc8",
   "engine": {
     "node": "22.18",
     "yarn": ">=1.22.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "olas-operate-app"
-version = "1.5.0-rc5"
+version = "1.5.0-rc8"
 description = ""
 authors = ["David Vilela <dvilelaf@gmail.com>", "Viraj Patel <vptl185@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Proposed changes

<img width="1122" height="608" alt="Screen2 at 8 19 07 PM" src="https://github.com/user-attachments/assets/f8cb361d-171c-43fa-a684-69531db2ddab" />

## Pre-conditions
- Have a working Pearl install with:
  - AutoRun ENABLED with agents configured
  - Multiple agents funded (isInitialFunded: true)
  - A backup wallet configured
  - Some archived agents
  - firstStakingRewardAchieved: true

## Test 1: Upgrade on same machine
1. Note current autoRun status (enabled/disabled), which agents are funded
2. Upgrade to the new version (install over existing)
3. Launch Pearl
4. CHECK: AutoRun toggle matches pre-upgrade state (enabled stays enabled)
5. CHECK: No "Complete Agent Setup" alert on funded agents
6. CHECK: Archived agents still hidden
7. CHECK: Backup wallet visible in settings
8. CHECK: DevTools console shows `pearl_store: Hydrated on attempt 1`
9. CHECK: DevTools console shows `pearl_store: Migrating N keys: ...`
10. CHECK: Console does NOT show "pearl_store: Failed to persist" errors

## Test 2: Restart after migration
1. Close Pearl, relaunch
2. CHECK: `pearl_store: Hydrated on attempt 1 (N keys)` — no migration log
3. CHECK: All settings preserved, autoRun still correct
4. CHECK: No setup wizard

## Test 3: Machine migration (macOS → macOS or Win → Win)
1. On OLD machine: run new Pearl version once (migration runs)
2. Verify `.operate/pearl_store.json` exists and has data
3. Copy entire `.operate/` folder to NEW machine
4. Launch Pearl on new machine
5. CHECK: Main page loads, no setup wizard
6. CHECK: AutoRun state preserved
7. CHECK: All agents show as funded
8. CHECK: Backup wallet visible

## Test 4: Export logs verification
1. Click "Export Logs" or send support logs
2. Open the zip
3. CHECK: `pearl_store.json` file exists with all agent data
4. CHECK: `electron_store.json` file exists (may be small — just native keys)
5. CHECK: `debug_data.json` does NOT contain store data (separate files now)

## Test 5: Corrupted store recovery
1. Manually corrupt `.operate/pearl_store.json` (write "broken" in it)
2. Launch Pearl
3. CHECK: App launches without crash
4. CHECK: Console shows hydration failure + fallback
5. CHECK: Setup wizard shown (expected — data lost)
6. CHECK: If Electron store has data, migration re-populates backend
7. CHECK: AutoRun state matches Electron store value (if available)

## Test 6: Backend briefly unavailable
1. Launch Pearl, wait for hydration
2. Kill backend process, relaunch Pearl quickly
3. CHECK: Console shows retry attempts
4. CHECK: App recovers when backend comes back

## Test 7: AutoRun repair for already-affected users
1. Simulate the bug: pearl_store.json has autoRun.enabled=false,
   Electron store has autoRun.enabled=true
   (edit pearl_store.json manually, set "enabled": false)
2. Delete pearlStoreAutoRunRepaired from Electron store
   (or use a fresh Electron store)
3. Launch Pearl
4. CHECK: Console shows "Repairing autoRun.enabled (was lost during migration)"
5. CHECK: AutoRun toggle shows ENABLED
6. CHECK: includedAgentInstances preserved (not wiped)
7. CHECK: Second launch shows "Migration already complete (flags set)"

## Test 8: AutoRun NOT force-enabled for genuinely disabled users
1. User had autoRun disabled before upgrade (both Electron and backend have enabled=false)
2. Launch with new version
3. CHECK: AutoRun stays DISABLED
4. CHECK: Console does NOT show "Repairing autoRun.enabled"

## Test 9: .operate folder swap on same machine
1. Run Pearl once (migration completes, flags set)
2. Rename .operate to .operate-backup
3. Copy a different .operate folder (from another user/backup)
4. Launch Pearl
5. CHECK: Uses new .operate's pearl_store.json data
6. CHECK: No migration runs (flags already set in Electron store)
7. CHECK: Old machine's Electron data does NOT overwrite new .operate data

## Test 10: Partial migration failure recovery
1. Start Pearl with backend that goes down mid-migration
   (or simulate by making pearl_store.json read-only)
2. CHECK: Console shows "Migration partially failed for keys: ..."
3. CHECK: pearlStoreMigrationComplete flag NOT set
4. Restart Pearl with backend healthy
5. CHECK: Migration re-runs and completes
6. CHECK: All data migrated correctly

## Test 11: Slow backend (funding_requirements blocking store API)
1. Launch Pearl when backend is under load (funding_requirements takes 10-15s)
2. CHECK: Login/dashboard screen renders immediately (not blank)
3. CHECK: AutoRun toggle shows correct state AFTER hydration completes
4. CHECK: No "pearl_store: Failed to persist" errors in console
5. CHECK: No store writes happen before hydration (no POST /api/store before GET resolves)

## Test 12: AutoRun persists across multiple restarts
1. Enable AutoRun, configure included/excluded agents
2. Close app, wait 3 seconds, reopen
3. CHECK: AutoRun still enabled, agent list correct
4. Close app, wait 3 seconds, reopen
5. CHECK: Same — no degradation across repeated restarts
6. Disable AutoRun
7. Close app, reopen
8. CHECK: AutoRun stays disabled

## Test 13: Store writes during hydration gap
1. Launch Pearl
2. Immediately click around (change agent selection, toggle settings) before dashboard fully loads
3. CHECK: No errors in console
4. CHECK: Changes persist after restart (writes queued and applied after hydration)

## Regression checks
- [ ] store.clear() works (new account setup flow)
- [ ] Changing agent selection persists across restart
- [ ] Enabling/disabling autoRun persists across restart
- [ ] Funding a new agent marks it as funded across restart
- [ ] Excluding agents from autoRun persists across restart
- [ ] Re-ordering agents in autoRun persists across restart
- [ ] App renders login/dashboard within 2 seconds even if backend is slow


## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
