### PR TITLE
chore(security): code security scans, supply-chain audit, and CodeQL fixes

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -376,8 +376,10 @@ const createSplashWindow = () => {
     title: 'Pearl',
     frame: false,
     webPreferences: {
-      nodeIntegration: true,
-      contextIsolation: false,
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: true,
+      preload: path.join(__dirname, 'preload-splash.js'),
     },
   });
   splashWindow.loadURL('file://' + __dirname + '/resources/app-loading.html');

--- a/electron/preload-splash.js
+++ b/electron/preload-splash.js
@@ -1,0 +1,7 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('splashApi', {
+  sendCheck: (message) => ipcRenderer.send('check', message),
+  onResponse: (callback) =>
+    ipcRenderer.on('response', (_event, arg) => callback(arg)),
+});

--- a/electron/preload-splash.js
+++ b/electron/preload-splash.js
@@ -1,7 +1,13 @@
+// Preload for the splash window. The splash runs with sandbox + contextIsolation,
+// so this is the only bridge between renderer and main. Surface is intentionally
+// minimal (only the two channels the splash uses) — do not extend without reason.
 const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('splashApi', {
   sendCheck: (message) => ipcRenderer.send('check', message),
-  onResponse: (callback) =>
-    ipcRenderer.on('response', (_event, arg) => callback(arg)),
+  onResponse: (callback) => {
+    const handler = (_event, arg) => callback(arg);
+    ipcRenderer.on('response', handler);
+    return () => ipcRenderer.removeListener('response', handler);
+  },
 });

--- a/electron/resources/app-loading.html
+++ b/electron/resources/app-loading.html
@@ -77,8 +77,7 @@
   </body>
 
   <script>
