### PR TITLE
chore(supply-chain): fix 28 high/critical CVEs

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,15 @@
 {
   "author": "Valory AG",
+  "resolutions": {
+    "glob": "10.5.0",
+    "handlebars": "4.7.9",
+    "immutable": "5.1.5",
+    "lodash": "4.18.1",
+    "lodash-es": "4.18.1",
+    "minimatch": "9.0.9",
+    "picomatch": "4.0.4",
+    "tar": "7.5.15"
+  },
   "dependencies": {
     "@ant-design/cssinjs": "1.24.0",
     "@ant-design/icons": "5.6.1",
@@ -12,7 +22,7 @@
     "framer-motion": "11.18.2",
     "graphql": "16.11.0",
     "graphql-request": "6.1.0",
-    "lodash": "4.17.21",
+    "lodash": "4.18.1",
     "lottie-react": "2.4.1",
     "next": "14.2.35",
     "react": "18.3.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2869,18 +2869,10 @@ bottleneck@^2.15.3:
   resolved "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz"
   integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
 
-brace-expansion@^1.1.7:
-  version "1.1.12"
-  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz"
-  integrity sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==
-  dependencies:
-    balanced-match "^1.0.0"
-    concat-map "0.0.1"
-
-brace-expansion@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz"
-  integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
+brace-expansion@^2.0.2:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz#4f41a41190216ee36067ec381526fe9539c4f0ae"
+  integrity sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==
   dependencies:
     balanced-match "^1.0.0"
 
@@ -3032,11 +3024,6 @@ chokidar@^4.0.0:
   integrity sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==
   dependencies:
     readdirp "^4.0.1"
-
-chownr@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz"
-  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
 chownr@^3.0.0:
   version "3.0.0"
@@ -3197,11 +3184,6 @@ compute-scroll-into-view@^3.0.2:
   version "3.1.1"
   resolved "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz"
   integrity sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==
-
-concat-map@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
 config-chain@^1.1.11:
   version "1.1.13"
@@ -4427,24 +4409,12 @@ fs-extra@^11.0.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-minipass@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
-  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
-  dependencies:
-    minipass "^3.0.0"
-
 fs-minipass@^3.0.0, fs-minipass@^3.0.3:
   version "3.0.3"
   resolved "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz"
   integrity sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==
   dependencies:
     minipass "^7.0.3"
-
-fs.realpath@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-  integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
 fsevents@^2.3.2:
   version "2.3.3"
@@ -4582,21 +4552,10 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob@10.3.10:
-  version "10.3.10"
-  resolved "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz"
-  integrity sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==
-  dependencies:
-    foreground-child "^3.1.0"
-    jackspeak "^2.3.5"
-    minimatch "^9.0.1"
-    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
-    path-scurry "^1.10.1"
-
-glob@^10.2.2, glob@^10.4.5:
-  version "10.4.5"
-  resolved "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz"
-  integrity sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==
+glob@10.3.10, glob@10.5.0, glob@^10.2.2, glob@^10.4.5, glob@^7.1.3, glob@^7.1.4:
+  version "10.5.0"
+  resolved "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz#8ec0355919cd3338c28428a23d4f24ecc5fe738c"
+  integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
   dependencies:
     foreground-child "^3.1.0"
     jackspeak "^3.1.2"
@@ -4604,18 +4563,6 @@ glob@^10.2.2, glob@^10.4.5:
     minipass "^7.1.2"
     package-json-from-dist "^1.0.0"
     path-scurry "^1.11.1"
-
-glob@^7.1.3, glob@^7.1.4:
-  version "7.2.3"
-  resolved "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz"
-  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.1.1"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
 
 globals@^13.19.0:
   version "13.24.0"
@@ -4689,10 +4636,10 @@ graphql@16.11.0:
   resolved "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz#96d17f66370678027fdf59b2d4c20b4efaa8a633"
   integrity sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==
 
-handlebars@^4.7.7:
-  version "4.7.8"
-  resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz"
-  integrity sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==
+handlebars@4.7.9, handlebars@^4.7.7:
+  version "4.7.9"
+  resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz#6f139082ab58dc4e5a0e51efe7db5ae890d56a0f"
+  integrity sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==
   dependencies:
     minimist "^1.2.5"
     neo-async "^2.6.2"
@@ -4879,10 +4826,10 @@ ignore@^7.0.3:
   resolved "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz"
   integrity sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==
 
-immutable@^5.0.2:
-  version "5.1.3"
-  resolved "https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz"
-  integrity sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==
+immutable@5.1.5, immutable@^5.0.2:
+  version "5.1.5"
+  resolved "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz#93ee4db5c2a9ab42a4a783069f3c5d8847d40165"
+  integrity sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==
 
 import-fresh@^3.2.1, import-fresh@^3.3.0:
   version "3.3.1"
@@ -4933,15 +4880,7 @@ index-to-position@^1.1.0:
   resolved "https://registry.npmjs.org/index-to-position/-/index-to-position-1.1.0.tgz"
   integrity sha512-XPdx9Dq4t9Qk1mTMbWONJqU7boCoumEH7fRET37HX5+khDUl3J2W6PdALxhILYlIYx2amlwYcRPp28p0tSiojg==
 
-inflight@^1.0.4:
-  version "1.0.6"
-  resolved "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
-  integrity sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
-  dependencies:
-    once "^1.3.0"
-    wrappy "1"
-
-inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
+inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -5350,15 +5289,6 @@ iterator.prototype@^1.1.4:
     get-proto "^1.0.0"
     has-symbols "^1.1.0"
     set-function-name "^2.0.2"
-
-jackspeak@^2.3.5:
-  version "2.3.6"
-  resolved "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz"
-  integrity sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==
-  dependencies:
-    "@isaacs/cliui" "^8.0.2"
-  optionalDependencies:
-    "@pkgjs/parseargs" "^0.11.0"
 
 jackspeak@^3.1.2:
   version "3.4.3"
@@ -6081,10 +6011,10 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash-es@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz"
-  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+lodash-es@4.18.1, lodash-es@^4.17.21:
+  version "4.18.1"
+  resolved "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
+  integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
 
 lodash.capitalize@^4.2.1:
   version "4.2.1"
@@ -6121,10 +6051,10 @@ lodash.uniqby@^4.7.0:
   resolved "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz"
   integrity sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==
 
-lodash@4.17.21, lodash@^4.17.4:
-  version "4.17.21"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+lodash@4.18.1, lodash@^4.17.4:
+  version "4.18.1"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
@@ -6286,26 +6216,12 @@ minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
   integrity sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==
 
-minimatch@9.0.3:
-  version "9.0.3"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz"
-  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
+minimatch@9.0.3, minimatch@9.0.9, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.2, minimatch@^9.0.0, minimatch@^9.0.4, minimatch@^9.0.5:
+  version "9.0.9"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
+  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
   dependencies:
-    brace-expansion "^2.0.1"
-
-minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
-  dependencies:
-    brace-expansion "^1.1.7"
-
-minimatch@^9.0.0, minimatch@^9.0.1, minimatch@^9.0.4, minimatch@^9.0.5:
-  version "9.0.5"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz"
-  integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
-  dependencies:
-    brace-expansion "^2.0.1"
+    brace-expansion "^2.0.2"
 
 minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.8"
@@ -6358,23 +6274,10 @@ minipass@^3.0.0:
   dependencies:
     yallist "^4.0.0"
 
-minipass@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz#3e9788ffb90b694a5d0ec94479a45b5d8738133d"
-  integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
-
 "minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.0.2, minipass@^7.0.3, minipass@^7.0.4, minipass@^7.1.1, minipass@^7.1.2:
   version "7.1.2"
   resolved "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz"
   integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
-
-minizlib@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
-  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
-  dependencies:
-    minipass "^3.0.0"
-    yallist "^4.0.0"
 
 minizlib@^3.0.1:
   version "3.0.2"
@@ -6389,11 +6292,6 @@ minizlib@^3.1.0:
   integrity sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==
   dependencies:
     minipass "^7.1.2"
-
-mkdirp@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz"
-  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 motion-dom@^11.18.1:
   version "11.18.1"
@@ -6815,13 +6713,6 @@ object.values@^1.1.6, object.values@^1.2.1:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-once@^1.3.0:
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
-  integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
-  dependencies:
-    wrappy "1"
-
 onetime@^5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz"
@@ -7074,11 +6965,6 @@ path-exists@^4.0.0:
   resolved "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
-path-is-absolute@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-  integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
-
 path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz"
@@ -7094,7 +6980,7 @@ path-parse@^1.0.7:
   resolved "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-path-scurry@^1.10.1, path-scurry@^1.11.1:
+path-scurry@^1.11.1:
   version "1.11.1"
   resolved "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz"
   integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
@@ -7117,15 +7003,10 @@ picocolors@^1.0.0, picocolors@^1.1.1:
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
-
-picomatch@^4.0.2:
-  version "4.0.3"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz"
-  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
+picomatch@4.0.4, picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1, picomatch@^4.0.2:
+  version "4.0.4"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
 pify@^3.0.0:
   version "3.0.0"
@@ -8584,22 +8465,10 @@ synckit@^0.11.7:
   dependencies:
     "@pkgr/core" "^0.2.9"
 
-tar@^6.1.11, tar@^6.2.1:
-  version "6.2.1"
-  resolved "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz"
-  integrity sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==
-  dependencies:
-    chownr "^2.0.0"
-    fs-minipass "^2.0.0"
-    minipass "^5.0.0"
-    minizlib "^2.1.1"
-    mkdirp "^1.0.3"
-    yallist "^4.0.0"
-
-tar@^7.4.3, tar@^7.5.10:
-  version "7.5.13"
-  resolved "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz#0d214ed56781a26edc313581c0e2d929ceeb866d"
-  integrity sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==
+tar@7.5.15, tar@^6.1.11, tar@^6.2.1, tar@^7.4.3, tar@^7.5.10:
+  version "7.5.15"
+  resolved "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz#afe6d1316cddf614a566e3813e42fe01aed46fee"
+  integrity sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==
   dependencies:
     "@isaacs/fs-minipass" "^4.0.0"
     chownr "^3.0.0"
@@ -9209,11 +9078,6 @@ wrap-ansi@^8.1.0:
     ansi-styles "^6.1.0"
     string-width "^5.0.1"
     strip-ansi "^7.0.1"
-
-wrappy@1:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-  integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
 write-file-atomic@^4.0.2:
   version "4.0.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "author": "Valory AG",
   "resolutions": {
-    "dayjs": "1.11.13"
+    "dayjs": "1.11.13",
+    "fast-uri": "3.1.2",
+    "immutable": "5.1.5",
+    "lodash": "4.18.1",
+    "picomatch": "2.3.2"
   },
   "dependencies": {
     "@ant-design/cssinjs": "1.24.0",
@@ -22,10 +26,10 @@
     "framer-motion": "11.18.2",
     "graphql": "16.11.0",
     "graphql-request": "6.1.0",
-    "lodash": "4.17.21",
+    "lodash": "4.18.1",
     "lottie-react": "2.4.1",
     "next": "14.2.35",
-    "node-forge": "1.3.1",
+    "node-forge": "1.4.0",
     "ps-tree": "1.2.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
@@ -34,7 +38,7 @@
     "semver": "7.7.2",
     "styled-components": "6.1.19",
     "sudo-prompt": "9.2.1",
-    "undici": "7.15.0",
+    "undici": "7.25.0",
     "usehooks-ts": "2.16.0",
     "winston": "3.17.0",
     "zod": "3.25.76",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3139,10 +3139,10 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
-fast-uri@^3.0.1:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz"
-  integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
+fast-uri@3.1.2, fast-uri@^3.0.1:
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
+  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
 
 fastq@^1.6.0:
   version "1.19.1"
@@ -3768,15 +3768,10 @@ immediate@~3.0.5:
   resolved "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz"
   integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
 
-immutable@^4.0.0-rc.12:
-  version "4.3.7"
-  resolved "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz"
-  integrity sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==
-
-immutable@^5.0.2:
-  version "5.1.3"
-  resolved "https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz"
-  integrity sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==
+immutable@5.1.5, immutable@^4.0.0-rc.12, immutable@^5.0.2:
+  version "5.1.5"
+  resolved "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz#93ee4db5c2a9ab42a4a783069f3c5d8847d40165"
+  integrity sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==
 
 import-fresh@^3.2.1:
   version "3.3.1"
@@ -4180,10 +4175,10 @@ lodash.merge@^4.6.2:
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@4.17.21, lodash@^4.17.11, lodash@^4.17.15:
-  version "4.17.21"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+lodash@4.18.1, lodash@^4.17.11, lodash@^4.17.15:
+  version "4.18.1"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 log-symbols@^4.1.0:
   version "4.1.0"
@@ -4631,10 +4626,10 @@ node-fetch@^2.7.0:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-forge@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
-  integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
+node-forge@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz#1c7b7d8bdc2d078739f58287d589d903a11b2fc2"
+  integrity sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==
 
 node-gyp-build@^4.2.0, node-gyp-build@^4.3.0:
   version "4.8.4"
@@ -4895,15 +4890,10 @@ picocolors@^1.0.0, picocolors@^1.1.1:
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
-
-picomatch@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz"
-  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
+picomatch@2.3.2, picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1, picomatch@^4.0.3:
+  version "2.3.2"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 pkg-up@^3.1.0:
   version "3.1.0"
@@ -6291,10 +6281,10 @@ undici-types@~6.21.0:
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
-undici@7.15.0:
-  version "7.15.0"
-  resolved "https://registry.npmjs.org/undici/-/undici-7.15.0.tgz#7485007549ad1782b7cab2abfaa1c1aa7b75e106"
-  integrity sha512-7oZJCPvvMvTd0OlqWsIxTuItTpJBpU1tcbVl24FMn3xt3+VSunwUasmfPJRE57oNO1KsZ4PgA1xTdAX4hq8NyQ==
+undici@7.25.0:
+  version "7.25.0"
+  resolved "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz#7d72fc429a0421769ca2966fd07cac875c85b781"
+  integrity sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==
 
 undici@^5.14.0:
   version "5.29.0"


### PR DESCRIPTION
## Summary

Implements **Phase 0** of [.plans/supply-chain-update.md](.plans/supply-chain-update.md) — clear the high/critical-severity advisory burn-down so the audit gate in #1960 ships green when it rebases.

This is the prerequisite PR for #1960 (Phase 2's audit gate). The plan explicitly anticipated this sequencing — see [§ Phase 0 "Why first"](.plans/supply-chain-update.md) — but PR #1954 (Phase 1) shipped without bundling Phase 0, leaving 44 advisories on the tree that would have made #1960 ship red.

## Numbers

| Tree | Before | After | Cleared |
|------|-------:|------:|--------:|
| root | 19 high | **5 high** | 14 (-74%) |
| frontend | 24 high + 1 critical | **5 high** | 20 (-80%) |

**Title arithmetic — 28 vs 34.** The title says "28 CVEs" because `yarn audit` reports advisories per advisory ID, and 6 of the cleared advisories surface in both trees (same GHSA in two `yarn.lock` files). The "cleared" column in the table sums per-tree (14 + 20 = 34), but the unique-advisory-ID count is 28. Adopting the unique-ID metric for the title matches how the npm advisory database reports — one advisory, not "advisory × number of trees it lives in."

The 5 residuals in each tree are all Next.js 14.x advisories that require a 14 → 15 major bump (see "Residuals" below). They're carved out for a dedicated migration PR and will be allowlisted by #1960 with a "not on a reachable code path" justification.

## Direct dep bumps (root)

| Package | Before | After | Clears |
|---------|--------|-------|--------|
| `node-forge` | 1.3.1 | 1.4.0 | 6 advisories — ASN.1 unbounded recursion, validator desync, basicConstraints bypass, Ed25519 signature forgery, modInverse DoS, RSA-PKCS signature forgery |
| `undici` | 7.15.0 | 7.25.0 | 3 advisories — WebSocket length overflow, permessage-deflate memory consumption, server_max_window_bits unhandled exception |
| `lodash` | 4.17.21 | 4.18.1 | 1 advisory — `_.template` code injection via tampered import key names (cleared in both trees; `lodash` is also a direct dep in frontend) |

## Transitive resolutions

`resolutions` entries land in both trees' `package.json`, forcing safe versions even when our direct deps want older ranges.

**Root tree:**
- `picomatch 2.3.2` — clears ReDoS in extglob quantifiers (path: `sass > @parcel/watcher > micromatch > picomatch`)
- `immutable 5.1.5` — clears prototype pollution (path: `sass > immutable`)
- `fast-uri 3.1.2` — clears 2 advisories (path traversal, host confusion via percent-encoded segments; path: `electron-store > conf > ajv > fast-uri`)
- `lodash 4.18.1` — flattens the 4.17.21 transitive that `electron-builder` et al. wanted under `^4.17.x`; the resolution catches what the direct-dep bump misses

**Frontend tree:**
- `handlebars 4.7.9` — clears **5** advisories (1 critical + 4 high): AST type confusion in `@partial-block` / dynamic partial / dynamic decorator, unescaped CLI precompiler injection. Reachable via `antd > dayjs > semantic-release > @semantic-release/commit-analyzer > conventional-changelog-writer > handlebars`.
- `tar 7.5.15` — clears 4 advisories (hardlink + symlink path traversal via drive-relative linkpath, APFS ligature race condition)
- `minimatch 9.0.9` — clears 3 nested-extglob ReDoS variants
- `picomatch 4.0.4` — clears ReDoS in 4.x branch (path: `tinyglobby > picomatch`)
- `glob 10.5.0` — clears prototype pollution in glob 10.2–10.4 range
- `immutable 5.1.5` — same `sass > immutable` path as root
- `lodash + lodash-es 4.18.1` — clears `_.template` code injection in both packages

## Yarn 1.x resolution warnings (informational, not failing)

`yarn install` emits warnings like:

```
warning Resolution field "minimatch@9.0.9" is incompatible with requested version "minimatch@^3.0.5"
```

These are **informational** — Yarn 1.x's `resolutions` field forcibly overrides the consumer's requested range. The install completes and `--frozen-lockfile` reproduces cleanly. The packages this affects are all build-time tools (semantic-release tree, sass watcher, npm internals) that Pearl never imports at runtime, so the forced upgrade is safe in practice.

**Picomatch asymmetry between trees — by design, not by accident.** Root pins `picomatch: 2.3.2`; frontend pins `picomatch: 4.0.4`. Each tree has independent yarn.lock and independent transitive demand:

- **Root tree:** the only path needing picomatch is `sass > @parcel/watcher > micromatch > picomatch` (advisory range `<2.3.2`). One caller wanted 4.x (a newer `@parcel/watcher` chain that isn't actually hoisted), so pinning 2.3.2 satisfies the actual consumer and is the minimal change that clears the advisory.
- **Frontend tree:** two independent paths — the same `sass>...>micromatch>picomatch` 2.x branch AND a separate `antd>dayjs>semantic-release>...>tinyglobby>picomatch` 4.x branch. A single `picomatch: 4.0.4` pin clears advisories on both branches; v4 is largely backward-compatible with v2's exports for the micromatch consumer.

Both trees end up safe via the minimal-change resolution for that tree's actual transitive surface. A contributor working across trees should not "fix" the inconsistency without confirming both trees' callers first.

## Smoke evidence — bumped deps don't break runtime / build paths

The big risk Tanya flagged was that the forced cross-major resolutions in the frontend tree (glob 10.5.0, tar 7.5.15, minimatch 9.0.9) might break electron-builder's import chain. **Verified locally — they don't reach electron-builder, because root and frontend yarn.lock are independent.**

### `node-forge` 1.4.0 self-signed cert generation (Tanya's main ask)

Ran a standalone script that mirrors [electron/main.js:509-573](electron/main.js#L509) verbatim against the installed `node-forge` 1.4.0 — generates RSA keypair, builds and signs the cert, round-trips through `pki.certificateFromPem`, then hands the PEM to `node:tls.createSecureContext` (which is what Electron uses via `addCACert` in [electron/utils/certificate.js](electron/utils/certificate.js)).

```
node-forge version: 1.4.0
private key PEM: 1702 bytes, starts with BEGIN RSA PRIVATE KEY  OK
certificate PEM: 1236 bytes, starts with BEGIN CERTIFICATE     OK
node-forge round-trip:  CN=localhost  O=Valory AG  serial=01   OK
tls.createSecureContext: OK
self-signature verify:  OK
```

### `electron-builder` import-chain smoke

Loaded `electron-builder`, `app-builder-lib`, and `dmg-builder` via `require()` on the root tree's fresh `yarn install --frozen-lockfile` state, and verified the installed transitive versions:

```
electron-builder loaded:    OK   (CLI reports 26.8.2)
app-builder-lib loaded:     OK
dmg-builder loaded:         OK

tar:        7.5.11   ← unforced (app-builder-lib wants ^7.5.7; natural resolution)
glob:       7.2.3    ← unforced (root tree has no glob resolution)
minimatch:  3.1.5    ← unforced root-level; app-builder-lib gets nested 10.2.4 from its own ^10.0.3 spec
picomatch:  2.3.2    ← forced by root resolution (sass>@parcel/watcher>micromatch consumer)
immutable:  5.1.5    ← forced (sass>immutable consumer)
fast-uri:   3.1.2    ← forced (electron-store>conf>ajv consumer)
```

**Key finding the review's concern needs to know:** the frontend's `tar/glob/minimatch` resolutions **do not propagate to the root tree** — yarn 1.x resolutions are scoped per-`package.json`. The root tree's `electron-builder` chain gets the natural yarn-resolution outcomes for its declared dep ranges (`app-builder-lib`'s `tar: ^7.5.7` and `minimatch: ^10.0.3`), not forced cross-major shifts. The forced majors only land where the advisories actually live: build-time tooling transitives in the frontend tree.

This means the Linux/Windows packaging via electron-builder will see **the same `tar 7.5.11`** + nested `minimatch 10.2.4` it would on supply-chain pre-Phase-0. The blast zone Tanya was worried about is empty.

## Residuals — 5 Next.js 14.x advisories per tree, all unreachable

Both trees have the same five remaining advisories, all on `next` 14.2.35 — listed here with **both the GHSA ID and the npm advisory.id** so #1960's allowlist follow-up commit can copy them straight in (the allowlist matches by numeric `id`):

| npm `id` | GHSA | Vulnerable range | Description |
|---------:|------|------------------|-------------|
| 1112653 | GHSA-h25m-26qc-wcjf | `>=13.0.0 <15.0.8` | RSC DoS via HTTP request deserialization |
| 1116376 | GHSA-q4gf-8mx6-v5v3 | `>=13.0.0 <15.5.15` | DoS with Server Components |
| 1117931 | GHSA-8h8q-6873-q5fj | `>=13.0.0 <15.5.16` | DoS with Server Components |
| 1117965 | GHSA-c4j6-fc7j-m34r | `>=13.4.13 <15.5.16` | SSRF via WebSocket upgrades |
| 1117973 | GHSA-36qx-fr4f-26g5 | `>=12.2.0 <15.5.16` | Pages Router middleware / i18n proxy bypass |

**All five fix versions require Next.js 15.0.8+ / 15.5.15+ / 15.5.16+.** No 14.x fix exists; Next.js 14 is EOL for these specific issues.

**Why deferred from this PR:** Bumping `next` 14 → 15 is a dedicated migration PR. Pearl uses Pages Router with no API routes / no `getServerSideProps` / no middleware, so the migration should be tractable, but it's out of scope here.

**Why allowlisting them in #1960 is justified:** Pearl uses Next.js as a glorified static React bundler. Electron serves `frontend/.next` as static HTML/JS via its protocol handler. There is **no Next runtime server** — so RSC DoS, WebSocket SSRF, and middleware/i18n bypass cannot fire. The advisories aren't on Pearl's reachable code path. This is the "not on a reachable code path" justification §2.2 of the plan asks for, not the boilerplate "no upstream fix" excuse.

#1960 will rebase on this branch and add the 5 advisory IDs to `.supply-chain/audit-allowlist.json` (both trees) with the above reasoning and a 90-day review date.

## Verification

- [x] `yarn install --frozen-lockfile` passes in both trees (lockfiles reproduce against the new pins).
- [x] `yarn deps:check-pinned` passes both trees — 56 exact-pinned specifiers each.
- [x] `yarn audit --groups dependencies` high/critical count: root 19 → 5, frontend 25 → 5.
- [x] Lockfiles SHRANK — root `-58` lines, frontend `-214` — because resolutions eliminated duplicate older transitives.

## Test plan

- [x] CI passes on this PR (`yarn install --frozen-lockfile`, lint, typecheck, frontend tests, gitleaks, deps-check-pinned, lockfile-lint). — All 11 checks green.
- [x] Local smoke on a fresh `node_modules`: `yarn install --frozen-lockfile` in both trees clean; `yarn quality-check:frontend` → 0 errors, 19 pre-existing warnings; `yarn test:frontend` → **313 test suites / 4526 tests pass**; `yarn build` in `frontend/` → all 6 static pages compile cleanly. (Production build is a stronger signal than `yarn dev:frontend` starting.)
- [x] Electron smoke (partial — non-interactive paths): `node-forge` 1.4.0 cert generation mirrors `electron/main.js:509-573` end-to-end with self-signature verify + `node:tls.createSecureContext` round-trip OK; `electron-builder` + `app-builder-lib` + `dmg-builder` all `require()` cleanly + CLI reports 26.8.2; transitive versions match what supply-chain pre-Phase-0 already shipped (forced majors don't cross tree boundaries). Evidence in the "Smoke evidence" section above.
- [ ] Electron smoke (interactive): `yarn dev` — Electron window opens, frontend renders, no console errors. *(Not run locally — needs interactive verification; user to confirm during review.)*
- [ ] On `supply-chain` after merge: rebase #1960 onto updated `supply-chain`; its `yarn audit (both trees)` job goes amber (5 allowlisted entries) instead of red. *(Blocked until this PR merges.)*

## Out of scope

- **Next.js 14 → 15 migration** — separate dedicated PR. Tractable (Pages Router, no API routes) but warrants its own scope.
- **`@xmldom/xmldom` / `flatted`** — listed in the plan but no high/critical advisories currently match. Already at safe versions transitively.
- **`electron` 33.4.11 bump** — current version is already past the four advisories the plan called out for the older 33.2.1 baseline. No bump needed.
- **Updating `.supply-chain/audit-allowlist.json`** — those files are introduced by #1960; this PR doesn't reach them. The follow-up commit on #1960 will populate them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

