### PR TITLE
feat(release): auto-bump MW pin on feature branches (VLOP-50)

### DIFF
--- a/.github/workflows/bump-mw-pin.yml
+++ b/.github/workflows/bump-mw-pin.yml
@@ -1,0 +1,71 @@
+name: Bump MW pin on feature branches
+
+on:
+  repository_dispatch:
+    types: [mw-released]
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ github.event.client_payload.branches }}
+    concurrency:
+      group: bump-mw-pin-${{ matrix.branch }}
+      cancel-in-progress: false
+    steps:
+      - name: Check if branch exists on this repo
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api "repos/${{ github.repository }}/branches/${{ matrix.branch }}" --silent 2>/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Branch '${{ matrix.branch }}' does not exist on ${{ github.repository }}; skipping."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout branch
+        if: steps.check.outputs.exists == 'true'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ matrix.branch }}
+          fetch-depth: 1
+
+      - name: Setup Python
+        if: steps.check.outputs.exists == 'true'
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Install Poetry
+        if: steps.check.outputs.exists == 'true'
+        run: python -m pip install --upgrade pip poetry
+
+      - name: Configure git identity
+        if: steps.check.outputs.exists == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump MW pin to released version
+        if: steps.check.outputs.exists == 'true'
+        run: |
+          poetry add "olas-operate-middleware==${{ github.event.client_payload.version }}"
+          git diff pyproject.toml poetry.lock || true
+
+      - name: Commit and push if changed
+        if: steps.check.outputs.exists == 'true'
+        run: |
+          if git diff --quiet pyproject.toml poetry.lock; then
+            echo "No change to pyproject.toml or poetry.lock; nothing to commit."
+            exit 0
+          fi
+          git add pyproject.toml poetry.lock
+          git commit -m "chore: bump olas-operate-middleware to ${{ github.event.client_payload.version }}"
+          git push origin "${{ matrix.branch }}"


### PR DESCRIPTION
## Summary
- New workflow `bump-mw-pin.yml` listens for `repository_dispatch` event_type `mw-released` from `olas-operate-middleware`.
- Matrix over `client_payload.branches` — per branch: existence check, checkout, `poetry add olas-operate-middleware==<version>`, commit + push if `pyproject.toml`/`poetry.lock` changed.
- Per-branch concurrency group; `fail-fast: false` so one branch failing doesn't cancel the rest.

Pairs with the dispatch step in [`olas-operate-middleware#425`](https://github.com/valory-xyz/olas-operate-middleware/pull/425). Tracks VLOP-50.

## Test plan
- [ ] Cannot be tested end-to-end until `GITHUB_APP_ID` + `GITHUB_APP_PRIVATE_KEY` secrets are configured on `olas-operate-middleware` and the coding-agent App is installed on `olas-operate-app` with `contents:write`.
- [ ] First production trigger: cut a real MW release; observe one matrix job per branch in the payload, with skip-or-bump behavior matching whether the branch exists here.