-    const { ipcRenderer } = require("electron");
-    ipcRenderer.on("response", (event, arg) => {
+    window.splashApi.onResponse((arg) => {
       if (typeof arg === "string") {
         if (arg.includes("Installing")) {
           document.getElementById("text").innerHTML =
@@ -91,7 +90,7 @@
       }
     });
 
-    ipcRenderer.send("check", "Starting check...");
+    window.splashApi.sendCheck("Starting check...");
   </script>
 
 </html>

--- a/operate/tendermint.py
+++ b/operate/tendermint.py
@@ -538,6 +538,17 @@ def create_app(  # pylint: disable=too-many-statements
     )
 
     app = Flask(__name__)  # pylint: disable=redefined-outer-name
+    # Route app.logger to stderr so exception logs land in the parent process's
+    # tm.log (deployment_runner pipes this subprocess's stderr there); without
+    # this they'd go to com.log, which isn't collected for support bundles.
+    _stderr_handler = logging.StreamHandler(sys.stderr)
+    _stderr_handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s %(levelname)s %(name)s %(threadName)s : %(message)s"
+        )
+    )
+    app.logger.addHandler(_stderr_handler)  # pylint: disable=no-member
+    app.logger.setLevel(logging.DEBUG)  # pylint: disable=no-member
     app._is_on_exit = (  # pylint: disable=protected-access
         False  # ugly but better than global ver
     )
@@ -571,7 +582,7 @@ def create_app(  # pylint: disable=too-many-statements
                 "error": None,
             }
         except (FileNotFoundError, json.JSONDecodeError):
-            cast(logging.Logger, app.logger).exception(  # pylint: disable=no-member
+            app.logger.exception(  # pylint: disable=no-member
                 "Failed to read tendermint params."
             )
             return {"params": {}, "status": False, "error": "Failed to read tendermint params."}
@@ -582,16 +593,16 @@ def create_app(  # pylint: disable=too-many-statements
 
         try:
             data: Dict = json.loads(request.get_data().decode(ENCODING))
-            cast(logging.Logger, app.logger).debug(  # pylint: disable=no-member
+            app.logger.debug(  # pylint: disable=no-member
                 f"Data update requested with data={data}"
             )
 
-            cast(logging.Logger, app.logger).info(  # pylint: disable=no-member
+            app.logger.info(  # pylint: disable=no-member
                 "Updating genesis config."
             )
             update_genesis_config(data=data)
 
-            cast(logging.Logger, app.logger).info(  # pylint: disable=no-member
+            app.logger.info(  # pylint: disable=no-member
                 "Updating peristent peers."
             )
             config_path = Path(os.environ["TMHOME"]) / "config" / "config.toml"
@@ -606,7 +617,7 @@ def create_app(  # pylint: disable=too-many-statements
 
             return {"status": True, "error": None}
         except (FileNotFoundError, json.JSONDecodeError, PermissionError):
-            cast(logging.Logger, app.logger).exception(  # pylint: disable=no-member
+            app.logger.exception(  # pylint: disable=no-member
                 "Failed to update tendermint params."
             )
             return {"status": False, "error": "Failed to update tendermint params."}
@@ -624,7 +635,7 @@ def create_app(  # pylint: disable=too-many-statements
                 HTTPStatus.OK,
             )
         except Exception:  # pylint: disable=W0703
-            cast(logging.Logger, app.logger).exception(  # pylint: disable=no-member
+            app.logger.exception(  # pylint: disable=no-member
                 "Gentle reset failed."
             )
             return (
@@ -644,7 +655,7 @@ def create_app(  # pylint: disable=too-many-statements
             app_hash_ = res.json()["result"]["block"]["header"]["app_hash"]
             return jsonify({"app_hash": app_hash_}), res.status_code
         except Exception:  # pylint: disable=W0703
-            cast(logging.Logger, app.logger).exception(  # pylint: disable=no-member
+            app.logger.exception(  # pylint: disable=no-member
                 "Could not get the app hash."
             )
             return (
@@ -679,7 +690,7 @@ def create_app(  # pylint: disable=too-many-statements
                 HTTPStatus.OK,
             )
         except Exception:  # pylint: disable=W0703
-            cast(logging.Logger, app.logger).exception(  # pylint: disable=no-member
+            app.logger.exception(  # pylint: disable=no-member
                 "Hard reset failed."
             )
             return (
@@ -690,7 +701,7 @@ def create_app(  # pylint: disable=too-many-statements
     @app.errorhandler(HTTPStatus.NOT_FOUND)  # type: ignore
     def handle_notfound(e: NotFound) -> Response:
         """Handle server error."""
-        cast(logging.Logger, app.logger).info(e)  # pylint: disable=E
+        app.logger.info(e)  # pylint: disable=E
         return Response(
             "Not Found", status=HTTPStatus.NOT_FOUND, mimetype="application/json"
         )
@@ -698,7 +709,7 @@ def create_app(  # pylint: disable=too-many-statements
     @app.errorhandler(HTTPStatus.INTERNAL_SERVER_ERROR)  # type: ignore
     def handle_server_error(e: InternalServerError) -> Response:
         """Handle server error."""
-        cast(logging.Logger, app.logger).info(e)  # pylint: disable=E
+        app.logger.info(e)  # pylint: disable=E
         return Response(
             "Error Closing Node",
             status=HTTPStatus.INTERNAL_SERVER_ERROR,

--- a/operate/tendermint.py
+++ b/operate/tendermint.py
@@ -33,7 +33,6 @@ import signal
 import stat
 import subprocess  # nosec:
 import sys
-import traceback
 from http import HTTPStatus
 from logging import Logger
 from pathlib import Path
@@ -572,7 +571,10 @@ def create_app(  # pylint: disable=too-many-statements
                 "error": None,
             }
         except (FileNotFoundError, json.JSONDecodeError):
-            return {"params": {}, "status": False, "error": traceback.format_exc()}
+            cast(logging.Logger, app.logger).exception(  # pylint: disable=no-member
+                "Failed to read tendermint params."
+            )
+            return {"params": {}, "status": False, "error": "Failed to read tendermint params."}
 
     @app.post("/params")
     def update_params() -> Dict:
@@ -604,7 +606,10 @@ def create_app(  # pylint: disable=too-many-statements
 
             return {"status": True, "error": None}
         except (FileNotFoundError, json.JSONDecodeError, PermissionError):
-            return {"status": False, "error": traceback.format_exc()}
+            cast(logging.Logger, app.logger).exception(  # pylint: disable=no-member
+                "Failed to update tendermint params."
+            )
+            return {"status": False, "error": "Failed to update tendermint params."}
 
     @app.route("/gentle_reset")
     def gentle_reset() -> Tuple[Any, int]:
@@ -618,9 +623,12 @@ def create_app(  # pylint: disable=too-many-statements
                 jsonify({"message": "Reset successful.", "status": True}),
                 HTTPStatus.OK,
             )
-        except Exception as e:  # pylint: disable=W0703
+        except Exception:  # pylint: disable=W0703
+            cast(logging.Logger, app.logger).exception(  # pylint: disable=no-member
+                "Gentle reset failed."
+            )
             return (
-                jsonify({"message": f"Reset failed: {e}", "status": False}),
+                jsonify({"message": "Reset failed.", "status": False}),
                 HTTPStatus.OK,
             )
 
@@ -635,9 +643,12 @@ def create_app(  # pylint: disable=too-many-statements
             res = requests.get(endpoint, params, timeout=DEFAULT_TIMEOUT)
             app_hash_ = res.json()["result"]["block"]["header"]["app_hash"]
             return jsonify({"app_hash": app_hash_}), res.status_code
-        except Exception as e:  # pylint: disable=W0703
+        except Exception:  # pylint: disable=W0703
+            cast(logging.Logger, app.logger).exception(  # pylint: disable=no-member
+                "Could not get the app hash."
+            )
             return (
-                jsonify({"error": f"Could not get the app hash: {str(e)}"}),
+                jsonify({"error": "Could not get the app hash."}),
                 200,
             )
 
@@ -667,9 +678,12 @@ def create_app(  # pylint: disable=too-many-statements
                 jsonify({"message": "Reset successful.", "status": True}),
                 HTTPStatus.OK,
             )
-        except Exception as e:  # pylint: disable=W0703
+        except Exception:  # pylint: disable=W0703
+            cast(logging.Logger, app.logger).exception(  # pylint: disable=no-member
+                "Hard reset failed."
+            )
             return (
-                jsonify({"message": f"Reset failed: {e}", "status": False}),
+                jsonify({"message": "Reset failed.", "status": False}),
                 HTTPStatus.OK,
             )
 

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.6.12-rc7",
+  "version": "1.6.12-rc13",
   "engine": {
     "node": "22.18",
     "yarn": ">=1.22.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "olas-operate-app"
-version = "1.6.12-rc7"
+version = "1.6.12-rc13"
 description = ""
 authors = ["David Vilela <dvilelaf@gmail.com>", "Viraj Patel <vptl185@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary

Addresses GitHub code-scanning (CodeQL) alerts. Reviewed all 54 open alerts and split them into in-code fixes + dismissals.

### Fixed in code (8 alerts)

- **Stack-trace / server-info exposure (5)** — `/params` (GET + POST), `/gentle_reset`, `/app_hash`, `/hard_reset` in `operate/tendermint.py` were returning `traceback.format_exc()` / `str(e)` to HTTP clients. Replaced with `logger.exception(...)` server-side + a generic error string in the response. Response shape (keys, status codes) unchanged.
- **XSS in `/app_hash` (1)** — same root cause as above, fixed by the same change.
- **Insecure Electron splash window (2)** — splash window used `nodeIntegration: true` + `contextIsolation: false`. Switched to `nodeIntegration: false`, `contextIsolation: true`, `sandbox: true`, with a dedicated `preload-splash.js` exposing only the two IPC channels the splash needs (`check` send, `response` receive). All other Electron windows in the app already used the secure pattern.

### Dismissed as false positives (46 alerts, no code change)

- **35 ×** hardcoded test mnemonics/passwords in `frontend/tests/**` — jest fixtures, not real secrets → "used in tests"
- **9 ×** path traversal in `operate/tendermint.py` from `os.environ["TMHOME" | "TMSTATE" | "ID"]` — set internally by the Pearl middleware, not user-controlled → "won't fix"
- **2 ×** HTTP module usage (Next.js localhost server, localhost reachability HEAD) — loopback only → "won't fix"

Dismissal comments visible on each alert in the Security → Code scanning UI.

## Test plan

- [x] Python + JS syntax checks pass
- [x] Manually verified splash → main window transition works in `yarn dev`
- [x] Confirmed 46 dismissals + 8 in-code fixes against the Security tab
- [x] CI lint + typecheck pass
- [ ] CodeQL rescan auto-closes the 8 in-code-fixed alerts

## Notes for reviewers

- `operate/tendermint.py` is the vendored Tendermint manager bundled into PyInstaller. Error-message changes are pure shape-preserving rewording; agent ABCI callers inspect `status: false` only, not the error text.
- New `electron/preload-splash.js` is intentionally minimal — only the two channels the splash actually uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)