### PR TITLE
chore(supply-chain): add yarn audit gate 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,39 @@ jobs:
       - name: Check frontend deps are exact-pinned
         run: cd frontend && yarn deps:check-pinned
 
+  audit:
+    name: yarn audit (both trees)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+
+      - name: Activate pinned Yarn via Corepack
+        run: |
+          corepack enable
+          # Read the full integrity-verified spec from package.json so corepack
+          # checks the sha512 hash. Plain `corepack prepare yarn@1.22.22 --activate`
+          # downloads from npm without verifying against the hash.
+          PM_SPEC=$(node -p "require('./package.json').packageManager")
+          corepack prepare "$PM_SPEC" --activate
+
+      - name: Verify Yarn version
+        run: |
+          yarn --version
+          test "$(yarn --version)" = "1.22.22" || (echo "::error::Yarn version mismatch" && exit 1)
+
+      # No `yarn install` — `yarn audit` reads yarn.lock directly. Skipping
+      # install means a compromised `postinstall` script cannot execute inside
+      # the audit job. Defense in depth at the workflow level.
+      - name: Audit root tree
+        run: yarn audit:prod
+
+      - name: Audit frontend tree
+        run: cd frontend && yarn audit:prod
+
   install-hooks-root:
     name: install-hooks (root tree)
     runs-on: ubuntu-latest
@@ -287,7 +320,7 @@ jobs:
 
   all-checks-passed:
     name: All checks passed
-    needs: [backend, frontend, frontend-tests, gitleaks, deps-check-pinned, lockfile-lint, install-hooks-root, install-hooks-frontend]
+    needs: [backend, frontend, frontend-tests, gitleaks, deps-check-pinned, lockfile-lint, audit, install-hooks-root, install-hooks-frontend]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.supply-chain/audit-allowlist.json
+++ b/.supply-chain/audit-allowlist.json
@@ -10,5 +10,52 @@
     "added": "YYYY-MM-DD when the entry was added — REQUIRED",
     "review": "YYYY-MM-DD by which the entry must be re-evaluated — REQUIRED. An expired entry prints a CI warning but does not fail the job."
   },
-  "entries": []
+  "_residual_group_doc": "All five entries below are Next.js 14.x advisories cleared from PR #1961 (Phase 0). Fix versions require Next 15.0.8+ / 15.5.15+ / 15.5.16+; a 14 → 15 migration is a dedicated separate PR. Justification for allowlisting rather than bumping: Pearl runs Next.js as a build-time static React bundler. Electron serves frontend/.next as static HTML/JS via its protocol handler — no Next runtime server, no API routes (frontend/pages/api/ does not exist), no getServerSideProps, no middleware.ts. Therefore RSC DoS, WebSocket SSRF, and middleware/i18n bypass cannot fire on Pearl's actual runtime path. If Pearl ever grows server-side Next code (an API route, getServerSideProps, or middleware), re-evaluate every entry below — the 'not reachable' premise becomes false the moment any of those exist.",
+  "entries": [
+    {
+      "id": 1112653,
+      "ghsa": "GHSA-h25m-26qc-wcjf",
+      "package": "next",
+      "severity": "high",
+      "reason": "Next.js HTTP request deserialization can lead to DoS when using insecure React Server Components. Vulnerable range >=13.0.0 <15.0.8. Fix requires Next 15.x major bump (deferred to dedicated migration PR). Not reachable: Pearl has no RSC components — frontend/.next is static-bundled and served by Electron's protocol handler, not by Next's server.",
+      "added": "2026-05-15",
+      "review": "2026-08-15"
+    },
+    {
+      "id": 1116376,
+      "ghsa": "GHSA-q4gf-8mx6-v5v3",
+      "package": "next",
+      "severity": "high",
+      "reason": "Next.js DoS with Server Components. Vulnerable range >=13.0.0 <15.5.15. Fix requires Next 15.x (deferred). Not reachable: Pearl has no Server Components — static-bundled only.",
+      "added": "2026-05-15",
+      "review": "2026-08-15"
+    },
+    {
+      "id": 1117931,
+      "ghsa": "GHSA-8h8q-6873-q5fj",
+      "package": "next",
+      "severity": "high",
+      "reason": "Next.js DoS with Server Components (second advisory, same class). Vulnerable range >=13.0.0 <15.5.16. Fix requires Next 15.x (deferred). Not reachable: same justification as 1116376.",
+      "added": "2026-05-15",
+      "review": "2026-08-15"
+    },
+    {
+      "id": 1118954,
+      "ghsa": "GHSA-c4j6-fc7j-m34r",
+      "package": "next",
+      "severity": "high",
+      "reason": "Next.js SSRF via WebSocket upgrades. Vulnerable range >=13.4.13 <15.5.16. Fix requires Next 15.x (deferred). Not reachable: no Next runtime server in Pearl, so no WebSocket upgrade path exists. Electron uses its own session/protocol handler, not Next's HTTP layer.",
+      "added": "2026-05-15",
+      "review": "2026-08-15"
+    },
+    {
+      "id": 1118962,
+      "ghsa": "GHSA-36qx-fr4f-26g5",
+      "package": "next",
+      "severity": "high",
+      "reason": "Next.js Pages Router middleware / i18n proxy bypass. Vulnerable range >=12.2.0 <15.5.16. Fix requires Next 15.x (deferred). Not reachable: Pearl has no middleware.ts and no i18n routing in next.config.mjs — the bypass path doesn't exist in the tree.",
+      "added": "2026-05-15",
+      "review": "2026-08-15"
+    }
+  ]
 }

