### PR TITLE
ci: gate release publishing behind approval + tag ruleset

### DIFF
--- a/.github/rulesets/restrict-release-tag-creation.json
+++ b/.github/rulesets/restrict-release-tag-creation.json
@@ -1,0 +1,21 @@
+{
+  "name": "Restrict release tag creation",
+  "target": "tag",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/tags/v*"],
+      "exclude": ["refs/tags/v*-*"]
+    }
+  },
+  "rules": [
+    { "type": "creation" }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 3235133,
+      "actor_type": "Integration",
+      "bypass_mode": "always"
+    }
+  ]
+}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,77 @@
+# Publishes a draft GitHub Release to the public — the only sanctioned way to
+# ship a production release.
+#
+# The release version is read from package.json on `main` — no manual input.
+#
+# The `publish` job is gated by the `production-publish` environment (1 required
+# reviewer, "Prevent self-review" on), so every publish needs a second person's
+# approval; the triggerer cannot approve their own run.
+#
+# Publishing creates the `vX.Y.Z` git tag. The tag ruleset that restricts `v*`
+# creation lists the valory-coding-agent App as its only bypass actor, so an
+# App token is the only identity that can create a release tag
+
+name: Publish release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # Ungated: resolves which release to publish so the version is visible on the
+  # run page before a reviewer approves the gated job below.
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.version.outputs.release_tag }}
+    steps:
+      - name: Check out main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - name: Read release version from package.json on main
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "Release version on main: $VERSION"
+          echo "release_tag=v${VERSION}" | tee -a "$GITHUB_OUTPUT"
+
+  publish:
+    needs: resolve
+    runs-on: ubuntu-latest
+    environment: production-publish
+    steps:
+      - name: Mint valory-coding-agent App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Verify the target release exists and is still a draft
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
+        run: |
+          IS_DRAFT=$(gh release view "$RELEASE_TAG" \
+            --repo "${{ github.repository }}" --json isDraft --jq .isDraft 2>/dev/null || echo "missing")
+          if [ "$IS_DRAFT" = "missing" ]; then
+            echo "::error::No release found for $RELEASE_TAG — nothing to publish."
+            exit 1
+          fi
+          if [ "$IS_DRAFT" != "true" ]; then
+            echo "::error::$RELEASE_TAG is already published — refusing to act."
+            exit 1
+          fi
+
+      - name: Publish the draft release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
+        run: |
+          gh release edit "$RELEASE_TAG" --draft=false --repo "${{ github.repository }}"
+          echo "Published $RELEASE_TAG — users receive it on the next auto-update check."

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -57,12 +57,27 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
         run: |
+          # Capture stdout and stderr separately so a transient gh failure
+          # (auth, rate limit, network) is not misreported as "release missing".
+          set +e
           IS_DRAFT=$(gh release view "$RELEASE_TAG" \
-            --repo "${{ github.repository }}" --json isDraft --jq .isDraft 2>/dev/null || echo "missing")
-          if [ "$IS_DRAFT" = "missing" ]; then
-            echo "::error::No release found for $RELEASE_TAG — nothing to publish."
+            --repo "${{ github.repository }}" --json isDraft --jq .isDraft 2> /tmp/gh_stderr)
+          RC=$?
+          STDERR=$(cat /tmp/gh_stderr)
+          set -e
+
+          if [ $RC -ne 0 ]; then
+            # Treat as "missing" only when gh says exactly that; any other
+            # failure (auth, rate limit, network) must surface as a real error.
+            if echo "$STDERR" | grep -qi 'release not found'; then
+              echo "::error::No release found for $RELEASE_TAG — nothing to publish."
+            else
+              echo "::error::gh release view failed for $RELEASE_TAG (exit $RC):"
+              echo "$STDERR"
+            fi
             exit 1
           fi
+
           if [ "$IS_DRAFT" != "true" ]; then
             echo "::error::$RELEASE_TAG is already published — refusing to act."
             exit 1


### PR DESCRIPTION
## Summary

Closes the last open sub-gap from [VLOP-70](https://linear.app/valory-xyz/issue/VLOP-70): anyone with `Write` on the repo can publish a production release (push a build to every Pearl user). GitHub bundles "publish a release" into the `Write` role — there is no per-permission split.

Two pieces:

- **`.github/workflows/publish-release.yml`** — the sanctioned way to publish. `workflow_dispatch`, no input: an ungated job reads the release version from `package.json` on `main`; a job gated by the `production-publish` environment (1 required reviewer, "Prevent self-review" on) publishes the matching draft Release. Every publish needs a second person's approval — the triggerer cannot approve their own run.
- **`.github/rulesets/restrict-release-tag-creation.json`** — a tag ruleset config. Publishing a release creates the `vX.Y.Z` git tag; this ruleset restricts creation of clean `vX.Y.Z` tags to the `valory-coding-agent` App, so no human can publish directly. `vX.Y.Z-signed` / `vX.Y.Z-rcN` workflow tags are excluded — the build workflows are unaffected.

## Manual setup required (NOT done by merging this PR)

The ruleset JSON is config-as-documentation — it is not auto-applied. After merge, an admin must:

1. **Create the `production-publish` environment** (Settings → Environments): 1 required reviewer, "Prevent self-review" ON, "Allow admins to bypass" OFF, deployment branches = `main`. No environment secrets needed — the workflow uses the existing repo secrets `APP_ID` / `APP_PRIVATE_KEY`.
2. **Apply the ruleset**: `gh api repos/valory-xyz/olas-operate-app/rulesets --method POST --input .github/rulesets/restrict-release-tag-creation.json`

Order: create the environment before the workflow is first run; apply the ruleset last (once active, manual publishing is blocked, so the sanctioned path must already exist).

## Validation

Mechanism validated on a fork (`rajat2502/olas-operate-app`):
- Tag ruleset — publishing a draft release → blocked (`HTTP 422`); clean `v7.7.7` tag push → blocked; `v7.7.7-signed` → allowed.
- Approval flow — a job gated by `environment: production-publish` paused at `waiting`, un-gated only on reviewer approval.

## Trade-off

The ruleset's bypass actor is the shared `valory-coding-agent` App (reused, not a dedicated app). Any workflow able to mint a `valory-coding-agent` token could therefore also create a release tag, bypassing the gate. Residual risk is bounded by PR review on workflow changes. A dedicated App with environment-scoped secrets would close this fully — deliberately not done, to avoid operating a second App.

## Test plan

- [ ] Create the `production-publish` environment as described
- [ ] Merge this PR
- [ ] Apply the ruleset via `gh api`
- [ ] Next release: build → draft → run `publish-release.yml` → second person approves → release goes public
- [ ] Confirm a non-reviewer cannot publish directly (UI publish → blocked by ruleset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)