### PR TITLE
fix(ci): grant actions:write to create-feature-release workflow

### DIFF
--- a/.github/workflows/create-feature-release.yml
+++ b/.github/workflows/create-feature-release.yml
@@ -1,6 +1,7 @@
 name: Create Feature Release
 permissions:
   contents: write
+  actions: write # required by calculate-and-update-version.yml to re-dispatch CI for the version-bump commit
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- `create-feature-release.yml` calls the reusable `calculate-and-update-version.yml`, which requires `actions: write` to re-dispatch CI for the version-bump commit
- Without this permission the workflow fails with: `The workflow is requesting 'actions: write', but is only allowed 'actions: none'` ([failed run](https://github.com/valory-xyz/olas-operate-app/actions/runs/26027626148))
- Mirrors the fix already applied to `production-release.yml` (#1964)

## Test plan
- [ ] Re-run the Create Feature Release workflow and confirm `calculate-version` job no longer fails the permission check

🤖 Generated with [Claude Code](https://claude.com/claude-code)