--- a/.supply-chain/audit-allowlist.json
+++ b/.supply-chain/audit-allowlist.json
@@ -1,0 +1,14 @@
+{
+  "_doc": "Allowlist for yarn audit high/critical advisories in the ROOT tree that cannot be fixed in the current branch. Every entry needs a reason and a review date. See SUPPLY-CHAIN-SECURITY.md (added in Phase 4) and CONTRIBUTING.md ('Supply-chain checks').",
+  "_keep_when_empty": "Do NOT delete this file when entries: [] is empty. The empty file is the running assertion of 'audit gate exists AND zero current debt' — it pre-paves the schema for the next suppression, preserves git history of past suppressions, keeps the CODEOWNERS-routed surface, and lets the cross-repo tracker distinguish 'clean gate' (count=0) from 'wrapper pattern not in use' (no file at all). Burn down ENTRIES; keep the FILE.",
+  "_fields": {
+    "id": "npm advisory numeric ID (from `yarn audit --json` advisory.id) — REQUIRED, used for matching",
+    "ghsa": "GitHub Security Advisory ID (e.g., GHSA-xxxx-xxxx-xxxx) — for humans, not used for matching",
+    "package": "package name — for humans",
+    "severity": "advisory severity (high|critical) — for humans",
+    "reason": "why the advisory is allowlisted — upstream has no fix, major-version bump deferred, not on a reachable code path, etc.",
+    "added": "YYYY-MM-DD when the entry was added — REQUIRED",
+    "review": "YYYY-MM-DD by which the entry must be re-evaluated — REQUIRED. An expired entry prints a CI warning but does not fail the job."
+  },
+  "entries": []
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,9 +117,34 @@ Types:
   ```
 2. **Test on multiple platforms** if applicable
 
-### Supply-chain checks — install-hook gate
+### Supply-chain checks
 
-CI maintains a per-tree allowlist of every dependency that declares a non-trivial `preinstall` / `install` / `postinstall` script. Adding a new dependency — or bumping an existing one to a version whose maintainer introduced a new install hook — will trip the gate until the new package is reviewed and added to the allowlist.
+Two CI gates protect the dep tree. Both run on every PR; both block merge.
+
+#### Audit gate — high/critical CVE detection
+
+A blocking `yarn audit` gate runs against both `package.json` trees (root and `frontend/`). Adding a new dependency or bumping an existing one will trip the gate if the change pulls in (directly or transitively) a known high- or critical-severity npm advisory. To clear the gate, in order of preference:
+
+1. **Wait for the upstream fix.** If a patched version exists, bump the offending direct dep — or add an exact-version `resolutions` entry if it's only reachable transitively. This is always the right first answer.
+2. **Bump to a fixed version.** Update `package.json` (with an exact pin) so the resolved version sits in the `patched_versions` range from the advisory.
+3. **Pin a transitive via Yarn `resolutions`.** Add the safe version to `resolutions` in the affected tree's `package.json`.
+4. **Allowlist the advisory.** Only when the above are infeasible. Add an entry to `.supply-chain/audit-allowlist.json` (root) or `frontend/.supply-chain/audit-allowlist.json` (frontend). Every entry requires `id`, `reason`, `added` (YYYY-MM-DD), and `review` (YYYY-MM-DD, 90 days out from `added`). Expired `review` dates emit a `::warning::` in CI but don't fail the job — they're your reminder to re-justify.
+
+To reproduce CI behaviour locally:
+
+```bash
+# Root tree
+yarn audit:prod
+
+# Frontend tree
+cd frontend && yarn audit:prod
+```
+
+Both calls share the same wrapper (`scripts/audit.mjs` is duplicated under `frontend/scripts/audit.mjs` so each tree can be audited from its own working directory). Each consults the allowlist sitting next to it.
+
+#### Install-hook gate — new postinstall detection
+
+A separate per-tree allowlist tracks every dependency that declares a non-trivial `preinstall` / `install` / `postinstall` script. Adding a new dependency — or bumping an existing one to a version whose maintainer introduced a new install hook — will trip the gate until the new package is reviewed and added to the allowlist.
 
 This is distinct from `.npmrc`'s `ignore-scripts=true` (which *prevents execution*); the install-hook gate *detects new additions* so a transitive package quietly gaining a `postinstall` in its latest version fails CI rather than running silently on a contributor machine.
 

--- a/frontend/.supply-chain/audit-allowlist.json
+++ b/frontend/.supply-chain/audit-allowlist.json
@@ -10,5 +10,52 @@
     "added": "YYYY-MM-DD when the entry was added — REQUIRED",
     "review": "YYYY-MM-DD by which the entry must be re-evaluated — REQUIRED. An expired entry prints a CI warning but does not fail the job."
   },
-  "entries": []
+  "_residual_group_doc": "All five entries below are Next.js 14.x advisories cleared from PR #1961 (Phase 0). Fix versions require Next 15.0.8+ / 15.5.15+ / 15.5.16+; a 14 → 15 migration is a dedicated separate PR. Justification for allowlisting rather than bumping: Pearl runs Next.js as a build-time static React bundler. Electron serves frontend/.next as static HTML/JS via its protocol handler — no Next runtime server, no API routes (frontend/pages/api/ does not exist), no getServerSideProps, no middleware.ts. Therefore RSC DoS, WebSocket SSRF, and middleware/i18n bypass cannot fire on Pearl's actual runtime path. If Pearl ever grows server-side Next code (an API route, getServerSideProps, or middleware), re-evaluate every entry below — the 'not reachable' premise becomes false the moment any of those exist.",
+  "entries": [
+    {
+      "id": 1112653,
+      "ghsa": "GHSA-h25m-26qc-wcjf",
+      "package": "next",
+      "severity": "high",
+      "reason": "Next.js HTTP request deserialization can lead to DoS when using insecure React Server Components. Vulnerable range >=13.0.0 <15.0.8. Fix requires Next 15.x major bump (deferred to dedicated migration PR). Not reachable: Pearl has no RSC components — frontend/.next is static-bundled and served by Electron's protocol handler, not by Next's server.",
+      "added": "2026-05-15",
+      "review": "2026-08-15"
+    },
+    {
+      "id": 1116376,
+      "ghsa": "GHSA-q4gf-8mx6-v5v3",
+      "package": "next",
+      "severity": "high",
+      "reason": "Next.js DoS with Server Components. Vulnerable range >=13.0.0 <15.5.15. Fix requires Next 15.x (deferred). Not reachable: Pearl has no Server Components — static-bundled only.",
+      "added": "2026-05-15",
+      "review": "2026-08-15"
+    },
+    {
+      "id": 1117931,
+      "ghsa": "GHSA-8h8q-6873-q5fj",
+      "package": "next",
+      "severity": "high",
+      "reason": "Next.js DoS with Server Components (second advisory, same class). Vulnerable range >=13.0.0 <15.5.16. Fix requires Next 15.x (deferred). Not reachable: same justification as 1116376.",
+      "added": "2026-05-15",
+      "review": "2026-08-15"
+    },
+    {
+      "id": 1118954,
+      "ghsa": "GHSA-c4j6-fc7j-m34r",
+      "package": "next",
+      "severity": "high",
+      "reason": "Next.js SSRF via WebSocket upgrades. Vulnerable range >=13.4.13 <15.5.16. Fix requires Next 15.x (deferred). Not reachable: no Next runtime server in Pearl, so no WebSocket upgrade path exists. Electron uses its own session/protocol handler, not Next's HTTP layer.",
+      "added": "2026-05-15",
+      "review": "2026-08-15"
+    },
+    {
+      "id": 1118962,
+      "ghsa": "GHSA-36qx-fr4f-26g5",
+      "package": "next",
+      "severity": "high",
+      "reason": "Next.js Pages Router middleware / i18n proxy bypass. Vulnerable range >=12.2.0 <15.5.16. Fix requires Next 15.x (deferred). Not reachable: Pearl has no middleware.ts and no i18n routing in next.config.mjs — the bypass path doesn't exist in the tree.",
+      "added": "2026-05-15",
+      "review": "2026-08-15"
+    }
+  ]
 }

--- a/frontend/.supply-chain/audit-allowlist.json
+++ b/frontend/.supply-chain/audit-allowlist.json
@@ -1,0 +1,14 @@
+{
+  "_doc": "Allowlist for yarn audit high/critical advisories in the FRONTEND tree that cannot be fixed in the current branch. Every entry needs a reason and a review date. See SUPPLY-CHAIN-SECURITY.md (added in Phase 4) and CONTRIBUTING.md ('Supply-chain checks').",
+  "_keep_when_empty": "Do NOT delete this file when entries: [] is empty. The empty file is the running assertion of 'audit gate exists AND zero current debt' — it pre-paves the schema for the next suppression, preserves git history of past suppressions, keeps the CODEOWNERS-routed surface, and lets the cross-repo tracker distinguish 'clean gate' (count=0) from 'wrapper pattern not in use' (no file at all). Burn down ENTRIES; keep the FILE.",
+  "_fields": {
+    "id": "npm advisory numeric ID (from `yarn audit --json` advisory.id) — REQUIRED, used for matching",
+    "ghsa": "GitHub Security Advisory ID (e.g., GHSA-xxxx-xxxx-xxxx) — for humans, not used for matching",
+    "package": "package name — for humans",
+    "severity": "advisory severity (high|critical) — for humans",
+    "reason": "why the advisory is allowlisted — upstream has no fix, major-version bump deferred, not on a reachable code path, etc.",
+    "added": "YYYY-MM-DD when the entry was added — REQUIRED",
+    "review": "YYYY-MM-DD by which the entry must be re-evaluated — REQUIRED. An expired entry prints a CI warning but does not fail the job."
+  },
+  "entries": []
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,6 +67,7 @@
   "scripts": {
     "audit:install-hooks": "node scripts/audit-install-hooks.mjs",
     "audit:install-hooks:update": "node scripts/audit-install-hooks.mjs --update",
+    "audit:prod": "node scripts/audit.mjs",
     "dev": "next dev",
     "deps:check-pinned": "node ../scripts/check-deps-pinned.mjs",
     "build": "bash -c \"GNOSIS_RPC=$GNOSIS_RPC BASE_RPC=$BASE_RPC OPTIMISM_RPC=$OPTIMISM_RPC ETHEREUM_RPC=$ETHEREUM_RPC MODE_RPC=$MODE_RPC CELO_RPC=$CELO_RPC POLYGON_RPC=$POLYGON_RPC NODE_ENV=production next build\"",

--- a/frontend/scripts/audit.mjs
+++ b/frontend/scripts/audit.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+/**
+ * Run `yarn audit --groups dependencies` and fail on high/critical
+ * advisories in the production tree — unless the advisory is listed in
+ * .supply-chain/audit-allowlist.json with a reason and review date.
+ *
+ * Necessary because the stock Yarn 1.x `yarn audit` has no suppression
+ * mechanism and its exit code is a severity bitmask, not a threshold —
+ * a `--level high` filter changes printed output but NOT exit code.
+ *
+ * See SUPPLY-CHAIN-SECURITY.md (to be added in Phase 4) and
+ * CONTRIBUTING.md ("Supply-chain checks") for the contributor workflow.
+ *
+ * Wrapper is duplicated under scripts/audit.mjs — keep the two files in
+ * sync. Each reads its own tree's .supply-chain/audit-allowlist.json.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { resolve } from 'node:path';
+
+const ROOT = resolve('.');
+const ALLOWLIST_PATH = resolve(ROOT, '.supply-chain/audit-allowlist.json');
+
+function loadAllowlist() {
+  if (!existsSync(ALLOWLIST_PATH)) return { entries: [] };
+  let data;
+  try {
+    data = JSON.parse(readFileSync(ALLOWLIST_PATH, 'utf8'));
+  } catch (err) {
+    console.error(`::error::failed to parse ${ALLOWLIST_PATH}: ${err.message}`);
+    process.exit(2);
+  }
+  for (const entry of data.entries || []) {
+    const errors = [];
+    if (typeof entry.id !== 'number') errors.push('`id` must be a number');
+    if (typeof entry.reason !== 'string' || !entry.reason.trim()) errors.push('`reason` is required');
+    if (typeof entry.added !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(entry.added)) {
+      errors.push('`added` must be YYYY-MM-DD');
+    }
+    if (typeof entry.review !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(entry.review)) {
+      errors.push('`review` must be YYYY-MM-DD');
+    }
+    if (errors.length) {
+      console.error(`::error::malformed entry in ${ALLOWLIST_PATH}: ${errors.join('; ')} — ${JSON.stringify(entry)}`);
+      process.exit(2);
+    }
+  }
+  return data;
+}
+
+function runYarnAudit() {
+  return new Promise((resolvePromise) => {
+    // `shell: true` is required on Windows so the `yarn.cmd` shim in
+    // PATH resolves; harmless on Linux/macOS runners where `yarn` is a
+    // plain executable.
+    const child = spawn('yarn', ['audit', '--groups', 'dependencies', '--json'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: true,
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => (stdout += d));
+    child.stderr.on('data', (d) => (stderr += d));
+    child.on('close', (code) => resolvePromise({ stdout, stderr, code }));
+  });
+}
+
+function parseAdvisories(stdout) {
+  const advisories = new Map();
+  for (const line of stdout.split('\n')) {
+    if (!line.trim()) continue;
+    let row;
+    try {
+      row = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (row.type !== 'auditAdvisory') continue;
+    const a = row.data.advisory;
+    const key = a.id;
+    if (!advisories.has(key)) advisories.set(key, { advisory: a, paths: new Set() });
+    advisories.get(key).paths.add(row.data.resolution.path);
+  }
+  return [...advisories.values()];
+}
+
+const allowlist = loadAllowlist();
+const allowed = new Map();
+for (const entry of allowlist.entries || []) {
+  if (typeof entry.id !== 'number') continue;
+  allowed.set(entry.id, entry);
+}
+
+const { stdout, stderr } = await runYarnAudit();
+
+// Yarn 1.x exits non-zero even on success when advisories exist; we
+// don't gate on exit code — we parse the JSON and apply our own gate.
+if (!stdout) {
+  console.error('::error::`yarn audit` produced no output.');
+  if (stderr) console.error(stderr);
+  process.exit(2);
+}
+
+const advisories = parseAdvisories(stdout);
+
+const blocking = [];
+const suppressed = [];
+const expired = [];
+const stale = [];
+
+const today = new Date().toISOString().slice(0, 10);
+
+for (const { advisory, paths } of advisories) {
+  const sev = advisory.severity;
+  if (sev !== 'high' && sev !== 'critical') continue;
+  const entry = allowed.get(advisory.id);
+  if (!entry) {
+    blocking.push({ advisory, paths });
+    continue;
+  }
+  suppressed.push({ advisory, paths, entry });
+  if (entry.review && entry.review < today) {
+    expired.push({ advisory, entry });
+  }
+}
+
+// Entries allowlisted but no longer suppressing a high/critical advisory — drift.
+// Compare against the *suppressed* set, not the full advisory list: an advisory
+// whose severity has dropped below high/critical still appears in `advisories`,
+// but the allowlist entry is no longer doing any work.
+const suppressedIds = new Set(suppressed.map(({ advisory }) => advisory.id));
+for (const entry of allowlist.entries || []) {
+  if (!suppressedIds.has(entry.id)) {
+    stale.push(entry);
+  }
+}
+
+if (suppressed.length > 0) {
+  console.log(`Allowlisted (${suppressed.length}):`);
+  for (const { advisory, paths, entry } of suppressed) {
+    console.log(`  [${advisory.severity}] ${advisory.module_name} ${advisory.vulnerable_versions}`);
+    console.log(`    advisory ${advisory.id} (${advisory.github_advisory_id || 'no GHSA'})`);
+    console.log(`    ${paths.size} path(s). reason: ${entry.reason}`);
+    console.log(`    added ${entry.added}, review by ${entry.review}`);
+  }
+  console.log('');
+}
+
+for (const { advisory, entry } of expired) {
+  console.log(
+    `::warning::Allowlist entry for advisory ${advisory.id} (${advisory.module_name}) expired on ${entry.review}. Review and either update the review date with fresh justification, or remove if a fix is available.`,
+  );
+}
+
+for (const entry of stale) {
+  console.log(
+    `::warning::Allowlist entry ${entry.id} (${entry.package}) is no longer in the production tree. Remove it from .supply-chain/audit-allowlist.json.`,
+  );
+}
+
+if (blocking.length > 0) {
+  console.error('');
+  console.error(`::error::${blocking.length} HIGH/CRITICAL advisory/advisories in the production tree are not allowlisted:`);
+  for (const { advisory, paths } of blocking) {
+    console.error(`  [${advisory.severity}] ${advisory.module_name} ${advisory.vulnerable_versions} → fix in ${advisory.patched_versions}`);
+    console.error(`    advisory ${advisory.id} (${advisory.github_advisory_id || 'no GHSA'})`);
+    console.error(`    ${advisory.title}`);
+    console.error(`    ${paths.size} path(s), e.g. ${[...paths][0]}`);
+    console.error(`    fix: bump the dep, add a Yarn resolution, or allowlist in .supply-chain/audit-allowlist.json with a reason + review date.`);
+    console.error('');
+  }
+  process.exit(1);
+}
+
+console.log(`yarn audit: OK (${suppressed.length} allowlisted, no unlisted high/critical).`);
+process.exit(0);

--- a/frontend/scripts/audit.mjs
+++ b/frontend/scripts/audit.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 /**
  * Run `yarn audit --groups dependencies` and fail on high/critical
- * advisories in the production tree — unless the advisory is listed in
- * .supply-chain/audit-allowlist.json with a reason and review date.
+ * advisories in the production dependencies — unless the advisory is
+ * listed in .supply-chain/audit-allowlist.json with a reason and
+ * review date.
  *
  * Necessary because the stock Yarn 1.x `yarn audit` has no suppression
  * mechanism and its exit code is a severity bitmask, not a threshold —
@@ -49,6 +50,11 @@ function loadAllowlist() {
   return data;
 }
 
+// Bound the subprocess so a hung npm registry can't pin the CI job at
+// the workflow-level timeout. 5 min is well above the typical 30s yarn
+// audit while still failing fast on a registry outage.
+const AUDIT_TIMEOUT_MS = 5 * 60 * 1000;
+
 function runYarnAudit() {
   return new Promise((resolvePromise) => {
     // `shell: true` is required on Windows so the `yarn.cmd` shim in
@@ -60,9 +66,21 @@ function runYarnAudit() {
     });
     let stdout = '';
     let stderr = '';
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGKILL');
+    }, AUDIT_TIMEOUT_MS);
     child.stdout.on('data', (d) => (stdout += d));
     child.stderr.on('data', (d) => (stderr += d));
-    child.on('close', (code) => resolvePromise({ stdout, stderr, code }));
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      if (timedOut) {
+        console.error(`::error::yarn audit timed out after ${AUDIT_TIMEOUT_MS / 1000}s (npm registry likely unresponsive).`);
+        process.exit(2);
+      }
+      resolvePromise({ stdout, stderr, code });
+    });
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
   "scripts": {
     "audit:install-hooks": "node scripts/audit-install-hooks.mjs",
     "audit:install-hooks:update": "node scripts/audit-install-hooks.mjs --update",
+    "audit:prod": "node scripts/audit.mjs",
     "build:frontend": "cd frontend && yarn build && rm -rf ../electron/.next && cp -r .next ../electron/.next && rm -rf ../electron/public && cp -r public ../electron/public",
     "deps:check-pinned": "node scripts/check-deps-pinned.mjs",
     "build:pearl": "sh build_pearl.sh",

--- a/scripts/audit.mjs
+++ b/scripts/audit.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+/**
+ * Run `yarn audit --groups dependencies` and fail on high/critical
+ * advisories in the production tree — unless the advisory is listed in
+ * .supply-chain/audit-allowlist.json with a reason and review date.
+ *
+ * Necessary because the stock Yarn 1.x `yarn audit` has no suppression
+ * mechanism and its exit code is a severity bitmask, not a threshold —
+ * a `--level high` filter changes printed output but NOT exit code.
+ *
+ * See SUPPLY-CHAIN-SECURITY.md (to be added in Phase 4) and
+ * CONTRIBUTING.md ("Supply-chain checks") for the contributor workflow.
+ *
+ * Wrapper is duplicated under frontend/scripts/audit.mjs — keep the two
+ * files in sync. Each reads its own tree's .supply-chain/audit-allowlist.json.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { resolve } from 'node:path';
+
+const ROOT = resolve('.');
+const ALLOWLIST_PATH = resolve(ROOT, '.supply-chain/audit-allowlist.json');
+
+function loadAllowlist() {
+  if (!existsSync(ALLOWLIST_PATH)) return { entries: [] };
+  let data;
+  try {
+    data = JSON.parse(readFileSync(ALLOWLIST_PATH, 'utf8'));
+  } catch (err) {
+    console.error(`::error::failed to parse ${ALLOWLIST_PATH}: ${err.message}`);
+    process.exit(2);
+  }
+  for (const entry of data.entries || []) {
+    const errors = [];
+    if (typeof entry.id !== 'number') errors.push('`id` must be a number');
+    if (typeof entry.reason !== 'string' || !entry.reason.trim()) errors.push('`reason` is required');
+    if (typeof entry.added !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(entry.added)) {
+      errors.push('`added` must be YYYY-MM-DD');
+    }
+    if (typeof entry.review !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(entry.review)) {
+      errors.push('`review` must be YYYY-MM-DD');
+    }
+    if (errors.length) {
+      console.error(`::error::malformed entry in ${ALLOWLIST_PATH}: ${errors.join('; ')} — ${JSON.stringify(entry)}`);
+      process.exit(2);
+    }
+  }
+  return data;
+}
+
+function runYarnAudit() {
+  return new Promise((resolvePromise) => {
+    // `shell: true` is required on Windows so the `yarn.cmd` shim in
+    // PATH resolves; harmless on Linux/macOS runners where `yarn` is a
+    // plain executable.
+    const child = spawn('yarn', ['audit', '--groups', 'dependencies', '--json'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: true,
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => (stdout += d));
+    child.stderr.on('data', (d) => (stderr += d));
+    child.on('close', (code) => resolvePromise({ stdout, stderr, code }));
+  });
+}
+
+function parseAdvisories(stdout) {
+  const advisories = new Map();
+  for (const line of stdout.split('\n')) {
+    if (!line.trim()) continue;
+    let row;
+    try {
+      row = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (row.type !== 'auditAdvisory') continue;
+    const a = row.data.advisory;
+    const key = a.id;
+    if (!advisories.has(key)) advisories.set(key, { advisory: a, paths: new Set() });
+    advisories.get(key).paths.add(row.data.resolution.path);
+  }
+  return [...advisories.values()];
+}
+
+const allowlist = loadAllowlist();
+const allowed = new Map();
+for (const entry of allowlist.entries || []) {
+  if (typeof entry.id !== 'number') continue;
+  allowed.set(entry.id, entry);
+}
+
+const { stdout, stderr } = await runYarnAudit();
+
+// Yarn 1.x exits non-zero even on success when advisories exist; we
+// don't gate on exit code — we parse the JSON and apply our own gate.
+if (!stdout) {
+  console.error('::error::`yarn audit` produced no output.');
+  if (stderr) console.error(stderr);
+  process.exit(2);
+}
+
+const advisories = parseAdvisories(stdout);
+
+const blocking = [];
+const suppressed = [];
+const expired = [];
+const stale = [];
+
+const today = new Date().toISOString().slice(0, 10);
+
+for (const { advisory, paths } of advisories) {
+  const sev = advisory.severity;
+  if (sev !== 'high' && sev !== 'critical') continue;
+  const entry = allowed.get(advisory.id);
+  if (!entry) {
+    blocking.push({ advisory, paths });
+    continue;
+  }
+  suppressed.push({ advisory, paths, entry });
+  if (entry.review && entry.review < today) {
+    expired.push({ advisory, entry });
+  }
+}
+
+// Entries allowlisted but no longer suppressing a high/critical advisory — drift.
+// Compare against the *suppressed* set, not the full advisory list: an advisory
+// whose severity has dropped below high/critical still appears in `advisories`,
+// but the allowlist entry is no longer doing any work.
+const suppressedIds = new Set(suppressed.map(({ advisory }) => advisory.id));
+for (const entry of allowlist.entries || []) {
+  if (!suppressedIds.has(entry.id)) {
+    stale.push(entry);
+  }
+}
+
+if (suppressed.length > 0) {
+  console.log(`Allowlisted (${suppressed.length}):`);
+  for (const { advisory, paths, entry } of suppressed) {
+    console.log(`  [${advisory.severity}] ${advisory.module_name} ${advisory.vulnerable_versions}`);
+    console.log(`    advisory ${advisory.id} (${advisory.github_advisory_id || 'no GHSA'})`);
+    console.log(`    ${paths.size} path(s). reason: ${entry.reason}`);
+    console.log(`    added ${entry.added}, review by ${entry.review}`);
+  }
+  console.log('');
+}
+
+for (const { advisory, entry } of expired) {
+  console.log(
+    `::warning::Allowlist entry for advisory ${advisory.id} (${advisory.module_name}) expired on ${entry.review}. Review and either update the review date with fresh justification, or remove if a fix is available.`,
+  );
+}
+
+for (const entry of stale) {
+  console.log(
+    `::warning::Allowlist entry ${entry.id} (${entry.package}) is no longer in the production tree. Remove it from .supply-chain/audit-allowlist.json.`,
+  );
+}
+
+if (blocking.length > 0) {
+  console.error('');
+  console.error(`::error::${blocking.length} HIGH/CRITICAL advisory/advisories in the production tree are not allowlisted:`);
+  for (const { advisory, paths } of blocking) {
+    console.error(`  [${advisory.severity}] ${advisory.module_name} ${advisory.vulnerable_versions} → fix in ${advisory.patched_versions}`);
+    console.error(`    advisory ${advisory.id} (${advisory.github_advisory_id || 'no GHSA'})`);
+    console.error(`    ${advisory.title}`);
+    console.error(`    ${paths.size} path(s), e.g. ${[...paths][0]}`);
+    console.error(`    fix: bump the dep, add a Yarn resolution, or allowlist in .supply-chain/audit-allowlist.json with a reason + review date.`);
+    console.error('');
+  }
+  process.exit(1);
+}
+
+console.log(`yarn audit: OK (${suppressed.length} allowlisted, no unlisted high/critical).`);
+process.exit(0);

--- a/scripts/audit.mjs
+++ b/scripts/audit.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 /**
  * Run `yarn audit --groups dependencies` and fail on high/critical
- * advisories in the production tree — unless the advisory is listed in
- * .supply-chain/audit-allowlist.json with a reason and review date.
+ * advisories in the production dependencies — unless the advisory is
+ * listed in .supply-chain/audit-allowlist.json with a reason and
+ * review date.
  *
  * Necessary because the stock Yarn 1.x `yarn audit` has no suppression
  * mechanism and its exit code is a severity bitmask, not a threshold —
@@ -49,6 +50,11 @@ function loadAllowlist() {
   return data;
 }
 
+// Bound the subprocess so a hung npm registry can't pin the CI job at
+// the workflow-level timeout. 5 min is well above the typical 30s yarn
+// audit while still failing fast on a registry outage.
+const AUDIT_TIMEOUT_MS = 5 * 60 * 1000;
+
 function runYarnAudit() {
   return new Promise((resolvePromise) => {
     // `shell: true` is required on Windows so the `yarn.cmd` shim in
@@ -60,9 +66,21 @@ function runYarnAudit() {
     });
     let stdout = '';
     let stderr = '';
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGKILL');
+    }, AUDIT_TIMEOUT_MS);
     child.stdout.on('data', (d) => (stdout += d));
     child.stderr.on('data', (d) => (stderr += d));
-    child.on('close', (code) => resolvePromise({ stdout, stderr, code }));
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      if (timedOut) {
+        console.error(`::error::yarn audit timed out after ${AUDIT_TIMEOUT_MS / 1000}s (npm registry likely unresponsive).`);
+        process.exit(2);
+      }
+      resolvePromise({ stdout, stderr, code });
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

Implements **Phase 2.1** of [.plans/supply-chain-update.md](.plans/supply-chain-update.md) — adds a custom Yarn 1.x audit gate to CI that parses `yarn audit --json` directly and applies its own high/critical threshold. Replaces the *non-existent* `yarn audit` integration (Phase 1 left the rubric at 11/15 — this PR closes marker #7).

Built on the same wrapper pattern already shipped at [valory-xyz/agents-fun PR #48](https://github.com/valory-xyz/agents-fun/pull/48) and documented in [`ci-yarn1-patterns.md` Patterns 2–3](https://github.com/valory-xyz/personal-skills/blob/main/.claude/skills/supply-chain-audit/references/ci-yarn1-patterns.md). PR 3 (install-hook gate) will follow the same shape.

## Why a custom wrapper

Stock `yarn audit` has three quiet landmines that defeat a naive gate:

1. **Exit code is a severity bitmask, not a threshold.** `yarn audit --level high` filters *printed output* but does NOT change the exit code. A "blocking" gate that trusts the exit code alone lets a critical past silently. This shipped to production once at Valory before this pattern was established.
2. **No native suppression.** A single unfixable transitive advisory blocks every PR forever unless we can carve out an explicit exception with justification + a review date.
3. **A `package.json` script named `audit` is silently shadowed by the built-in `yarn audit` command.** Must be `audit:prod`.

The wrapper exits on parsed severity (explicit code, not bitmask), validates the allowlist schema on load, and warns — but doesn't fail — on stale or expired-review-date entries so drift surfaces in PR annotations without breaking CI.

## What's in this PR

| File | Status | Purpose |
|------|--------|---------|
| `scripts/audit.mjs` | new (177 LOC) | Audit wrapper for the root tree |
| `frontend/scripts/audit.mjs` | new (177 LOC) | Same wrapper, frontend tree |
| `.supply-chain/audit-allowlist.json` | new | Empty allowlist + schema doc, root tree |
| `frontend/.supply-chain/audit-allowlist.json` | new | Same, frontend tree |
| `package.json` | modified | Added `"audit:prod": "node scripts/audit.mjs"` |
| `frontend/package.json` | modified | Added `"audit:prod": "node scripts/audit.mjs"` |
| `.github/workflows/ci.yml` | modified | New `audit` job (corepack + verify yarn + no install + two `yarn audit:prod` steps); added to `all-checks-passed` `needs:` |
| `CONTRIBUTING.md` | modified | New "Supply-chain checks" subsection — 4 resolution paths + local repro commands |

**The two `scripts/audit.mjs` files are byte-identical except for one cross-reference comment** so reviewers can `diff` them once and trust the rest. We deliberately picked Option A (duplicated wrapper, per-tree allowlist) over Option B (single wrapper + `--cwd` flag) because each tree's `yarn.lock` carries an independent transitive surface anyway — sharing the wrapper saves ~200 LOC but couples the two audit surfaces in a way the plan explicitly argues against (§2.1).

## CI job follows Pattern 3 — no `yarn install`

`yarn audit` reads `yarn.lock` directly. Skipping install means a compromised `postinstall` in the production tree cannot execute inside the audit job specifically. Defense in depth at the workflow level. (PR 3's install-hook job will install with `--ignore-scripts` for the same reason from the opposite angle.)

## ⚠️ Gate is currently RED — needs Phase 0 first

This PR ships the **gate**; clearing the **dirty tree** is Phase 0's job. Tested locally against the live npm advisory DB:

| Tree | Unique high+critical |
|------|---------------------|
| root | 19 (all `high`) |
| frontend | 25 (24 `high` + 1 `critical` — handlebars 1115539) |

Top offenders (each clears multiple advisories):
- **`next` 14.2.35** — clears 5 advisories in frontend, 5 in root. Highest leverage single bump.
- **`node-forge` 1.3.1** — clears 6 root advisories (transitive via `electron-builder` and `electron/utils/certificate.js`).
- **`undici` 7.15.0** — clears 3 root advisories.
- **`handlebars` 4.7.x** — clears 5 frontend advisories (the lone `critical` lives here, deep under `antd > dayjs > semantic-release > … > handlebars` — `resolutions` pin).
- **`tar`, `minimatch`, `picomatch`, `lodash`, `fast-uri`, `immutable`, `lodash-es`, `glob`** — all transitives, `resolutions`-pin candidates.

**Phase 0 lands as a separate PR onto `supply-chain` before this PR merges.** The plan ([§ Phase 0](.plans/supply-chain-update.md)) explicitly anticipated this sequencing — don't bulk-allowlist criticals to "make CI green" because that normalizes ignoring them.

## Test plan

- [ ] Phase 0 PR (#1961) lands on `supply-chain` first, clearing the 44 high/critical advisories down to 10 documented Next.js residuals. *(Open, CI green, awaiting review.)*
- [ ] After rebase onto cleaned `supply-chain` + populating the allowlist with the 5 Next.js IDs per tree: `audit` job goes green in CI. *(Blocked until #1961 merges. Follow-up commit will land here.)*
- [x] Smoke-test failure mode: the gate IS firing on this PR right now against the unfixed advisories — 19 in root, 25 in frontend, exit code 1 in both wrappers. CI's `yarn audit (both trees)` job is RED for exactly this reason. No sandbox dep needed; the natural state of the tree pre-Phase 0 IS the failure mode.
- [x] Confirm CI `all-checks-passed` now requires the `audit` job. Verified two ways: `.github/workflows/ci.yml` line 230 lists `audit` in `needs:`, and live CI on this PR shows "All checks passed" failing precisely because `yarn audit (both trees)` failed.
- [ ] Local repro: `yarn audit:prod` and `cd frontend && yarn audit:prod` both succeed once Phase 0 is in **and** the 5 Next.js advisories per tree are allowlisted. *(Blocked until #1961 merges + allowlist follow-up lands.)*
- [x] CONTRIBUTING.md "Supply-chain checks" section reads sensibly to a new contributor. Reviewed in place: 4 resolution paths in priority order, local repro commands, schema explanation, wrapper-duplication rationale.

## Out of scope (deferred)

- **Phase 0 (CVE burn-down)** — separate PR, lands first.
- **Phase 3 (install-hook gate)** — separate PR (also onto `supply-chain`), same wrapper shape.
- **Test suite for `audit.mjs`** — same deferred follow-up as `check-deps-pinned.mjs` from PR #1954.
- **Branch protection toggle** — admin step, not a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
