### PR TITLE
chore: remove flashbots dependency from PyInstaller build scripts

### DIFF
--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -71,7 +71,7 @@ jobs:
           poetry run pyinstaller operate/tendermint.py --onefile
           cp dist/tendermint dist/tendermint_bin
 
-          poetry run pyinstaller --collect-data eth_account --collect-all aea --collect-all autonomy --collect-all operate --collect-all aea_ledger_ethereum --collect-all aea_ledger_cosmos --collect-all aea_ledger_ethereum_flashbots --hidden-import aea_ledger_ethereum --hidden-import aea_ledger_cosmos --hidden-import aea_ledger_ethereum_flashbots operate/pearl.py --onedir --name pearl_${{ env.OS_ARCH }}
+          poetry run pyinstaller --collect-data eth_account --collect-all aea --collect-all autonomy --collect-all operate --collect-all aea_ledger_ethereum --collect-all aea_ledger_cosmos --hidden-import aea_ledger_ethereum --hidden-import aea_ledger_cosmos operate/pearl.py --onedir --name pearl_${{ env.OS_ARCH }}
 
       # Package middleware with tar to preserve signatures and extended attributes
       - name: Package middleware with tar

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -70,7 +70,7 @@ jobs:
           poetry run pyinstaller operate/tendermint.py --onefile
           cp dist/tendermint dist/tendermint_bin
 
-          poetry run pyinstaller --collect-data eth_account --collect-all aea --collect-all autonomy --collect-all operate --collect-all aea_ledger_ethereum --collect-all aea_ledger_cosmos --collect-all aea_ledger_ethereum_flashbots --hidden-import aea_ledger_ethereum --hidden-import aea_ledger_cosmos --hidden-import aea_ledger_ethereum_flashbots operate/pearl.py --onedir --name pearl_${{ env.OS_ARCH }}
+          poetry run pyinstaller --collect-data eth_account --collect-all aea --collect-all autonomy --collect-all operate --collect-all aea_ledger_ethereum --collect-all aea_ledger_cosmos --hidden-import aea_ledger_ethereum --hidden-import aea_ledger_cosmos operate/pearl.py --onedir --name pearl_${{ env.OS_ARCH }}
 
       - name: Sign PyInstaller binaries
         env:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endef
 
 ./dist/pearl_win: ./operate/ ./dist/tendermint_win
 	pwd
-	poetry install --no-root && poetry run pyinstaller --collect-data eth_account --collect-all aea --collect-all coincurve --collect-all autonomy --collect-all operate --collect-all aea_ledger_ethereum --collect-all aea_ledger_cosmos --collect-all aea_ledger_ethereum_flashbots --hidden-import aea_ledger_ethereum --hidden-import aea_ledger_cosmos --hidden-import aea_ledger_ethereum_flashbots operate/pearl.py --onedir --name pearl_win
+	poetry install --no-root && poetry run pyinstaller --collect-data eth_account --collect-all aea --collect-all coincurve --collect-all autonomy --collect-all operate --collect-all aea_ledger_ethereum --collect-all aea_ledger_cosmos --hidden-import aea_ledger_ethereum --hidden-import aea_ledger_cosmos operate/pearl.py --onedir --name pearl_win
 
 
 ./electron/bins/tendermint.exe: ./electron/bins/

--- a/build_pearl.sh
+++ b/build_pearl.sh
@@ -38,10 +38,8 @@ poetry run pyinstaller \
     --collect-all operate \
     --collect-all aea_ledger_ethereum \
     --collect-all aea_ledger_cosmos \
-    --collect-all aea_ledger_ethereum_flashbots \
     --hidden-import aea_ledger_ethereum \
     --hidden-import aea_ledger_cosmos \
-    --hidden-import aea_ledger_ethereum_flashbots \
     operate/pearl.py \
     --add-binary ${BIN_DIR}/aea_bin_x64:. \
     --add-binary ${BIN_DIR}/aea_bin_arm64:. \

--- a/operate/pearl.py
+++ b/operate/pearl.py
@@ -38,7 +38,6 @@ from aea.crypto.registries.base import *
 from aea.mail.base_pb2 import DESCRIPTOR
 from aea_ledger_cosmos.cosmos import *  # noqa
 from aea_ledger_ethereum.ethereum import *
-from aea_ledger_ethereum_flashbots.ethereum_flashbots import *  # noqa
 from google.protobuf.descriptor_pb2 import FileDescriptorProto
 from multiaddr.codecs.idna import to_bytes as _
 from multiaddr.codecs.uint16be import to_bytes as _


### PR DESCRIPTION
Fixes this error
```
Traceback (most recent call last):
  File "pearl.py", line 41, in <module>
2026-04-29T20:01:10.980Z cli: ModuleNotFoundError: No module named 'aea_ledger_ethereum_flashbots'
[PYI-304616:ERROR] Failed to execute script 'pearl' due to unhandled exception!
```

This pull request removes the dependency on `aea_ledger_ethereum_flashbots` from the build and packaging process for the `pearl` binary across all supported platforms. This change simplifies the build configuration and the `pearl` application by eliminating unnecessary imports and packaging steps related to Flashbots functionality.

Dependency and packaging cleanup:

* Removed `aea_ledger_ethereum_flashbots` from the list of collected packages and hidden imports in the PyInstaller commands for Linux, macOS, and Windows build workflows (`.github/workflows/release_linux.yml`, `.github/workflows/release_mac.yml`, `Makefile`, `build_pearl.sh`). [[1]](diffhunk://#diff-1a51bf580fab36eb26fd92c94ed93e412d018dc0961efb7d1f9093cefb8e21f8L74-R74) [[2]](diffhunk://#diff-789a4b227ee8f46a834ceb8f355cbbd9eba1092f4ef632a2cee01c4a3a561ecbL73-R73) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L23-R23) [[4]](diffhunk://#diff-a5faf8c1e186441229bb01f30d764de92337579e5ba08ddfd2600b41bfd554c5L41-L44)
* Removed the import of `aea_ledger_ethereum_flashbots.ethereum_flashbots` from `operate/pearl.py`.