### PR TITLE
release/v1.6.4: block new Polystrat agents during deposit wallet migration

### DIFF
--- a/frontend/components/SetupPage/AgentOnboarding/AgentOnboarding.tsx
+++ b/frontend/components/SetupPage/AgentOnboarding/AgentOnboarding.tsx
@@ -223,6 +223,9 @@ export const AgentOnboarding = () => {
     if (currentAgentConfig.isUnderConstruction) {
       return false;
     }
+    if (currentAgentConfig.isAddingNewBlocked) {
+      return false;
+    }
     return true;
   }, [selectedAgent, isAgentGeoRestricted]);
 

--- a/frontend/components/SetupPage/AgentOnboarding/FundingRequirementStep.tsx
+++ b/frontend/components/SetupPage/AgentOnboarding/FundingRequirementStep.tsx
@@ -14,6 +14,7 @@ import {
   AgentMap,
   AgentType,
   COLOR,
+  POLYMARKET_DEPOSIT_WALLET_MIGRATION_URL,
   UNICODE_SYMBOLS,
   X_DEVELOPER_CONSOLE_URL,
 } from '@/constants';
@@ -35,6 +36,32 @@ const UnderConstructionAlert = () => (
           The agent is unavailable due to technical issues for an unspecified
           time.
         </Text>
+      </Flex>
+    }
+  />
+);
+
+const DepositWalletMigrationAlert = () => (
+  <Alert
+    type="warning"
+    fullWidth={false}
+    showIcon
+    className="rounded-12"
+    message={
+      <Flex gap={8} vertical>
+        <Text className="text-sm">
+          Due to the Deposit Wallet Migration on Polymarket, creation of new
+          accounts is temporarily unavailable.
+        </Text>
+        <Link
+          href={POLYMARKET_DEPOSIT_WALLET_MIGRATION_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary text-sm"
+        >
+          See more here
+          <span className="text-xxs ml-4">{UNICODE_SYMBOLS.EXTERNAL_LINK}</span>
+        </Link>
       </Flex>
     }
   />
@@ -206,8 +233,15 @@ export const FundingRequirementStep = ({
     middlewareHomeChainId,
     category,
     isUnderConstruction,
+    isAddingNewBlocked,
   } = AGENT_CONFIG[agentType];
   const { name, displayName } = asEvmChainDetails(middlewareHomeChainId);
+
+  const blockingAlert = isUnderConstruction ? (
+    <UnderConstructionAlert />
+  ) : isAddingNewBlocked ? (
+    <DepositWalletMigrationAlert />
+  ) : null;
 
   return (
     <IntroductionAnimatedContainer>
@@ -218,10 +252,8 @@ export const FundingRequirementStep = ({
           category={category}
           desc={desc}
         />
-        {isUnderConstruction ? (
-          <div style={{ marginBottom: 300 }}>
-            <UnderConstructionAlert />
-          </div>
+        {blockingAlert ? (
+          <div style={{ marginBottom: 300 }}>{blockingAlert}</div>
         ) : (
           <>
             <OperatingChain chainName={name} chainDisplayName={displayName} />

--- a/frontend/components/SetupPage/AgentOnboarding/SelectAgent.tsx
+++ b/frontend/components/SetupPage/AgentOnboarding/SelectAgent.tsx
@@ -72,17 +72,18 @@ const SelectYourAgentList = ({
   const { getInstancesOfAgentType } = useServices();
 
   const agents = useMemo(() => {
+    const isBlocked = (config: AgentConfig) =>
+      !!config.isUnderConstruction || !!config.isAddingNewBlocked;
     return (
       [...ACTIVE_AGENTS]
-        // Sorted with under-construction at the end
+        // Sorted with under-construction / adding-blocked agents at the end
         .sort(
           (
             [, agentA]: [string, AgentConfig],
             [, agentB]: [string, AgentConfig],
           ) => {
-            if (agentA.isUnderConstruction === agentB.isUnderConstruction)
-              return 0;
-            return agentA.isUnderConstruction ? 1 : -1;
+            if (isBlocked(agentA) === isBlocked(agentB)) return 0;
+            return isBlocked(agentA) ? 1 : -1;
           },
         )
     );
@@ -110,7 +111,8 @@ const SelectYourAgentList = ({
             />
             <Text style={{ flex: 1 }}>{agentConfig.displayName}</Text>
             <InstanceCount count={instanceCount} />
-            {agentConfig.isUnderConstruction && <UnderConstructionIcon />}
+            {(agentConfig.isUnderConstruction ||
+              agentConfig.isAddingNewBlocked) && <UnderConstructionIcon />}
           </AgentSelectionContainer>
         );
       })}

--- a/frontend/config/agents.ts
+++ b/frontend/config/agents.ts
@@ -103,6 +103,7 @@ export const AGENT_CONFIG: {
   },
   [AgentMap.Polystrat]: {
     isAgentEnabled: true,
+    isAddingNewBlocked: true,
     requiresSetup: true,
     isX402Enabled: X402_ENABLED_FLAGS[AgentMap.Polystrat],
     name: 'Polystrat',

--- a/frontend/constants/urls.ts
+++ b/frontend/constants/urls.ts
@@ -105,6 +105,8 @@ export const SUPPORT_API_URL = `${PEARL_API_URL}/api/zendesk`;
 export const GEO_ELIGIBILITY_API_URL = `${PEARL_API_URL}/api/geo/agent-eligibility`;
 export const GEO_ELIGIBILITY_DOCS_URL =
   'https://docs.polymarket.com/polymarket-learn/FAQ/geoblocking#close-only-countries';
+export const POLYMARKET_DEPOSIT_WALLET_MIGRATION_URL: Url =
+  'https://docs.polymarket.com/trading/deposit-wallet-migration';
 
 // Predict website
 export const PREDICT_WEBSITE_URL = 'https://predict.olas.network';

--- a/frontend/types/Agent.ts
+++ b/frontend/types/Agent.ts
@@ -50,6 +50,11 @@ export type AgentConfig = {
   description: string;
   /** Adds under construction tab above card */
   isUnderConstruction?: boolean;
+  /**
+   * Blocks creation of new instances while keeping existing instances fully
+   * functional (sidebar, staking, auto-run continue working).
+   */
+  isAddingNewBlocked?: boolean;
   /** Whether the agent is enabled and can be shown in the UI */
   isAgentEnabled: boolean;
   /** If agent is enabled but not yet available to use */

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.6.3",
+  "version": "1.6.4",
   "engine": {
     "node": "22.18",
     "yarn": ">=1.22.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "olas-operate-app"
-version = "1.6.3"
+version = "1.6.4"
 description = ""
 authors = ["David Vilela <dvilelaf@gmail.com>", "Viraj Patel <vptl185@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Adds `isAddingNewBlocked` on `AgentConfig` and sets it on Polystrat
- Hides the **Select Agent** button and shows a *Deposit Wallet Migration* warning (linking to https://docs.polymarket.com/trading/deposit-wallet-migration) when a user picks Polystrat in the new-agent flow
- Treats the flag like `isUnderConstruction` in the agent list (yellow construction icon, sorted to bottom) — but **only** in the onboarding flow; sidebar / staking / auto-run / notifications are untouched, so existing Polystrat instances keep running

<img width="1792" height="1028" alt="image" src="https://github.com/user-attachments/assets/d74d6e25-51b9-490f-8e0f-8bbb254c8887" />


## Why
The Polymarket deposit-wallet migration breaks the funding flow for new Polystrat instances. Existing instances are unaffected, so `isUnderConstruction` is too broad (it would disable auto-run, staking UI, and notifications for current users).

## Test plan
- [ ] Open the new-agent flow → Polystrat shows the construction icon and is sorted to the bottom
- [ ] Select Polystrat → right panel shows the *Deposit Wallet Migration* alert with a purple link to the Polymarket docs; **Select Agent** button is hidden
- [ ] An existing Polystrat instance continues to run normally (sidebar, staking, auto-run unaffected)
- [ ] Other agents (Trader, Modius, Optimus, AgentsFun, Pett.ai) still onboard normally
- [ ] Production release workflow produces `v1.6.4-signed` artefacts on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)