### PR TITLE
ci(release): inline release-not-published guard so downstream jobs run

### DIFF
--- a/.github/workflows/create-feature-release.yml
+++ b/.github/workflows/create-feature-release.yml
@@ -22,48 +22,61 @@ jobs:
   # Override deletes-and-recreates the tag at v$(package.json version), which
   # reattaches it to a new commit and lets electron-builder rewrite the
   # corresponding GitHub Release. If that release was already published it
-  # would be silently overwritten — including its Latest marker. Compute the
-  # release tag from package.json on the target branch so the guard can
-  # short-circuit before any destructive work.
-  compute-release-tag:
-    if: inputs.action == 'override'
+  # would be silently overwritten — including its Latest marker. The guard
+  # always runs so downstream jobs don't need `always()` (which propagates
+  # "skipped ancestor" status and silently skips dependents); the actual
+  # check is gated on action=override at the step level.
+  guard-release-not-published:
     runs-on: ubuntu-latest
-    outputs:
-      release_tag: ${{ steps.compute-tag.outputs.release_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - if: inputs.action == 'override'
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
 
-      - name: Compute release tag from package.json
-        id: compute-tag
+      - if: inputs.action == 'override'
+        name: Fail if release tag is already published
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          echo "release_tag=v${PACKAGE_VERSION}" | tee -a $GITHUB_OUTPUT
+          RELEASE_TAG="v${PACKAGE_VERSION}"
 
-  check-release-not-published:
-    if: inputs.action == 'override'
-    needs: compute-release-tag
-    uses: ./.github/workflows/check-release-not-published.yml
-    with:
-      release_tag: ${{ needs.compute-release-tag.outputs.release_tag }}
-    secrets: inherit
+          # Capture stdout and stderr separately so we can distinguish
+          # "release not found" from transient gh errors (auth, network, rate limit).
+          set +e
+          STDOUT=$(gh release view "$RELEASE_TAG" \
+            --repo "${{ github.repository }}" \
+            --json isDraft \
+            --jq '.isDraft' 2> /tmp/gh_stderr)
+          RC=$?
+          STDERR=$(cat /tmp/gh_stderr)
+          set -e
+
+          if [ $RC -eq 0 ]; then
+            if [ "$STDOUT" = "false" ]; then
+              echo "::error::Release $RELEASE_TAG is already published. Refusing to overwrite — that would replace the existing GitHub Release and could strip its Latest marker."
+              echo "::error::Bump the version before re-running."
+              exit 1
+            fi
+            echo "Release $RELEASE_TAG exists as a draft — safe to overwrite."
+            exit 0
+          fi
+
+          # Match only the specific "release not found" wording from `gh`
+          # so unrelated 404-style errors (auth, repo not found, rate limit)
+          # don't get treated as "safe to create".
+          if echo "$STDERR" | grep -qi 'release not found'; then
+            echo "No existing release for $RELEASE_TAG — safe to create."
+            exit 0
+          fi
+
+          echo "::error::gh release view failed for $RELEASE_TAG (exit $RC):"
+          echo "$STDERR"
+          exit 1
 
   calculate-version:
-    needs: [compute-release-tag, check-release-not-published]
-    # On `action=override`: both the tag computation and the guard must
-    # succeed — if either fails, the destructive override path must not
-    # proceed. On `action=new`: both jobs are skipped (their own `if`
-    # gates them on override), so allow that combination through.
-    if: >-
-      ${{ always() && (
-        (inputs.action == 'override'
-          && needs.compute-release-tag.result == 'success'
-          && needs.check-release-not-published.result == 'success')
-        || (inputs.action == 'new'
-          && needs.compute-release-tag.result == 'skipped'
-          && needs.check-release-not-published.result == 'skipped')
-      ) }}
+    needs: guard-release-not-published
     uses: ./.github/workflows/calculate-and-update-version.yml
     with:
       branch: ${{ inputs.branch }}


### PR DESCRIPTION
## Summary
PR #1906 introduced a structure where \`compute-release-tag\` and \`check-release-not-published\` are gated on \`inputs.action == 'override'\`. On \`action=new\` both jobs skip, forcing \`calculate-version\` to use \`if: always() && ...\` to run anyway. GitHub Actions then propagates that "skipped ancestor" status through the chain — and through explicit \`needs.<job>.result == 'success'\` checks — so every downstream release job (\`run-release\` / \`-win\` / \`-linux\` / \`merge-latest-mac-yml\` / \`summary\`) was silently skipped on every recent feature release run.

This was caught on \`feat/update-polystrat-hash-5-5\` ([run 25379168397](https://github.com/valory-xyz/olas-operate-app/actions/runs/25379168397)) — \`calculate-version\` succeeded but every downstream job had \`conclusion: skipped\` with empty \`steps\`.

## Fix (cherry-picked from \`feat/update-polystrat-hash-5-5\` 04cef7147)
- Replaces the two-job guard with a single \`guard-release-not-published\` job that **always runs** but only does the actual \`gh release view\` check at the step level when \`action == 'override'\`.
- Removes \`if: always()\` from \`calculate-version\`. With no skipped ancestors anywhere in the chain, downstream jobs use the default \`success()\` semantics correctly.
- The reusable \`check-release-not-published.yml\` workflow is unchanged and still in use by \`production-release.yml\` (which doesn't hit this issue because its guards never skip).

## Test plan
- [ ] Trigger Create Feature Release with \`action=new\` from a branch — verify \`run-release\`, \`run-release-win\`, \`run-release-linux\`, \`merge-latest-mac-yml\`, \`summary\` all run (not skipped).
- [ ] Trigger with \`action=override\` against a branch whose package.json points at an existing **published** release — verify \`guard-release-not-published\` fails with the "already published" error.
- [ ] Trigger with \`action=override\` against a branch whose package.json points at a tag with no release — verify guard exits "safe to create" and the rest of the pipeline runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)