### PR TITLE
chore: update optimus hash and version

### DIFF
--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -18,14 +18,14 @@ const BABYDEGEN_COMMON_TEMPLATE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeiawldqbuxzmzmdkpb7rv7xcwmqwub5cjvt7erwqvi273zkohwrteu',
-  service_version: 'v0.9.0',
+  hash: 'bafybeigcpif3zh337v72d7m3dxjk663gego4wpmbuz4s26363zydjjm33i',
+  service_version: 'v0.9.2',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.9.0',
+      version: 'v0.9.2',
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.6.12-rc7",
+  "version": "1.6.12-rc10",
   "engine": {
     "node": "22.18",
     "yarn": ">=1.22.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "olas-operate-app"
-version = "1.6.12-rc7"
+version = "1.6.12-rc10"
 description = ""
 authors = ["David Vilela <dvilelaf@gmail.com>", "Viraj Patel <vptl185@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
Update babydegen to [v0.9.2](https://github.com/valory-xyz/optimus/releases/tag/v0.9.2)
