### PR TITLE
ci(release): guard against clobbering published releases on override

### DIFF
--- a/.github/workflows/check-release-not-published.yml
+++ b/.github/workflows/check-release-not-published.yml
@@ -1,0 +1,57 @@
+# Reusable: fails if `release_tag` already exists on GitHub as a published
+# (non-draft) release. Used by flows that delete-and-recreate a tag
+# (production-release, create-feature-release with action=override) — in
+# those flows, reattaching the tag would silently overwrite the existing
+# release contents and could strip its "Latest" marker.
+
+name: Check release not published
+
+on:
+  workflow_call:
+    inputs:
+      release_tag:
+        description: "GitHub Release tag to check (no -signed suffix; e.g. v1.5.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if release is already published
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          # Capture stdout and stderr separately so we can distinguish
+          # "release not found" from transient gh errors (auth, network, rate limit).
+          set +e
+          STDOUT=$(gh release view "$RELEASE_TAG" \
+            --repo "${{ github.repository }}" \
+            --json isDraft \
+            --jq '.isDraft' 2> /tmp/gh_stderr)
+          RC=$?
+          STDERR=$(cat /tmp/gh_stderr)
+          set -e
+
+          if [ $RC -eq 0 ]; then
+            if [ "$STDOUT" = "false" ]; then
+              echo "::error::Release $RELEASE_TAG is already published. Refusing to overwrite — that would replace the existing GitHub Release and could strip its Latest marker."
+              echo "::error::Bump the version before re-running."
+              exit 1
+            fi
+            echo "Release $RELEASE_TAG exists as a draft — safe to overwrite."
+            exit 0
+          fi
+
+          if echo "$STDERR" | grep -qiE 'release not found|not found'; then
+            echo "No existing release for $RELEASE_TAG — safe to create."
+            exit 0
+          fi
+
+          echo "::error::gh release view failed for $RELEASE_TAG (exit $RC):"
+          echo "$STDERR"
+          exit 1

--- a/.github/workflows/check-release-not-published.yml
+++ b/.github/workflows/check-release-not-published.yml
@@ -47,7 +47,10 @@ jobs:
             exit 0
           fi
 
-          if echo "$STDERR" | grep -qiE 'release not found|not found'; then
+          # Match only the specific "release not found" wording from `gh`
+          # so unrelated 404-style errors (auth, repo not found, rate limit)
+          # don't get treated as "safe to create".
+          if echo "$STDERR" | grep -qi 'release not found'; then
             echo "No existing release for $RELEASE_TAG — safe to create."
             exit 0
           fi

--- a/.github/workflows/create-feature-release.yml
+++ b/.github/workflows/create-feature-release.yml
@@ -19,7 +19,40 @@ on:
         default: 'new'
 
 jobs:
+  # Override deletes-and-recreates the tag at v$(package.json version), which
+  # reattaches it to a new commit and lets electron-builder rewrite the
+  # corresponding GitHub Release. If that release was already published it
+  # would be silently overwritten — including its Latest marker. Compute the
+  # release tag from package.json on the target branch so the guard can
+  # short-circuit before any destructive work.
+  compute-release-tag:
+    if: inputs.action == 'override'
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.compute-tag.outputs.release_tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Compute release tag from package.json
+        id: compute-tag
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          echo "release_tag=v${PACKAGE_VERSION}" | tee -a $GITHUB_OUTPUT
+
+  check-release-not-published:
+    if: inputs.action == 'override'
+    needs: compute-release-tag
+    uses: ./.github/workflows/check-release-not-published.yml
+    with:
+      release_tag: ${{ needs.compute-release-tag.outputs.release_tag }}
+    secrets: inherit
+
   calculate-version:
+    needs: check-release-not-published
+    # Run on success of the guard, or when the guard is skipped (action=new).
+    if: ${{ always() && (needs.check-release-not-published.result == 'success' || needs.check-release-not-published.result == 'skipped') }}
     uses: ./.github/workflows/calculate-and-update-version.yml
     with:
       branch: ${{ inputs.branch }}

--- a/.github/workflows/create-feature-release.yml
+++ b/.github/workflows/create-feature-release.yml
@@ -50,9 +50,20 @@ jobs:
     secrets: inherit
 
   calculate-version:
-    needs: check-release-not-published
-    # Run on success of the guard, or when the guard is skipped (action=new).
-    if: ${{ always() && (needs.check-release-not-published.result == 'success' || needs.check-release-not-published.result == 'skipped') }}
+    needs: [compute-release-tag, check-release-not-published]
+    # On `action=override`: both the tag computation and the guard must
+    # succeed — if either fails, the destructive override path must not
+    # proceed. On `action=new`: both jobs are skipped (their own `if`
+    # gates them on override), so allow that combination through.
+    if: >-
+      ${{ always() && (
+        (inputs.action == 'override'
+          && needs.compute-release-tag.result == 'success'
+          && needs.check-release-not-published.result == 'success')
+        || (inputs.action == 'new'
+          && needs.compute-release-tag.result == 'skipped'
+          && needs.check-release-not-published.result == 'skipped')
+      ) }}
     uses: ./.github/workflows/calculate-and-update-version.yml
     with:
       branch: ${{ inputs.branch }}

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -1,7 +1,10 @@
 # push to release/* branch
 #        │
 #        ▼
