### PR TITLE
fix(ci): push release version-bump under GitHub App identity

### DIFF
--- a/.github/workflows/calculate-and-update-version.yml
+++ b/.github/workflows/calculate-and-update-version.yml
@@ -27,7 +27,6 @@ on:
 
 permissions:
   contents: write
-  actions: write # required to re-dispatch PR checks for the version-bump commit
 
 jobs:
   calculate-and-update-version:
@@ -36,12 +35,31 @@ jobs:
       new_tag: ${{ steps.calculate-version.outputs.new_tag }}
       new_version: ${{ steps.calculate-version.outputs.new_version }}
     steps:
+      # GITHUB_TOKEN pushes do not trigger downstream `push`/`pull_request`
+      # workflow runs, so a version-bump commit pushed with it leaves the
+      # release PR's required-status-check rollup empty and blocks the merge.
+      # Pushing under a GitHub App identity is treated as a regular user push,
+      # which fires pull_request synchronize and feeds the rollup normally.
+      - name: Get GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Get GitHub App user ID
+        id: app-user
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          echo "id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.branch || github.ref }}
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -63,8 +81,8 @@ jobs:
 
       - name: Configure Git
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --local user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config --local user.email "${{ steps.app-user.outputs.id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
       - name: Extract version from branch name
         id: branch-version
@@ -268,12 +286,10 @@ jobs:
           fi
 
       - name: Commit and push version update
-        id: commit
         run: |
           git add package.json pyproject.toml poetry.lock
           if git diff --staged --quiet; then
             echo "No version file changes detected — skipping commit."
-            echo "pushed=false" >> "$GITHUB_OUTPUT"
           else
             COMMIT_MSG="chore: bump version to ${{ steps.calculate-version.outputs.new_version }}"
             COMMIT_SUFFIX="${{ steps.calculate-version.outputs.commit_suffix }}"
@@ -289,29 +305,7 @@ jobs:
               PUSH_BRANCH="${GITHUB_REF_NAME}"
             fi
             git push origin "$PUSH_BRANCH"
-            echo "pushed=true" >> "$GITHUB_OUTPUT"
-            echo "push_branch=$PUSH_BRANCH" >> "$GITHUB_OUTPUT"
           fi
-
-      # The version-bump commit above is pushed with GITHUB_TOKEN, and GitHub
-      # deliberately does not start push/pull_request workflow runs for commits
-      # made by GITHUB_TOKEN. That leaves the release PR's head commit without
-      # the "All checks passed" CI check — the only check main's branch
-      # protection requires — so the merge stays blocked. The one documented
-      # exception is workflow_dispatch: GITHUB_TOKEN *can* start those runs, so
-      # re-dispatch CI against the freshly pushed branch. It attaches check runs
-      # to the new HEAD commit, satisfying the required status check. Non-fatal:
-      # if a release branch predates the workflow_dispatch trigger, fall back to
-      # a manual re-trigger.
-      - name: Re-trigger CI for the version-bump commit
-        if: steps.commit.outputs.pushed == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PUSH_BRANCH="${{ steps.commit.outputs.push_branch }}"
-          echo "Dispatching CI on $PUSH_BRANCH"
-          gh workflow run ci.yml --ref "$PUSH_BRANCH" \
-            || echo "::warning::Could not dispatch CI on $PUSH_BRANCH — re-trigger checks manually."
 
       - name: Create and push tag
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
   push:
     branches: [main, staging]
-  workflow_dispatch: # lets the release workflow re-trigger CI on GITHUB_TOKEN-pushed version-bump commits
 
 permissions:
   contents: read

--- a/.github/workflows/create-feature-release.yml
+++ b/.github/workflows/create-feature-release.yml
@@ -1,7 +1,6 @@
 name: Create Feature Release
 permissions:
   contents: write
-  actions: write # required by calculate-and-update-version.yml to re-dispatch CI for the version-bump commit
 
 on:
   workflow_dispatch:

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -27,7 +27,6 @@ on:
 
 permissions:
   contents: write
-  actions: write # required by calculate-and-update-version.yml to re-dispatch CI for the version-bump commit
 
 # Prevent multiple release builds running at the same time for the same branch
 concurrency:

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.6.12-rc5",
+  "version": "1.6.12-rc8",
   "engine": {
     "node": "22.18",
     "yarn": ">=1.22.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "olas-operate-app"
-version = "1.6.12-rc5"
+version = "1.6.12-rc8"
 description = ""
 authors = ["David Vilela <dvilelaf@gmail.com>", "Viraj Patel <vptl185@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Replace `GITHUB_TOKEN` with a GitHub App token (`actions/create-github-app-token`) for the version-bump commit + tag push in `calculate-and-update-version.yml`. App pushes are treated as regular user pushes and fire `pull_request: synchronize`, populating the PR's required-status-check rollup naturally.
- Drop the previous `workflow_dispatch` re-trigger workaround — GitHub filters `workflow_dispatch` check suites out of the PR rollup, so the gate never went green (verified on #1963 where the re-dispatched CI run was fully green but `gh pr checks` reported "no checks reported" and `mergeStateStatus` stayed `BLOCKED`).
- Clean up the now-unneeded `actions: write` permissions on `production-release.yml` and `create-feature-release.yml`, plus the `workflow_dispatch:` trigger on `ci.yml`.

## Required setup before merging

This PR will not work until two repo secrets are present:

- `APP_ID` — numeric GitHub App ID
- `APP_PRIVATE_KEY` — full PEM contents of the App's private key

The App must be installed on `valory-xyz/olas-operate-app` with `Contents: Read & write` permission.

## Test plan

- [x] Add `APP_ID` + `APP_PRIVATE_KEY` repo secrets
- [ ] Run a feature release (`Create Feature Release` workflow_dispatch) — verify the bump commit appears authored by the App bot, and that CI fires against the new HEAD with event=`pull_request`
- [ ] Confirm the release PR's required status check populates and `gh pr checks <PR>` reports the runs
- [ ] Run a production release end-to-end (push to `release/*`) and verify the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)