### PR TITLE
fix(tests): repair frontend test suite for unified CI

### DIFF
--- a/frontend/jest.config.ts
+++ b/frontend/jest.config.ts
@@ -14,6 +14,12 @@ const config: Config = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   roots: ['<rootDir>/tests'],
   testMatch: ['<rootDir>/tests/**/*.test.{ts,tsx}'],
+  // Redirect antd's ESM build (antd/es/*) to its CommonJS build (antd/lib/*)
+  // so Jest can require() them. next/jest's default transformIgnorePatterns
+  // excludes node_modules, so antd/es files would otherwise hit Jest as raw ESM.
+  moduleNameMapper: {
+    '^antd/es/(.*)$': 'antd/lib/$1',
+  },
   collectCoverageFrom: [
     '**/*.{ts,tsx}',
     '!**/*.d.ts',

--- a/frontend/tests/components/AccountRecovery/utils.test.ts
+++ b/frontend/tests/components/AccountRecovery/utils.test.ts
@@ -25,7 +25,7 @@ jest.mock(
   () => require('../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 
 describe('getBackupWalletStatus', () => {
   it('returns hasBackupWalletsAcrossEveryChain=true when all chains have backup owners', () => {

--- a/frontend/tests/components/AchievementModal/hooks/useCurrentAchievement.test.ts
+++ b/frontend/tests/components/AchievementModal/hooks/useCurrentAchievement.test.ts
@@ -7,7 +7,7 @@ import { ONE_MINUTE_IN_MS } from '../../../../utils';
 import { makePolystratPayoutAchievement } from '../../../helpers/factories';
 
 jest.mock('ethers-multicall', () => ({ Contract: jest.fn() }));
-jest.mock('../../../../constants/providers', () => ({}));
+jest.mock('../../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../../config/providers', () => ({ providers: [] }));
 
 jest.mock(

--- a/frontend/tests/components/AgentWallet/AgentWalletProvider.test.tsx
+++ b/frontend/tests/components/AgentWallet/AgentWalletProvider.test.tsx
@@ -21,7 +21,7 @@ jest.mock(
   () => require('../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 
 jest.mock('../../../hooks', () => ({
   useServices: jest.fn(),

--- a/frontend/tests/components/AgentWallet/Withdraw/useWithdrawFunds.test.ts
+++ b/frontend/tests/components/AgentWallet/Withdraw/useWithdrawFunds.test.ts
@@ -16,7 +16,7 @@ jest.mock(
   () => require('../../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../../constants/providers', () => ({}));
+jest.mock('../../../../constants/providers', () => ({ PROVIDERS: {} }));
 
 jest.mock('../../../../hooks', () => ({
   useServices: jest.fn(),

--- a/frontend/tests/components/Bridge/Bridge.test.tsx
+++ b/frontend/tests/components/Bridge/Bridge.test.tsx
@@ -14,7 +14,7 @@ jest.mock(
   () => require('../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../config/providers', () => ({ providers: [] }));
 
 const mockGoto = jest.fn();

--- a/frontend/tests/components/Bridge/BridgeInProgress/BridgeInProgress.test.tsx
+++ b/frontend/tests/components/Bridge/BridgeInProgress/BridgeInProgress.test.tsx
@@ -16,7 +16,7 @@ jest.mock(
   () => require('../../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../../constants/providers', () => ({}));
+jest.mock('../../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../../config/providers', () => ({ providers: [] }));
 
 // Mock antd

--- a/frontend/tests/components/Bridge/BridgeInProgress/BridgingSteps.test.tsx
+++ b/frontend/tests/components/Bridge/BridgeInProgress/BridgingSteps.test.tsx
@@ -14,7 +14,7 @@ jest.mock(
   () => require('../../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../../constants/providers', () => ({}));
+jest.mock('../../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../../config/providers', () => ({ providers: [] }));
 
 // Mock UI components

--- a/frontend/tests/components/Bridge/BridgeInProgress/useMasterSafeCreateAndTransferSteps.test.ts
+++ b/frontend/tests/components/Bridge/BridgeInProgress/useMasterSafeCreateAndTransferSteps.test.ts
@@ -16,7 +16,7 @@ jest.mock(
   () => require('../../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../../constants/providers', () => ({}));
+jest.mock('../../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../../config/providers', () => ({ providers: [] }));
 
 const mockUseServices = jest.fn();

--- a/frontend/tests/components/Bridge/BridgeInProgress/useRetryBridge.test.ts
+++ b/frontend/tests/components/Bridge/BridgeInProgress/useRetryBridge.test.ts
@@ -13,7 +13,7 @@ jest.mock(
   () => require('../../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../../constants/providers', () => ({}));
+jest.mock('../../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../../config/providers', () => ({ providers: [] }));
 
 jest.mock('../../../../hooks/useBalanceAndRefillRequirementsContext', () => ({

--- a/frontend/tests/components/Bridge/BridgeOnEvm/DepositForBridging.test.tsx
+++ b/frontend/tests/components/Bridge/BridgeOnEvm/DepositForBridging.test.tsx
@@ -23,7 +23,7 @@ jest.mock(
   () => require('../../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../../constants/providers', () => ({}));
+jest.mock('../../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../../config/providers', () => ({ providers: [] }));
 
 // Mock styled-components so RootCard renders as a plain div

--- a/frontend/tests/components/Bridge/BridgeTransferFlow.test.tsx
+++ b/frontend/tests/components/Bridge/BridgeTransferFlow.test.tsx
@@ -3,7 +3,7 @@ import { createElement } from 'react';
 
 import { MiddlewareChain, MiddlewareChainMap } from '../../../constants/chains';
 
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../config/providers', () => ({ providers: [] }));
 
 jest.mock('antd', () => {

--- a/frontend/tests/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/frontend/tests/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -11,7 +11,7 @@ jest.mock(
   () => require('../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../config/providers', () => ({ providers: [] }));
 
 jest.mock('../../../components/SupportModal/SupportModal', () => ({

--- a/frontend/tests/components/FundPearlWallet.test.tsx
+++ b/frontend/tests/components/FundPearlWallet.test.tsx
@@ -11,7 +11,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 
 const mockClearNavParams = jest.fn();
 const mockGoto = jest.fn();

--- a/frontend/tests/components/Layout/WindowControls.test.tsx
+++ b/frontend/tests/components/Layout/WindowControls.test.tsx
@@ -14,7 +14,7 @@ jest.mock(
   () => require('../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../config/providers', () => ({ providers: [] }));
 
 jest.mock('next/router', () => ({

--- a/frontend/tests/components/MainPage/Sidebar/AgentListMenu.test.tsx
+++ b/frontend/tests/components/MainPage/Sidebar/AgentListMenu.test.tsx
@@ -6,7 +6,7 @@ import { AgentType, Pages } from '../../../../constants';
 import { AgentMap } from '../../../../constants/agent';
 import { useAgentRunning } from '../../../../hooks';
 
-jest.mock('../../../../constants/providers', () => ({}));
+jest.mock('../../../../constants/providers', () => ({ PROVIDERS: {} }));
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 jest.mock(

--- a/frontend/tests/components/MainPage/Sidebar/AgentTreeMenu.test.tsx
+++ b/frontend/tests/components/MainPage/Sidebar/AgentTreeMenu.test.tsx
@@ -20,7 +20,7 @@ jest.mock(
   () => require('../../../mocks/styledComponents').styledComponentsMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../../constants/providers', () => ({}));
+jest.mock('../../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../../config/providers', () => ({}));
 
 jest.mock('next/image', () => ({
@@ -214,7 +214,9 @@ describe('AgentTreeMenu', () => {
       />,
     );
 
-    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(/rewards earned this cycle/i),
+    ).not.toBeInTheDocument();
   });
 
   it('does not show reward dot for a running instance', () => {
@@ -234,8 +236,10 @@ describe('AgentTreeMenu', () => {
       />,
     );
 
-    // PulseDot (role="status") should be shown, no RewardDot (role="img")
+    // PulseDot (role="status") should be shown; RewardDot (aria-label "*rewards earned this cycle*") should not.
     expect(screen.getByRole('status')).toBeInTheDocument();
-    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(/rewards earned this cycle/i),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/tests/components/MainPage/Sidebar/AutoRunControl.test.tsx
+++ b/frontend/tests/components/MainPage/Sidebar/AutoRunControl.test.tsx
@@ -107,12 +107,6 @@ jest.mock('antd', () => {
   };
 });
 
-// Suppress antd Image preview warnings
-jest.mock('antd/es/image', () => {
-  const actual = jest.requireActual('antd');
-  return actual.Image;
-});
-
 // Mock next/image
 jest.mock('next/image', () => {
   const MockImage = (props: Record<string, unknown>) => (

--- a/frontend/tests/components/MainPage/Sidebar/Sidebar.test.tsx
+++ b/frontend/tests/components/MainPage/Sidebar/Sidebar.test.tsx
@@ -24,7 +24,7 @@ jest.mock(
   () => require('../../../mocks/styledComponents').styledComponentsMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../../constants/providers', () => ({}));
+jest.mock('../../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../../config/providers', () => ({}));
 
 jest.mock('next/image', () => ({
@@ -67,6 +67,8 @@ jest.mock('../../../../hooks', () => ({
   useIsInitiallyFunded: () => ({
     isInstanceInitiallyFunded: mockIsInstanceInitiallyFunded,
   }),
+  useAllInstancesRewardStatus: () => new Map(),
+  useBackupOwnerStatus: () => ({}),
 }));
 
 const mockUseServices = jest.fn();

--- a/frontend/tests/components/MainPage/UpdateAvailableAlert/useAppStatus.test.ts
+++ b/frontend/tests/components/MainPage/UpdateAvailableAlert/useAppStatus.test.ts
@@ -10,7 +10,7 @@ jest.mock(
   () => require('../../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../../constants/providers', () => ({}));
+jest.mock('../../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../../config/providers', () => ({ providers: [] }));
 
 const mockCheckForUpdates = jest.fn();

--- a/frontend/tests/components/MainPage/hooks/useSidebarAgents.test.ts
+++ b/frontend/tests/components/MainPage/hooks/useSidebarAgents.test.ts
@@ -11,7 +11,7 @@ import {
   useStore,
 } from '../../../../hooks';
 
-jest.mock('../../../../constants/providers', () => ({}));
+jest.mock('../../../../constants/providers', () => ({ PROVIDERS: {} }));
 
 jest.mock('../../../../utils', () => ({
   getServiceInstanceName: (_service: unknown, displayName: string) =>

--- a/frontend/tests/components/OnRamp/OnRamp.test.tsx
+++ b/frontend/tests/components/OnRamp/OnRamp.test.tsx
@@ -13,7 +13,7 @@ jest.mock(
   () => require('../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../config/providers', () => ({ providers: [] }));
 
 const mockUseOnRampContext = jest.fn();

--- a/frontend/tests/components/OnRamp/OnRampPaymentSteps/OnRampPaymentSteps.test.tsx
+++ b/frontend/tests/components/OnRamp/OnRampPaymentSteps/OnRampPaymentSteps.test.tsx
@@ -14,7 +14,7 @@ jest.mock(
   () => require('../../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../../constants/providers', () => ({}));
+jest.mock('../../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../../config/providers', () => ({ providers: [] }));
 
 // Mock hooks

--- a/frontend/tests/components/OnRamp/OnRampPaymentSteps/useBuyCryptoStep.test.ts
+++ b/frontend/tests/components/OnRamp/OnRampPaymentSteps/useBuyCryptoStep.test.ts
@@ -16,7 +16,7 @@ jest.mock(
   () => require('../../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../../constants/providers', () => ({}));
+jest.mock('../../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../../config/providers', () => ({ providers: [] }));
 
 jest.mock('../../../../hooks/useElectronApi', () => ({

--- a/frontend/tests/components/OnRamp/OnRampPaymentSteps/useCreateAndTransferFundsToMasterSafeSteps.test.ts
+++ b/frontend/tests/components/OnRamp/OnRampPaymentSteps/useCreateAndTransferFundsToMasterSafeSteps.test.ts
@@ -21,7 +21,7 @@ jest.mock(
   () => require('../../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../../constants/providers', () => ({}));
+jest.mock('../../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../../config/providers', () => ({ providers: [] }));
 
 jest.mock('../../../../hooks/useMasterSafeCreationAndTransfer', () => ({

--- a/frontend/tests/components/OnRamp/OnRampPaymentSteps/useSwapFundsStep.test.ts
+++ b/frontend/tests/components/OnRamp/OnRampPaymentSteps/useSwapFundsStep.test.ts
@@ -21,7 +21,7 @@ jest.mock(
   () => require('../../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../../constants/providers', () => ({}));
+jest.mock('../../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../../config/providers', () => ({ providers: [] }));
 
 jest.mock('../../../../hooks', () => ({

--- a/frontend/tests/components/OnRamp/PayingReceivingTable/useBridgeRequirementsQuery.test.ts
+++ b/frontend/tests/components/OnRamp/PayingReceivingTable/useBridgeRequirementsQuery.test.ts
@@ -16,7 +16,7 @@ jest.mock(
   () => require('../../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../../constants/providers', () => ({}));
+jest.mock('../../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../../config/providers', () => ({ providers: [] }));
 
 jest.mock('../../../../hooks/useBalanceAndRefillRequirementsContext', () => ({

--- a/frontend/tests/components/OnRamp/hooks/useBridgeRequirementsUtils.test.ts
+++ b/frontend/tests/components/OnRamp/hooks/useBridgeRequirementsUtils.test.ts
@@ -20,7 +20,7 @@ jest.mock(
   () => require('../../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../../constants/providers', () => ({}));
+jest.mock('../../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../../config/providers', () => ({ providers: [] }));
 
 jest.mock('../../../../hooks/useOnRampContext', () => ({

--- a/frontend/tests/components/OnRampIframe/OnRampIframe.test.tsx
+++ b/frontend/tests/components/OnRampIframe/OnRampIframe.test.tsx
@@ -15,7 +15,7 @@ jest.mock(
   () => require('../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../config/providers', () => ({ providers: [] }));
 
 jest.mock('../../../constants/urls', () => ({

--- a/frontend/tests/components/PearlDeposit/PearlDeposit.test.tsx
+++ b/frontend/tests/components/PearlDeposit/PearlDeposit.test.tsx
@@ -11,7 +11,7 @@ jest.mock(
   () => require('../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../config/providers', () => ({ providers: [] }));
 
 let depositProps: Record<string, unknown> = {};

--- a/frontend/tests/components/PearlDeposit/SelectPaymentMethod/BridgeCryptoOn.test.tsx
+++ b/frontend/tests/components/PearlDeposit/SelectPaymentMethod/BridgeCryptoOn.test.tsx
@@ -14,7 +14,7 @@ import {
   makeMasterSafe,
 } from '../../../helpers/factories';
 
-jest.mock('../../../../constants/providers', () => ({}));
+jest.mock('../../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../../config/providers', () => ({ providers: [] }));
 
 const mockUsePearlWallet = jest.fn();

--- a/frontend/tests/components/PearlDeposit/SelectPaymentMethod/SelectPaymentMethod.test.tsx
+++ b/frontend/tests/components/PearlDeposit/SelectPaymentMethod/SelectPaymentMethod.test.tsx
@@ -7,8 +7,15 @@ import {
 } from '../../../../constants/chains';
 import { MIN_ONRAMP_AMOUNT } from '../../../../constants/onramp';
 
-jest.mock('../../../../constants/providers', () => ({}));
+jest.mock('../../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../../config/providers', () => ({ providers: [] }));
+
+// IS_TRANSAK_UNAVAILABLE is currently true in production (on-ramp disabled);
+// these tests cover the on-ramp UI, so we force it to false here.
+jest.mock('../../../../constants/onramp', () => {
+  const actual = jest.requireActual('../../../../constants/onramp');
+  return { ...actual, IS_TRANSAK_UNAVAILABLE: false };
+});
 
 jest.mock('next/image', () => ({
   __esModule: true,

--- a/frontend/tests/components/PearlWallet/Withdraw/BalancesAndAssets/LowPearlWalletBalanceAlert.test.tsx
+++ b/frontend/tests/components/PearlWallet/Withdraw/BalancesAndAssets/LowPearlWalletBalanceAlert.test.tsx
@@ -14,7 +14,7 @@ jest.mock(
   () => require('../../../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../../../constants/providers', () => ({}));
+jest.mock('../../../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../../../config/providers', () => ({ providers: [] }));
 
 jest.mock('../../../../../components/ui', () => ({

--- a/frontend/tests/components/PearlWallet/Withdraw/EnterWithdrawalAddress/useWithdrawFunds.test.ts
+++ b/frontend/tests/components/PearlWallet/Withdraw/EnterWithdrawalAddress/useWithdrawFunds.test.ts
@@ -23,7 +23,7 @@ jest.mock(
   () => require('../../../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../../../constants/providers', () => ({}));
+jest.mock('../../../../../constants/providers', () => ({ PROVIDERS: {} }));
 
 jest.mock('../../../../../context/PearlWalletProvider', () => ({
   usePearlWallet: jest.fn(),

--- a/frontend/tests/components/PearlWallet/utils.test.ts
+++ b/frontend/tests/components/PearlWallet/utils.test.ts
@@ -13,7 +13,7 @@ jest.mock(
   'ethers-multicall',
   () => require('../../mocks/ethersMulticall').ethersMulticallMock,
 );
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 
 // Dynamically import after mocks are in place
 const { getInitialDepositForMasterSafe } =

--- a/frontend/tests/components/SettingsPage/BackupWallet/UpdateBackupWalletFlow/UpdateBackupWalletConfirmScreen.test.tsx
+++ b/frontend/tests/components/SettingsPage/BackupWallet/UpdateBackupWalletFlow/UpdateBackupWalletConfirmScreen.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { UpdateBackupWalletConfirmScreen } from '../../../../../components/SettingsPage/BackupWallet/UpdateBackupWalletFlow/UpdateBackupWalletConfirmScreen';
 import { BackupWalletError } from '../../../../../service/BackupWalletService';
 
-jest.mock('../../../../../constants/providers', () => ({}));
+jest.mock('../../../../../constants/providers', () => ({ PROVIDERS: {} }));
 
 // ---------------------------------------------------------------------------
 // Mocks

--- a/frontend/tests/components/SettingsPage/useRecoverySeedPhrase.test.ts
+++ b/frontend/tests/components/SettingsPage/useRecoverySeedPhrase.test.ts
@@ -10,7 +10,7 @@ jest.mock(
   () => require('../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../config/providers', () => ({ providers: [] }));
 
 const mockGetRecoverySeedPhrase = jest.fn();

--- a/frontend/tests/components/SettingsPage/useSettingsDrawer.test.ts
+++ b/frontend/tests/components/SettingsPage/useSettingsDrawer.test.ts
@@ -12,7 +12,7 @@ jest.mock(
   () => require('../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../config/providers', () => ({ providers: [] }));
 
 const mockGetSettings = jest.fn();

--- a/frontend/tests/components/SetupPage/AgentOnboarding/ArchivedAgentsList.test.tsx
+++ b/frontend/tests/components/SetupPage/AgentOnboarding/ArchivedAgentsList.test.tsx
@@ -12,7 +12,7 @@ jest.mock(
   () => require('../../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../../constants/providers', () => ({}));
+jest.mock('../../../../constants/providers', () => ({ PROVIDERS: {} }));
 
 // Mock next/image
 jest.mock('next/image', () => ({

--- a/frontend/tests/components/SetupPage/AgentOnboarding/findUndeployedInstance.test.ts
+++ b/frontend/tests/components/SetupPage/AgentOnboarding/findUndeployedInstance.test.ts
@@ -20,7 +20,7 @@ jest.mock(
   () => require('../../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../../constants/providers', () => ({}));
+jest.mock('../../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../../config/providers', () => ({ providers: [] }));
 jest.mock('../../../../hooks', () => ({
   useIsAgentGeoRestricted: jest.fn(),

--- a/frontend/tests/components/SetupPage/Create/SetupBackupSigner/BackupWalletManual.test.tsx
+++ b/frontend/tests/components/SetupPage/Create/SetupBackupSigner/BackupWalletManual.test.tsx
@@ -3,7 +3,7 @@ import { getAddress } from 'ethers/lib/utils';
 
 import { BackupWalletManual } from '../../../../../components/SetupPage/Create/SetupBackupSigner/BackupWalletManual';
 
-jest.mock('../../../../../constants/providers', () => ({}));
+jest.mock('../../../../../constants/providers', () => ({ PROVIDERS: {} }));
 
 // ---------------------------------------------------------------------------
 // Mocks

--- a/frontend/tests/components/SetupPage/Create/SetupBackupSigner/SetupBackupSigner.test.tsx
+++ b/frontend/tests/components/SetupPage/Create/SetupBackupSigner/SetupBackupSigner.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { SetupBackupSigner } from '../../../../../components/SetupPage/Create/SetupBackupSigner';
 import { SETUP_SCREEN } from '../../../../../constants/setupScreen';
 
-jest.mock('../../../../../constants/providers', () => ({}));
+jest.mock('../../../../../constants/providers', () => ({ PROVIDERS: {} }));
 
 // ---------------------------------------------------------------------------
 // Mocks

--- a/frontend/tests/components/SetupPage/FundRecovery/FundRecoveryScanResults.test.tsx
+++ b/frontend/tests/components/SetupPage/FundRecovery/FundRecoveryScanResults.test.tsx
@@ -39,7 +39,7 @@ jest.mock('../../../../components/ui', () => ({
 }));
 
 // Providers and chains mocks
-jest.mock('../../../../constants/providers', () => ({}));
+jest.mock('../../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../../config/providers', () => ({}));
 
 const GNOSIS_CHAIN_ID = 100;

--- a/frontend/tests/components/SetupPage/FundYourAgent/components/BalanceCheck.test.tsx
+++ b/frontend/tests/components/SetupPage/FundYourAgent/components/BalanceCheck.test.tsx
@@ -14,7 +14,7 @@ jest.mock(
   () => require('../../../../mocks/styledComponents').styledComponentsMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../../../constants/providers', () => ({}));
+jest.mock('../../../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../../../config/providers', () => ({}));
 
 jest.mock('next/image', () => ({

--- a/frontend/tests/components/SetupPage/FundYourAgent/components/ConfirmFunding.test.tsx
+++ b/frontend/tests/components/SetupPage/FundYourAgent/components/ConfirmFunding.test.tsx
@@ -15,7 +15,7 @@ jest.mock(
   () => require('../../../../mocks/styledComponents').styledComponentsMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../../../constants/providers', () => ({}));
+jest.mock('../../../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../../../config/providers', () => ({}));
 
 jest.mock('next/image', () => ({

--- a/frontend/tests/components/SetupPage/FundYourAgent/hooks/useTokensFundingStatus.test.ts
+++ b/frontend/tests/components/SetupPage/FundYourAgent/hooks/useTokensFundingStatus.test.ts
@@ -10,7 +10,7 @@ import { TokenRequirement } from '../../../../../types';
 import { DEFAULT_EOA_ADDRESS } from '../../../../helpers/factories';
 
 jest.mock('ethers-multicall', () => ({ Contract: jest.fn() }));
-jest.mock('../../../../../constants/providers', () => ({}));
+jest.mock('../../../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../../../config/providers', () => ({ providers: [] }));
 
 jest.mock('../../../../../hooks/useGetRefillRequirements', () => ({

--- a/frontend/tests/components/SetupPage/SetupWelcome.test.tsx
+++ b/frontend/tests/components/SetupPage/SetupWelcome.test.tsx
@@ -16,7 +16,7 @@ jest.mock(
   () => require('../../mocks/styledComponents').styledComponentsMock,
 );
 
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../config/providers', () => ({ providers: [] }));
 
 // Stub antd so no ESM imports are triggered

--- a/frontend/tests/components/SetupPage/SetupYourAgent/useDisplayAgentForm.test.tsx
+++ b/frontend/tests/components/SetupPage/SetupYourAgent/useDisplayAgentForm.test.tsx
@@ -14,7 +14,7 @@ jest.mock(
   () => require('../../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../../constants/providers', () => ({}));
+jest.mock('../../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../../config/providers', () => ({ providers: [] }));
 
 // Mock BackButton from @/components/ui to avoid antd ESM import chain

--- a/frontend/tests/components/SupportModal/useFallbackLogs.test.ts
+++ b/frontend/tests/components/SupportModal/useFallbackLogs.test.ts
@@ -17,7 +17,7 @@ jest.mock(
   () => require('../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../config/providers', () => ({ providers: [] }));
 
 const mockGetServices = jest.fn();

--- a/frontend/tests/components/SupportModal/useUploadSupportFiles.test.ts
+++ b/frontend/tests/components/SupportModal/useUploadSupportFiles.test.ts
@@ -12,7 +12,7 @@ jest.mock(
   () => require('../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../config/providers', () => ({ providers: [] }));
 
 const mockMainLogs = {

--- a/frontend/tests/components/UpdateAgentPage/context/UpdateAgentProvider.test.tsx
+++ b/frontend/tests/components/UpdateAgentPage/context/UpdateAgentProvider.test.tsx
@@ -62,7 +62,7 @@ jest.mock(
   () => require('../../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../../constants/providers', () => ({}));
+jest.mock('../../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../../config/providers', () => ({ providers: [] }));
 
 const mockUseService = jest.fn(() => ({

--- a/frontend/tests/components/Web3AuthIframe/Web3AuthIframe.test.tsx
+++ b/frontend/tests/components/Web3AuthIframe/Web3AuthIframe.test.tsx
@@ -14,7 +14,7 @@ jest.mock(
   () => require('../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../config/providers', () => ({ providers: [] }));
 
 // antd/es/tooltip uses ESM that jest cannot parse — stub it out

--- a/frontend/tests/components/Web3AuthIframe/Web3AuthSwapOwnerIframe.test.tsx
+++ b/frontend/tests/components/Web3AuthIframe/Web3AuthSwapOwnerIframe.test.tsx
@@ -20,7 +20,7 @@ jest.mock(
   () => require('../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../config/providers', () => ({ providers: [] }));
 
 // antd/es/tooltip uses ESM that jest cannot parse — stub it out

--- a/frontend/tests/components/ui/AgentTree.test.tsx
+++ b/frontend/tests/components/ui/AgentTree.test.tsx
@@ -23,7 +23,7 @@ jest.mock(
   () => require('../../mocks/styledComponents').styledComponentsMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../config/providers', () => ({}));
 
 jest.mock('next/image', () => ({

--- a/frontend/tests/components/ui/CopyAddress.test.tsx
+++ b/frontend/tests/components/ui/CopyAddress.test.tsx
@@ -9,7 +9,7 @@ import { DEFAULT_EOA_ADDRESS } from '../../helpers/factories';
 // ---------------------------------------------------------------------------
 // Module mocks
 // ---------------------------------------------------------------------------
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../config/providers', () => ({ providers: [] }));
 
 const mockCopyToClipboard = jest.fn(() => Promise.resolve());

--- a/frontend/tests/components/ui/FundingDescription.test.tsx
+++ b/frontend/tests/components/ui/FundingDescription.test.tsx
@@ -9,7 +9,7 @@ import { DEFAULT_EOA_ADDRESS } from '../../helpers/factories';
 // ---------------------------------------------------------------------------
 // Module mocks
 // ---------------------------------------------------------------------------
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../config/providers', () => ({ providers: [] }));
 
 /* eslint-disable @typescript-eslint/no-var-requires */

--- a/frontend/tests/components/ui/InsufficientSignerGasModal.test.tsx
+++ b/frontend/tests/components/ui/InsufficientSignerGasModal.test.tsx
@@ -13,7 +13,7 @@ jest.mock(
   () => require('../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 
 jest.mock('../../../components/ui/Modal', () => ({
   Modal: ({

--- a/frontend/tests/context/BalanceProvider/BalanceProvider.test.tsx
+++ b/frontend/tests/context/BalanceProvider/BalanceProvider.test.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../../context/BalanceProvider/BalanceProvider';
 import { MasterWalletContext } from '../../../context/MasterWalletProvider';
 import { OnlineStatusContext } from '../../../context/OnlineStatusProvider';
+import { PageStateContext } from '../../../context/PageStateProvider';
 import { ServicesContext } from '../../../context/ServicesProvider';
 import { AgentConfig } from '../../../types/Agent';
 import {
@@ -38,7 +39,7 @@ jest.mock(
   'ethers-multicall',
   () => require('../../mocks/ethersMulticall').ethersMulticallMock,
 );
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 /* eslint-enable @typescript-eslint/no-var-requires */
 
 const mockGetCrossChainBalances = jest.fn();
@@ -81,13 +82,18 @@ const makeStakedBalance = (
 
 type WrapperOptions = {
   isOnline?: boolean;
+  isUserLoggedIn?: boolean;
   masterWallets?: MasterWallet[] | null;
   services?: MiddlewareServiceResponse[] | null;
   selectedAgentConfig?: AgentConfig;
 };
 
 const createWrapper = (options: WrapperOptions = {}) => {
-  const { isOnline = true, selectedAgentConfig = defaultAgentConfig } = options;
+  const {
+    isOnline = true,
+    isUserLoggedIn = true,
+    selectedAgentConfig = defaultAgentConfig,
+  } = options;
   const masterWallets =
     options.masterWallets === null
       ? undefined
@@ -103,35 +109,47 @@ const createWrapper = (options: WrapperOptions = {}) => {
   return ({ children }: PropsWithChildren) => (
     <QueryClientProvider client={queryClient}>
       <OnlineStatusContext.Provider value={{ isOnline }}>
-        <MasterWalletContext.Provider value={{ masterWallets }}>
-          <ServicesContext.Provider
-            value={{
-              services,
-              selectedAgentConfig,
-              serviceWallets: undefined as AgentWallet[] | undefined,
-              availableServiceConfigIds: [],
-              getServiceConfigIdsOf: () => [],
-              getAgentTypeFromService: () => null,
-              getServiceConfigIdFromAgentType: () => null,
-              getInstancesOfAgentType: () => [],
-              isSelectedServiceDeploymentStatusLoading: false,
-              selectedAgentType: AgentMap.PredictTrader,
-              selectedAgentName: null,
-              selectedAgentNameOrFallback: 'My agent',
-              selectedServiceConfigId: null,
-              deploymentDetails: undefined,
-              updateAgentType: jest.fn(),
-              selectAgentTypeForSetup: jest.fn(),
-              updateSelectedServiceConfigId: jest.fn(),
-              overrideSelectedServiceStatus: jest.fn(),
-              paused: false,
-              setPaused: jest.fn(),
-              togglePaused: jest.fn(),
-            }}
-          >
-            <BalanceProvider>{children}</BalanceProvider>
-          </ServicesContext.Provider>
-        </MasterWalletContext.Provider>
+        <PageStateContext.Provider
+          value={
+            {
+              isUserLoggedIn,
+              pageState: 0,
+              setPageState: jest.fn(),
+              setNavParams: jest.fn(),
+              setIsUserLoggedIn: jest.fn(),
+            } as unknown as React.ContextType<typeof PageStateContext>
+          }
+        >
+          <MasterWalletContext.Provider value={{ masterWallets }}>
+            <ServicesContext.Provider
+              value={{
+                services,
+                selectedAgentConfig,
+                serviceWallets: undefined as AgentWallet[] | undefined,
+                availableServiceConfigIds: [],
+                getServiceConfigIdsOf: () => [],
+                getAgentTypeFromService: () => null,
+                getServiceConfigIdFromAgentType: () => null,
+                getInstancesOfAgentType: () => [],
+                isSelectedServiceDeploymentStatusLoading: false,
+                selectedAgentType: AgentMap.PredictTrader,
+                selectedAgentName: null,
+                selectedAgentNameOrFallback: 'My agent',
+                selectedServiceConfigId: null,
+                deploymentDetails: undefined,
+                updateAgentType: jest.fn(),
+                selectAgentTypeForSetup: jest.fn(),
+                updateSelectedServiceConfigId: jest.fn(),
+                overrideSelectedServiceStatus: jest.fn(),
+                paused: false,
+                setPaused: jest.fn(),
+                togglePaused: jest.fn(),
+              }}
+            >
+              <BalanceProvider>{children}</BalanceProvider>
+            </ServicesContext.Provider>
+          </MasterWalletContext.Provider>
+        </PageStateContext.Provider>
       </OnlineStatusContext.Provider>
     </QueryClientProvider>
   );

--- a/frontend/tests/context/BalanceProvider/utils.test.ts
+++ b/frontend/tests/context/BalanceProvider/utils.test.ts
@@ -36,7 +36,7 @@ jest.mock('ethers-multicall', () => ({
   })),
 }));
 
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 
 jest.mock('../../../service/agents/shared-services/StakedAgentService', () => ({
   StakedAgentService: {

--- a/frontend/tests/context/BalancesAndRefillRequirementsProvider/BalancesAndRefillRequirementsProvider.test.tsx
+++ b/frontend/tests/context/BalancesAndRefillRequirementsProvider/BalancesAndRefillRequirementsProvider.test.tsx
@@ -28,7 +28,7 @@ import {
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 jest.mock('ethers-multicall', () => ({ Contract: jest.fn() }));
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../config/providers', () => ({ providers: [] }));
 /* eslint-enable @typescript-eslint/no-var-requires */
 

--- a/frontend/tests/context/MasterWalletProvider.test.tsx
+++ b/frontend/tests/context/MasterWalletProvider.test.tsx
@@ -23,7 +23,7 @@ jest.mock(
   'ethers-multicall',
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 
 jest.mock('../../service/Wallet', () => ({
   WalletService: {
@@ -196,19 +196,20 @@ describe('MasterWalletProvider', () => {
     expect(result.current.getMasterSafeOf).toBeUndefined();
   });
 
-  it('disables refetch interval when offline', async () => {
+  it('disables the wallet query when offline', async () => {
     mockGetWallets.mockResolvedValue([makeWalletResponse()]);
 
     const { result } = renderHook(() => useContext(MasterWalletContext), {
       wrapper: createWrapper({ isOnline: false }),
     });
 
-    // Should still fetch initially, but refetchInterval is false
+    // Source uses `enabled: isOnline`, so the query never fires while offline
+    // and the derived wallet fields stay undefined.
     await waitFor(() => {
-      expect(result.current.masterEoa).toBeDefined();
+      expect(mockGetWallets).not.toHaveBeenCalled();
     });
-    // Verify data still loads (query is not disabled, only refetch interval is false)
-    expect(result.current.masterEoa?.address).toBe(DEFAULT_EOA_ADDRESS);
+    expect(result.current.masterEoa).toBeUndefined();
+    expect(result.current.masterSafes).toBeUndefined();
   });
 
   it('returns masterWallets including both EOA and safes', async () => {

--- a/frontend/tests/context/PearlWalletProvider.test.tsx
+++ b/frontend/tests/context/PearlWalletProvider.test.tsx
@@ -36,7 +36,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 jest.mock(

--- a/frontend/tests/context/RewardProvider.test.tsx
+++ b/frontend/tests/context/RewardProvider.test.tsx
@@ -27,7 +27,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../config/providers', () => ({}));
 jest.mock('../../hooks/useDynamicRefetchInterval', () => ({
   useDynamicRefetchInterval: jest.fn((interval: number) => interval),

--- a/frontend/tests/context/ServicesProvider.test.tsx
+++ b/frontend/tests/context/ServicesProvider.test.tsx
@@ -44,7 +44,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../config/providers', () => ({}));
 
 // ServicesService

--- a/frontend/tests/context/SharedProvider.test.tsx
+++ b/frontend/tests/context/SharedProvider.test.tsx
@@ -11,7 +11,7 @@ import { Service } from '../../types/Service';
 import { makeService as makeFactoryService } from '../helpers/factories';
 
 jest.mock('ethers-multicall', () => ({ Contract: jest.fn() }));
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../config/providers', () => ({ providers: [] }));
 
 jest.mock('../../hooks/useServices', () => ({

--- a/frontend/tests/context/StakingContractDetailsProvider.test.tsx
+++ b/frontend/tests/context/StakingContractDetailsProvider.test.tsx
@@ -30,7 +30,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../config/providers', () => ({}));
 
 // ── Hook mocks ────────────────────────────────────────────────────────

--- a/frontend/tests/context/StakingProgramProvider.test.tsx
+++ b/frontend/tests/context/StakingProgramProvider.test.tsx
@@ -26,7 +26,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../config/providers', () => ({}));
 
 // ── Hook mocks ────────────────────────────────────────────────────────

--- a/frontend/tests/context/migrations/autoRunInstances.test.ts
+++ b/frontend/tests/context/migrations/autoRunInstances.test.ts
@@ -15,7 +15,7 @@ jest.mock(
   () => require('../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../config/providers', () => ({}));
 
 const serviceFor = (

--- a/frontend/tests/context/migrations/isInitialFunded.test.ts
+++ b/frontend/tests/context/migrations/isInitialFunded.test.ts
@@ -15,7 +15,7 @@ jest.mock(
   () => require('../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../config/providers', () => ({}));
 
 const serviceFor = (

--- a/frontend/tests/context/migrations/serviceSelection.test.ts
+++ b/frontend/tests/context/migrations/serviceSelection.test.ts
@@ -15,7 +15,7 @@ jest.mock(
   () => require('../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../../config/providers', () => ({}));
 
 const serviceFor = (

--- a/frontend/tests/hooks/useActiveStakingProgramId.test.ts
+++ b/frontend/tests/hooks/useActiveStakingProgramId.test.ts
@@ -20,7 +20,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../config/agents', () => ({ AGENT_CONFIG: {} }));
 jest.mock('../../hooks/useRewardsHistory', () => ({
   useRewardsHistory: jest.fn(),

--- a/frontend/tests/hooks/useAgentActivity.test.ts
+++ b/frontend/tests/hooks/useAgentActivity.test.ts
@@ -11,7 +11,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 
 const mockDeploymentDetails: ServiceDeployment = {
   status: MiddlewareDeploymentStatusMap.DEPLOYED,

--- a/frontend/tests/hooks/useAgentStakingRewardsDetails.test.ts
+++ b/frontend/tests/hooks/useAgentStakingRewardsDetails.test.ts
@@ -33,7 +33,7 @@ jest.mock(
   () => require('../mocks/onlineStatus').onlineStatusProviderMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 
 jest.mock('../../hooks/useServices', () => ({
   useServices: jest.fn(),

--- a/frontend/tests/hooks/useAllInstancesRewardStatus.test.ts
+++ b/frontend/tests/hooks/useAllInstancesRewardStatus.test.ts
@@ -29,7 +29,7 @@ jest.mock(
   () => require('../mocks/onlineStatus').onlineStatusProviderMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 
 jest.mock('../../hooks/useServices', () => ({
   useServices: jest.fn(),

--- a/frontend/tests/hooks/useApplyBackupDuringSetup.test.ts
+++ b/frontend/tests/hooks/useApplyBackupDuringSetup.test.ts
@@ -9,7 +9,7 @@ import {
 } from '../../service/BackupWalletService';
 import { Address } from '../../types/Address';
 
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 
 const mockApplyBackupOwner = jest.fn();
 const mockSetPassword = jest.fn();

--- a/frontend/tests/hooks/useArchivedAgents.test.ts
+++ b/frontend/tests/hooks/useArchivedAgents.test.ts
@@ -8,7 +8,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 
 const mockSetStore = jest.fn();
 const mockElectronApi = jest.fn();

--- a/frontend/tests/hooks/useAvailableAgentAssets.test.ts
+++ b/frontend/tests/hooks/useAvailableAgentAssets.test.ts
@@ -24,7 +24,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 
 jest.mock('../../hooks/useServices', () => ({
   useServices: jest.fn(),

--- a/frontend/tests/hooks/useBalanceAndRefillRequirementsContext.test.ts
+++ b/frontend/tests/hooks/useBalanceAndRefillRequirementsContext.test.ts
@@ -10,7 +10,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../config/providers', () => ({ providers: [] }));
 
 describe('useBalanceAndRefillRequirementsContext', () => {

--- a/frontend/tests/hooks/useBalanceContext.test.ts
+++ b/frontend/tests/hooks/useBalanceContext.test.ts
@@ -11,7 +11,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../config/providers', () => ({ providers: [] }));
 
 describe('useBalanceContext', () => {

--- a/frontend/tests/hooks/useBridgeRefillRequirements.test.ts
+++ b/frontend/tests/hooks/useBridgeRefillRequirements.test.ts
@@ -22,7 +22,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../config/providers', () => ({ providers: [] }));
 jest.mock('../../service/Bridge', () => ({
   BridgeService: {

--- a/frontend/tests/hooks/useBridgeRefillRequirementsOnDemand.test.ts
+++ b/frontend/tests/hooks/useBridgeRefillRequirementsOnDemand.test.ts
@@ -21,7 +21,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../config/providers', () => ({ providers: [] }));
 jest.mock('../../service/Bridge', () => ({
   BridgeService: {

--- a/frontend/tests/hooks/useBridgingSteps.test.ts
+++ b/frontend/tests/hooks/useBridgingSteps.test.ts
@@ -15,7 +15,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../config/providers', () => ({ providers: [] }));
 
 const mockUseOnlineStatusContext = jest.fn();

--- a/frontend/tests/hooks/useCompleteAgentSetup.test.ts
+++ b/frontend/tests/hooks/useCompleteAgentSetup.test.ts
@@ -23,7 +23,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 
 jest.mock('../../hooks/useWallet', () => ({
   useMasterWalletContext: jest.fn(),

--- a/frontend/tests/hooks/useFundRecoveryExecute.test.ts
+++ b/frontend/tests/hooks/useFundRecoveryExecute.test.ts
@@ -12,7 +12,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 
 jest.mock('../../service/FundRecovery', () => ({
   FundRecoveryService: {

--- a/frontend/tests/hooks/useFundRecoveryScan.test.ts
+++ b/frontend/tests/hooks/useFundRecoveryScan.test.ts
@@ -12,7 +12,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 
 jest.mock('../../service/FundRecovery', () => ({
   FundRecoveryService: {

--- a/frontend/tests/hooks/useFundingEligibleServices.test.ts
+++ b/frontend/tests/hooks/useFundingEligibleServices.test.ts
@@ -15,7 +15,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 
 const mockUseServices = jest.fn();
 const mockUseIsInitiallyFunded = jest.fn();

--- a/frontend/tests/hooks/useGetBridgeRequirementsParams.test.ts
+++ b/frontend/tests/hooks/useGetBridgeRequirementsParams.test.ts
@@ -47,7 +47,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../config/providers', () => ({ providers: [] }));
 
 jest.mock('../../hooks/useServices', () => ({

--- a/frontend/tests/hooks/useGetOnRampRequirementsParams.test.ts
+++ b/frontend/tests/hooks/useGetOnRampRequirementsParams.test.ts
@@ -21,7 +21,7 @@ jest.mock('ethers-multicall', () => ({
   Provider: jest.fn().mockImplementation(() => ({})),
   Contract: jest.fn().mockImplementation(() => ({})),
 }));
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../config/providers', () => ({ providers: [] }));
 
 jest.mock('../../context/PearlWalletProvider', () => ({

--- a/frontend/tests/hooks/useGetRefillRequirements.test.ts
+++ b/frontend/tests/hooks/useGetRefillRequirements.test.ts
@@ -31,7 +31,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../config/providers', () => ({ providers: [] }));
 
 jest.mock('../../hooks/useBalanceAndRefillRequirementsContext', () => ({

--- a/frontend/tests/hooks/useInitialFundingRequirements.test.ts
+++ b/frontend/tests/hooks/useInitialFundingRequirements.test.ts
@@ -13,7 +13,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../config/providers', () => ({ providers: [] }));
 
 const mockGetMasterSafeOf = jest.fn();

--- a/frontend/tests/hooks/useIsAgentGeoRestricted.test.ts
+++ b/frontend/tests/hooks/useIsAgentGeoRestricted.test.ts
@@ -11,7 +11,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 
 const geoRestrictedConfig = {
   isGeoLocationRestricted: true,

--- a/frontend/tests/hooks/useIsInitiallyFunded.test.ts
+++ b/frontend/tests/hooks/useIsInitiallyFunded.test.ts
@@ -16,7 +16,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 
 const mockSetStore = jest.fn();
 const mockElectronApi = jest.fn();

--- a/frontend/tests/hooks/useMasterBalances.test.ts
+++ b/frontend/tests/hooks/useMasterBalances.test.ts
@@ -24,7 +24,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 
 jest.mock('../../hooks/useServices', () => ({
   useServices: jest.fn(),

--- a/frontend/tests/hooks/useMasterSafeCreationAndTransfer.test.ts
+++ b/frontend/tests/hooks/useMasterSafeCreationAndTransfer.test.ts
@@ -23,7 +23,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 
 jest.mock('../../service/Wallet', () => ({
   WalletService: { createSafe: jest.fn() },

--- a/frontend/tests/hooks/useRewardsHistory.test.ts
+++ b/frontend/tests/hooks/useRewardsHistory.test.ts
@@ -30,7 +30,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 
 // Mock graphql-request
 const mockGraphqlRequest = jest.fn();

--- a/frontend/tests/hooks/useService.test.ts
+++ b/frontend/tests/hooks/useService.test.ts
@@ -23,7 +23,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../hooks/useServices', () => ({
   useServices: jest.fn(),
 }));

--- a/frontend/tests/hooks/useServiceBalances.test.ts
+++ b/frontend/tests/hooks/useServiceBalances.test.ts
@@ -21,7 +21,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 
 jest.mock('../../hooks/useServices', () => ({
   useServices: jest.fn(),

--- a/frontend/tests/hooks/useStakingContractDetails.test.ts
+++ b/frontend/tests/hooks/useStakingContractDetails.test.ts
@@ -3,6 +3,7 @@ import { createElement, PropsWithChildren } from 'react';
 
 import { StakingProgramId } from '../../constants/stakingProgram';
 import { StakingContractDetailsContext } from '../../context/StakingContractDetailsProvider';
+import { StakingProgramContext } from '../../context/StakingProgramProvider';
 import {
   useActiveStakingContractDetails,
   useStakingContractContext,
@@ -38,32 +39,53 @@ type ContextValue = {
   >;
   isAllStakingContractDetailsRecordLoaded?: boolean;
   isPaused?: boolean;
+  selectedStakingProgramId?: StakingProgramId | null;
 };
 
 /**
- * Builds a React wrapper that provides StakingContractDetailsContext
- * with the given (partial) value merged over sensible defaults.
+ * Builds a React wrapper that provides both StakingContractDetailsContext
+ * and StakingProgramContext. selectedStakingProgramId defaults to a valid
+ * program ID so isServiceStakedForMinimumDuration exercises its full logic;
+ * tests that want the no_staking short-circuit can pass null explicitly.
  */
 function makeWrapper(overrides: ContextValue = {}) {
+  const selectedStakingProgramId =
+    'selectedStakingProgramId' in overrides
+      ? (overrides.selectedStakingProgramId ?? null)
+      : DEFAULT_STAKING_PROGRAM_ID;
+
   const Wrapper = ({ children }: PropsWithChildren) =>
     createElement(
-      StakingContractDetailsContext.Provider,
+      StakingProgramContext.Provider,
       {
         value: {
-          selectedStakingContractDetails:
-            overrides.selectedStakingContractDetails ?? null,
-          isSelectedStakingContractDetailsLoading:
-            overrides.isSelectedStakingContractDetailsLoading ?? false,
-          allStakingContractDetailsRecord:
-            overrides.allStakingContractDetailsRecord,
-          isAllStakingContractDetailsRecordLoaded:
-            overrides.isAllStakingContractDetailsRecordLoaded ?? false,
-          refetchSelectedStakingContractDetails: async () => {},
-          isPaused: overrides.isPaused ?? false,
-          setIsPaused: () => {},
+          selectedStakingProgramId,
+          setDefaultStakingProgramId: () => {},
+          isActiveStakingProgramLoaded: true,
+          stakingProgramIdToMigrateTo: null,
+          setStakingProgramIdToMigrateTo: () => {},
+          stakingProgramIdByServiceConfigId: new Map(),
         },
       },
-      children,
+      createElement(
+        StakingContractDetailsContext.Provider,
+        {
+          value: {
+            selectedStakingContractDetails:
+              overrides.selectedStakingContractDetails ?? null,
+            isSelectedStakingContractDetailsLoading:
+              overrides.isSelectedStakingContractDetailsLoading ?? false,
+            allStakingContractDetailsRecord:
+              overrides.allStakingContractDetailsRecord,
+            isAllStakingContractDetailsRecordLoaded:
+              overrides.isAllStakingContractDetailsRecordLoaded ?? false,
+            refetchSelectedStakingContractDetails: async () => {},
+            isPaused: overrides.isPaused ?? false,
+            setIsPaused: () => {},
+          },
+        },
+        children,
+      ),
     );
   return Wrapper;
 }

--- a/frontend/tests/hooks/useStakingContracts.test.ts
+++ b/frontend/tests/hooks/useStakingContracts.test.ts
@@ -18,7 +18,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../config/providers', () => ({ providers: [] }));
 
 jest.mock('../../hooks/useServices', () => ({

--- a/frontend/tests/hooks/useStakingProgram.test.ts
+++ b/frontend/tests/hooks/useStakingProgram.test.ts
@@ -22,7 +22,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../config/providers', () => ({ providers: [] }));
 
 jest.mock('../../hooks/useServices', () => ({

--- a/frontend/tests/hooks/useStakingRewardsOf.test.ts
+++ b/frontend/tests/hooks/useStakingRewardsOf.test.ts
@@ -28,7 +28,7 @@ jest.mock(
   () => require('../mocks/onlineStatus').onlineStatusProviderMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 
 jest.mock('../../hooks/useServices', () => ({
   useServices: jest.fn(),

--- a/frontend/tests/hooks/useTotalFiatFromNativeToken.test.ts
+++ b/frontend/tests/hooks/useTotalFiatFromNativeToken.test.ts
@@ -14,7 +14,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../config/providers', () => ({ providers: [] }));
 
 jest.mock('../../constants/urls', () => ({

--- a/frontend/tests/hooks/useTotalNativeTokenRequired.test.ts
+++ b/frontend/tests/hooks/useTotalNativeTokenRequired.test.ts
@@ -22,7 +22,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../config/providers', () => ({ providers: [] }));
 
 const mockUpdateNativeAmountToPay = jest.fn();

--- a/frontend/tests/hooks/useValidatePassword.test.ts
+++ b/frontend/tests/hooks/useValidatePassword.test.ts
@@ -11,7 +11,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 
 jest.mock('../../service/Account', () => ({
   AccountService: {

--- a/frontend/tests/hooks/useWalletContribution.test.ts
+++ b/frontend/tests/hooks/useWalletContribution.test.ts
@@ -9,7 +9,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 jest.mock('../../config/providers', () => ({}));
 
 const mockUseTokensFundingStatus = jest.fn();

--- a/frontend/tests/service/Balance.test.ts
+++ b/frontend/tests/service/Balance.test.ts
@@ -14,7 +14,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 
 const makeBalancesAndFundingRequirements = (
   overrides: Partial<BalancesAndFundingRequirements> = {},

--- a/frontend/tests/service/Bridge.test.ts
+++ b/frontend/tests/service/Bridge.test.ts
@@ -19,7 +19,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 
 const MOCK_QUOTE_ID = 'rb-36c6cbe0-1841-4de3-b9f6-873305a833f5';
 

--- a/frontend/tests/service/Services.test.ts
+++ b/frontend/tests/service/Services.test.ts
@@ -23,7 +23,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 
 const mockJsonResponse = (body: unknown, ok = true, status = 200) =>
   Promise.resolve({

--- a/frontend/tests/service/agents/AgentsFunBase.test.ts
+++ b/frontend/tests/service/agents/AgentsFunBase.test.ts
@@ -15,7 +15,7 @@ jest.mock(
   'ethers-multicall',
   () => require('../../mocks/ethersMulticall').ethersMulticallMock,
 );
-jest.mock('../../../constants/providers', () => ({}));
+jest.mock('../../../constants/providers', () => ({ PROVIDERS: {} }));
 
 // Mock AgentsFunService — the parent class that AgentsFunBaseService delegates to
 jest.mock('../../../service/agents/shared-services/AgentsFun', () => ({

--- a/frontend/tests/service/agents/shared-services/StakedAgentService.test.ts
+++ b/frontend/tests/service/agents/shared-services/StakedAgentService.test.ts
@@ -22,7 +22,7 @@ jest.mock(
   () => require('../../../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../../../constants/providers', () => ({}));
+jest.mock('../../../../constants/providers', () => ({ PROVIDERS: {} }));
 
 // ── Mock program IDs ──
 const PROGRAM_A = 'program_a' as StakingProgramId;

--- a/frontend/tests/utils/setupMulticall.test.ts
+++ b/frontend/tests/utils/setupMulticall.test.ts
@@ -10,7 +10,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 
 const mockSetMulticallAddress = setMulticallAddress as jest.Mock;
 

--- a/frontend/tests/utils/stakingRewards.test.ts
+++ b/frontend/tests/utils/stakingRewards.test.ts
@@ -17,7 +17,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 
 const mockGetAgentStakingRewardsInfo = jest.fn();
 

--- a/frontend/tests/utils/wallet.test.ts
+++ b/frontend/tests/utils/wallet.test.ts
@@ -22,7 +22,7 @@ jest.mock(
   () => require('../mocks/ethersMulticall').ethersMulticallMock,
 );
 /* eslint-enable @typescript-eslint/no-var-requires */
-jest.mock('../../constants/providers', () => ({}));
+jest.mock('../../constants/providers', () => ({ PROVIDERS: {} }));
 
 describe('tokenBalancesToSentence', () => {
   it('returns empty string for empty object', () => {


### PR DESCRIPTION
## Summary
Unblocks PR #1946 (release/v1.6.12 → main). The unified CI workflow from PR #1945 made the Frontend Tests job required on every PR — previously `frontend-tests.yml` was `workflow_dispatch`-only, so PR CI never ran the suite. Several source-vs-test drifts had accumulated; this PR repairs them. **No production source files are touched** — only `jest.config.ts` and test files.

## Changes

### Test infrastructure
- `jest.config.ts`: `moduleNameMapper` redirects `antd/es/*` → `antd/lib/*` so Jest can `require()` antd's CJS build. (`next/jest`'s default `transformIgnorePatterns` excludes `node_modules`, so antd's ESM build was hitting Jest as raw ESM.)
- Bulk-replace `jest.mock('.../constants/providers', () => ({}))` with `() => ({ PROVIDERS: {} })` so transitive imports of `config/providers.ts` don't crash on `Object.entries(undefined)`.

### Per-suite fixes
- **useStakingContractDetails** — wrap with `StakingProgramContext.Provider` too, default `selectedStakingProgramId` to a valid id so the `no_staking` short-circuit added in `1f4dd81c8` doesn't bypass the logic under test.
- **MasterWalletProvider** — rewrite the offline test: source uses `enabled: isOnline` now (full query disable), not just `refetchInterval=false`.
- **BalanceProvider** — wrap with `PageStateContext.Provider` providing `isUserLoggedIn=true`; the source's `enabled` gate requires it.
- **Sidebar** — add missing `useAllInstancesRewardStatus` / `useBackupOwnerStatus` mocks (`useAllInstancesRewardStatus` returns a `Map`).
- **AgentTreeMenu** — query `RewardDot` by aria-label instead of `role="img"` (the agent avatar also has `role=img` and matched the broad query).
- **AutoRunControl** — drop the misshaped `antd/es/image` mock; the `moduleNameMapper` makes it unnecessary.
- **SelectPaymentMethod** — mock `IS_TRANSAK_UNAVAILABLE=false` so the on-ramp UI these tests cover is actually rendered (prod has the flag at `true`).

## Test plan
- [x] `yarn test` — 4526/4526 passing locally, 313/313 suites green
- [x] `yarn typecheck` — clean
- [x] `yarn lint:fix` — 0 errors (19 pre-existing warnings unrelated)
- [ ] CI Frontend Tests green on this PR
- [ ] After merge → PR #1946 Frontend Tests passes → release can merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)