### PR TITLE
chore(ota): improve OTA logging for upstream + post-install diagnosis

### DIFF
--- a/electron/autoUpdater.js
+++ b/electron/autoUpdater.js
@@ -10,6 +10,9 @@ let squirrelReady = false;
 let downloadCancellationToken = null;
 let pendingSquirrelListener = null;
 
+const ota = (message) =>
+  logger.electron(`[OTA] (current=${app.getVersion()}) ${message}`);
+
 const registerAutoUpdaterHandlers = ({
   getMainWindow,
   setAppRealClose,
@@ -21,16 +24,16 @@ const registerAutoUpdaterHandlers = ({
 
   // Native Electron autoUpdater tracks Squirrel completion on macOS
   nativeUpdater.on('update-downloaded', () => {
-    logger.electron('[OTA] Native Squirrel update-downloaded');
+    ota('Native Squirrel update-downloaded');
     squirrelReady = true;
   });
 
   nativeUpdater.on('error', (err) => {
-    logger.electron(`[OTA] Native updater error: ${err.message}`);
+    ota(`Native updater error: ${err.message}`);
   });
 
   autoUpdater.on('update-available', async (info) => {
-    logger.electron(`[OTA] Update available: ${info.version}`);
+    ota(`Update available: ${info.version}`);
     // electron-updater's GitHubProvider has a bug where releaseNotes come from
     // the wrong Atom feed entry when allowPrerelease is true. Fetch directly
     // from the GitHub API to get the correct release notes for this version.
@@ -49,13 +52,13 @@ const registerAutoUpdaterHandlers = ({
         releaseNotes = data.body_html || null;
       }
     } catch (e) {
-      logger.electron(`[OTA] Failed to fetch release notes: ${e.message}`);
+      ota(`Failed to fetch release notes: ${e.message}`);
     }
     send('update-available', { version: info.version, releaseNotes });
   });
 
   autoUpdater.on('update-not-available', () => {
-    logger.electron('[OTA] No update available');
+    ota('No update available');
     send('update-not-available');
   });
 
@@ -68,17 +71,17 @@ const registerAutoUpdaterHandlers = ({
     });
   });
 
-  autoUpdater.on('update-downloaded', () => {
-    logger.electron(
-      `[OTA] electron-updater update-downloaded (squirrelReady=${squirrelReady})`,
+  autoUpdater.on('update-downloaded', (info) => {
+    ota(
+      `electron-updater update-downloaded version=${info?.version ?? 'unknown'} squirrelReady=${squirrelReady}`,
     );
     if (process.platform === 'darwin') {
       // On macOS, wait for Squirrel to finish before notifying renderer
       if (squirrelReady) {
-        logger.electron('[OTA] Squirrel already ready, notifying renderer');
+        ota('Squirrel already ready, notifying renderer');
         send('update-downloaded');
       } else {
-        logger.electron('[OTA] Waiting for Squirrel to finish...');
+        ota('Waiting for Squirrel to finish...');
         // Remove only our previously-registered fallback listener (if any) —
         // must NOT use removeAllListeners, which would also strip the
         // module-scope nativeUpdater.on('update-downloaded', …) tracker above.
@@ -90,7 +93,7 @@ const registerAutoUpdaterHandlers = ({
         }
         pendingSquirrelListener = () => {
           pendingSquirrelListener = null;
-          logger.electron('[OTA] Squirrel finished, notifying renderer');
+          ota('Squirrel finished, notifying renderer');
           send('update-downloaded');
         };
         nativeUpdater.once('update-downloaded', pendingSquirrelListener);
@@ -101,7 +104,7 @@ const registerAutoUpdaterHandlers = ({
   });
 
   autoUpdater.on('error', (err) => {
-    logger.electron(`[OTA] Error: ${err.message}`);
+    ota(`Error: ${err.message}`);
     send('update-error', { message: err.message });
   });
 
@@ -113,47 +116,39 @@ const registerAutoUpdaterHandlers = ({
   ipcMain.removeHandler('update-quit-and-install');
 
   ipcMain.handle('update-check', async () => {
-    logger.electron('[OTA] Checking for updates...');
+    ota('Checking for updates...');
     return autoUpdater.checkForUpdates();
   });
 
   ipcMain.handle('update-download', () => {
-    logger.electron('[OTA] Starting download...');
+    ota('Starting download...');
     downloadCancellationToken = new CancellationToken();
     return autoUpdater.downloadUpdate(downloadCancellationToken);
   });
 
   ipcMain.handle('update-cancel', () => {
-    logger.electron('[OTA] Cancelling download');
+    ota('Cancelling download');
     downloadCancellationToken?.cancel();
     downloadCancellationToken = null;
   });
 
   ipcMain.handle('update-quit-and-install', async () => {
-    logger.electron(
-      `[OTA] quitAndInstall called (squirrelReady=${squirrelReady})`,
-    );
+    ota(`quitAndInstall called squirrelReady=${squirrelReady}`);
     const pid = getOperateDaemonPid();
     if (pid) {
       try {
         await killProcesses(pid);
       } catch (e) {
-        logger.electron(
-          `[OTA] killProcesses error (non-fatal): ${JSON.stringify(e)}`,
-        );
+        ota(`killProcesses error (non-fatal): ${JSON.stringify(e)}`);
       }
     }
     // Allow the app to quit — the before-quit and mainWindow close handlers check this
     setAppRealClose(true);
-    logger.electron(
-      '[OTA] appRealClose set to true, calling autoUpdater.quitAndInstall()',
-    );
+    ota('appRealClose set to true, calling autoUpdater.quitAndInstall()');
     autoUpdater.quitAndInstall();
     // Fallback: if quitAndInstall doesn't exit within the timeout, force exit
     setTimeout(() => {
-      logger.electron(
-        '[OTA] Fallback: quitAndInstall did not exit, forcing app.exit(0)',
-      );
+      ota('Fallback: quitAndInstall did not exit, forcing app.exit(0)');
       app.exit(0);
     }, QUIT_AND_INSTALL_FALLBACK_MS);
   });

--- a/electron/update.js
+++ b/electron/update.js
@@ -17,6 +17,17 @@ autoUpdater.autoInstallOnAppQuit = true;
 // the progress bar to report the diff size first, then jump to the full
 // size when it falls back — confusing and a frequent source of bugs.
 autoUpdater.disableDifferentialDownload = true;
-autoUpdater.logger = logger;
+
+// electron-updater calls logger.info/.warn/.error/.debug during its
+// lifecycle (upstream URL, version compare, staged ZIP path, code-sign
+// verification). The base winston logger emits those at non-'electron'
+// levels, which the electron.log file transport filters out. Re-emit at
+// the 'electron' level so the entries reach electron.log.
+autoUpdater.logger = {
+  info: (message) => logger.electron(`[OTA-internal] ${message}`),
+  warn: (message) => logger.electron(`[OTA-internal][warn] ${message}`),
+  error: (message) => logger.electron(`[OTA-internal][error] ${message}`),
+  debug: (message) => logger.electron(`[OTA-internal][debug] ${message}`),
+};
 
 module.exports = { autoUpdater };


### PR DESCRIPTION
## Summary

Two logger-only changes in the OTA flow.

- **`electron/update.js`** — adapter so `electron-updater`'s internal `info`/`warn`/`error`/`debug` calls reach `electron.log` (previously dropped by the file transport's exact-match level filter). Tagged `[OTA-internal]`.
- **`electron/autoUpdater.js`** — `ota()` helper stamps every `[OTA]` line with `(current=${app.getVersion()})`. Also logs `info.version` from the `update-downloaded` event.

No state, no IPC, no behavioural changes.

## Why

Came out of analysing a user's logs where a 1.5.6 OTA install silently failed. Two gaps:
1. `electron-updater`'s upstream activity (feed URL, version compare, signature/SHA validation) was invisible in `electron.log`.
2. `[OTA]` lines didn't carry the running app version, so spotting "Squirrel didn't swap the bundle" required cross-line inference. With `(current=…)` inline, the silent-install fingerprint is obvious in one line.

## Test plan
- [ ] \`yarn lint\` clean
- [ ] Trigger an OTA check; verify new \`[OTA-internal] …\` and \`[OTA] (current=X.Y.Z) …\` lines in \`electron.log\`
- [ ] No regression in update modal / download UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)