### PR TITLE
fix(ci): grant actions:write to production-release workflow

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -27,6 +27,7 @@ on:
 
 permissions:
   contents: write
+  actions: write # required by calculate-and-update-version.yml to re-dispatch CI for the version-bump commit
 
 # Prevent multiple release builds running at the same time for the same branch
 concurrency:


### PR DESCRIPTION
## Summary

- Adds `actions: write` to `production-release.yml` top-level permissions so it can grant that scope to the reusable `calculate-and-update-version.yml` it calls.
- Fixes the `startup_failure` seen on `release/v1.6.14` (run [25917696599](https://github.com/valory-xyz/olas-operate-app/actions/runs/25917696599)): `Error calling workflow ... The workflow is requesting 'actions: write', but is only allowed 'actions: none'`.
- Already applied directly to `release/v1.6.14` in commit a8eaa1a9c (which unblocked the v1.6.14 release). This PR mirrors the fix to `staging` so the next release branch inherits it.

## Why it broke now

PR #1959 added an "actions: write" permission to `calculate-and-update-version.yml` so it can re-dispatch CI on GITHUB_TOKEN-pushed version-bump commits. `create-feature-release.yml` calls the same reusable workflow via `workflow_dispatch` and continues to work, but the `push`-triggered `production-release.yml` does not — GitHub validates the permission gap at startup for `push` events and rejects the run.

## Test plan

- [x] Same change applied directly to `release/v1.6.14` — Production Release run [25918376876](https://github.com/valory-xyz/olas-operate-app/actions/runs/25918376876) got past the startup-failure stage.
- [ ] Once merged to staging, the next release branch cut from staging should not hit the same startup_failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)