### PR TITLE
chore: bump polystrat to switch to clob v2

### DIFF
--- a/frontend/constants/serviceTemplates/service/trader.ts
+++ b/frontend/constants/serviceTemplates/service/trader.ts
@@ -151,14 +151,14 @@ export const PREDICT_SERVICE_TEMPLATE: ServiceTemplate = {
 } as const;
 
 export const PREDICT_POLYMARKET_SERVICE_TEMPLATE: ServiceTemplate = {
-  hash: 'bafybeichhdcb76gqtjw3kucrnxvc5cwrj7xyn6dthqphaqgzk4x54b66sm',
-  service_version: 'v0.34.0-rc1',
+  hash: 'bafybeiaw7pugbxrcqtsiogmoa2psgw4svngkasc62rcjhiftq3blxo3wiq',
+  service_version: 'v0.35.0-rc1',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'trader',
-      version: 'v0.34.0-rc1',
+      version: 'v0.35.0-rc1',
     },
   },
   agentType: AgentMap.Polystrat,


### PR DESCRIPTION
- Has 2 markets hardcoded
- WILL multibet
- Polystrat traders on this release will swap all USDC.e funds to pUSD
- No metrics will track new bets


Needs env variable `POLYMARKET_DRY_RUN_HARDCODE` set to true to activate the hardcode. Without it, markets without liquidity on clobv2 would be selected resulting in no bets