### PR TITLE
chore: update babydegen hash and version

### DIFF
--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -18,14 +18,14 @@ const BABYDEGEN_COMMON_TEMPLATE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeidicz6bw37hnob5cl2nkrxnkxapyml77njrtgg2zs6rw6wxbqzuuu',
-  service_version: 'v0.7.5',
+  hash: 'bafybeie572dnien7dwihlwvhvbjosrpqerj7bvo7nrarjbuvxmn5kdh3ha',
+  service_version: 'v0.8.0',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.7.5',
+      version: 'v0.8.0',
     },
   },
 };


### PR DESCRIPTION
Update optimus to [v0.8.0](https://github.com/valory-xyz/optimus/releases/tag/v0.8.0)