### PR TITLE
chore: bump polystrat

### DIFF
--- a/frontend/constants/serviceTemplates/service/trader.ts
+++ b/frontend/constants/serviceTemplates/service/trader.ts
@@ -151,14 +151,14 @@ export const PREDICT_SERVICE_TEMPLATE: ServiceTemplate = {
 } as const;
 
 export const PREDICT_POLYMARKET_SERVICE_TEMPLATE: ServiceTemplate = {
-  hash: 'bafybeibas5fwd7erxnosqbpclt4xenkvoijblzowmcng4br7tukp4tyjse',
-  service_version: 'v0.33.5-rc2',
+  hash: 'bafybeichhdcb76gqtjw3kucrnxvc5cwrj7xyn6dthqphaqgzk4x54b66sm',
+  service_version: 'v0.34.0-rc1',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'trader',
-      version: 'v0.33.5-rc2',
+      version: 'v0.34.0-rc1',
     },
   },
   agentType: AgentMap.Polystrat,


### PR DESCRIPTION
Trader release: [v0.34.0-rc1](https://github.com/valory-xyz/trader/releases/tag/v0.34.0-rc1)

Main update: disable betting on Polymarket markets by tag. Theoretically better market selection leading to better roi