### PR TITLE
fix(auth): add missing zxcvbn runtime dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,8 @@
     "semver": "^7.6.3",
     "styled-components": "^6.1.8",
     "usehooks-ts": "^2.14.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.2",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9326,3 +9326,8 @@ zod@^3.23.8:
   version "3.25.76"
   resolved "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz"
   integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==
+
+zxcvbn@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.npmjs.org/zxcvbn/-/zxcvbn-4.4.2.tgz#28ec17cf09743edcab056ddd8b1b06262cc73c30"
+  integrity sha512-Bq0B+ixT/DMyG8kgX2xWcI5jUvCwqrMxSFam7m0lAf78nf04hv6lNCsyLYdyYTrCVMqNDY/206K7eExYCeSyUQ==


### PR DESCRIPTION
## Summary
- Cherry-picks the zxcvbn dep fix onto `release/v1.6.12` to unblock release PR #1946.
- `PasswordForm.tsx` imports `zxcvbn`, but only `@types/zxcvbn` was declared in devDependencies. CI's Frontend Tests job fails with `Cannot find module 'zxcvbn'` across 29 suites.
- Companion fix landing on `staging` separately via PR #1948.

## Test plan
- [x] Local: PasswordForm test suite 26/26 passing
- [ ] CI Frontend Tests green on this PR
- [ ] After merge → re-run PR #1946 (release/v1.6.12 → main); Frontend Tests passes; merge release

🤖 Generated with [Claude Code](https://claude.com/claude-code)