-# check-release-not-published  (guard: fail if vX.Y.Z-signed release is already published)
+# compute-release-tag  (extract release_tag=vX.Y.Z from branch name)
+#        │
+#        ▼
+# check-release-not-published  (guard: fail if vX.Y.Z release is already published)
 #        │
 #        ▼
 # calculate-version  (create/overwrite vX.Y.Z-signed tag on branch HEAD)
@@ -31,12 +34,12 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  check-release-not-published:
+  compute-release-tag:
     # Avoid looping on commits created by the action itself.
     if: ${{ github.actor != 'github-actions[bot]' && !contains(github.event.head_commit.message, '[skip release]') }}
     runs-on: ubuntu-latest
     outputs:
-      tag: ${{ steps.compute-tag.outputs.tag }}
+      release_tag: ${{ steps.compute-tag.outputs.release_tag }}
     steps:
       - name: Compute expected production tag from branch
         id: compute-tag
@@ -45,55 +48,19 @@ jobs:
           if [[ "$BRANCH" =~ (release/)?v?([0-9]+\.[0-9]+\.[0-9]+) ]]; then
             BASE_VERSION="${BASH_REMATCH[2]}"
             # Git tag is vX.Y.Z-signed (for audit); electron-builder publishes
-            # the GitHub Release at the unsuffixed vX.Y.Z. Expose both.
-            echo "tag=v${BASE_VERSION}-signed" | tee -a $GITHUB_OUTPUT
+            # the GitHub Release at the unsuffixed vX.Y.Z.
             echo "release_tag=v${BASE_VERSION}" | tee -a $GITHUB_OUTPUT
           else
             echo "::error::Failed to extract version from branch: $BRANCH"
             exit 1
           fi
 
-      - name: Fail if release is already published (guard against accidental overwrites)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          RELEASE_TAG="${{ steps.compute-tag.outputs.release_tag }}"
-
-          # Capture stdout and stderr separately so we can distinguish
-          # "release not found" from transient gh errors (auth, network, rate limit).
-          set +e
-          STDOUT=$(gh release view "$RELEASE_TAG" \
-            --repo "${{ github.repository }}" \
-            --json isDraft \
-            --jq '.isDraft' 2> /tmp/gh_stderr)
-          RC=$?
-          STDERR=$(cat /tmp/gh_stderr)
-          set -e
-
-          if [ $RC -eq 0 ]; then
-            if [ "$STDOUT" = "false" ]; then
-              echo "::error::Release $RELEASE_TAG is already published. Refusing to overwrite."
-              echo "::error::Bump the version on the release branch (e.g. release/v1.5.4) before pushing again."
-              exit 1
-            fi
-            echo "Release $RELEASE_TAG exists as a draft — safe to overwrite."
-            exit 0
-          fi
-
-          # Non-zero: treat "release not found" as a safe proceed, everything else as hard fail.
-          if echo "$STDERR" | grep -qiE 'release not found|not found'; then
-            echo "No existing release for $RELEASE_TAG — safe to create."
-            exit 0
-          fi
-
-          echo "::error::gh release view failed for $RELEASE_TAG (exit $RC):"
-          echo "$STDERR"
-          exit 1
-
-      - name: Log tag summary
-        run: |
-          echo "Git tag: ${{ steps.compute-tag.outputs.tag }}"
-          echo "GitHub Release tag: ${{ steps.compute-tag.outputs.release_tag }}"
+  check-release-not-published:
+    needs: compute-release-tag
+    uses: ./.github/workflows/check-release-not-published.yml
+    with:
+      release_tag: ${{ needs.compute-release-tag.outputs.release_tag }}
+    secrets: inherit
 
   calculate-version:
     needs: check-release-not-published


### PR DESCRIPTION
## Summary
- Extract the existing production-release "is the release already published?" guard into a reusable workflow `check-release-not-published.yml`.
- Wire it into `create-feature-release.yml`'s `override` path so the delete-and-recreate-tag flow can no longer silently overwrite an already published GitHub Release (and strip its Latest marker).
- Refactor `production-release.yml` to call the same reusable workflow, splitting the old monolithic job into a small `compute-release-tag` job + the shared guard.

Linear: [VLOP-60](https://linear.app/valory-xyz/issue/VLOP-60)

## Test plan
- [ ] Trigger `Create Feature Release` with `action=new` against a branch — `compute-release-tag` and `check-release-not-published` should be skipped, `calculate-version` should still run (verifies the `if: always() && (success || skipped)` gate).
- [ ] Trigger `Create Feature Release` with `action=override` against a branch whose `package.json` version corresponds to an already-published GitHub Release — workflow should fail at `check-release-not-published` with the "Refusing to overwrite" error, no tag changes should occur.
- [ ] Trigger `Create Feature Release` with `action=override` against a branch whose `package.json` version corresponds to a draft (or non-existent) release — guard should pass, normal flow continues.
- [ ] Push to a `release/*` branch and confirm `production-release.yml` still gates correctly via the new `compute-release-tag` → reusable guard chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)