### PR TITLE
chore: update agents fun hash and version

### DIFF
--- a/frontend/constants/serviceTemplates/serviceTemplates.ts
+++ b/frontend/constants/serviceTemplates/serviceTemplates.ts
@@ -22,17 +22,17 @@ const AGENTS_FUN_COMMON_TEMPLATE: Pick<
   | 'service_version'
   | 'agent_release'
 > = {
-  hash: 'bafybeicsj42w56hfdbrejtl5byevvtn6druoqubcx3b2e6pevbbdj3zb2q',
+  hash: 'bafybeier6rko4spomv4gdzhplo65ykdcbsxtdomuoijp4okgkirmtxo66y',
   image:
     'https://gateway.autonolas.tech/ipfs/QmQYDGMg8m91QQkTWSSmANs5tZwKrmvUCawXZfXVVWQPcu',
   description: `${KPI_DESC_PREFIX} Agents.Fun @twitter_handle`, // NOTE: @twitter_handle to be replaced with twitter username
-  service_version: 'v2.5.0',
+  service_version: 'v2.6.0',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'meme-ooorr',
-      version: 'v2.5.0',
+      version: 'v2.6.0',
     },
   },
   env_variables: {


### PR DESCRIPTION
Update agents-fun to [v2.6.0](https://github.com/valory-xyz/meme-ooorr/releases/tag/v2.6.0)