### PR TITLE
chore: lock Yarn engine to 1.x (refuse Yarn 4+ if Corepack is bypassed)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,6 +62,12 @@
     "ts-node": "10.9.2",
     "typescript": "5.3.3"
   },
+  "engineStrict": true,
+  "engines": {
+    "node": ">=22.18",
+    "npm": "please-use-yarn",
+    "yarn": "1.x"
+  },
   "name": "olas-operate-app",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "engines": {
     "node": ">=22.18",
     "npm": "please-use-yarn",
-    "yarn": ">=1.22.0"
+    "yarn": "1.x"
   },
   "main": "electron/main.js",
   "name": "olas-operate-app",
@@ -96,10 +96,5 @@
     "test:frontend": "cd frontend && yarn test"
   },
   "version": "1.6.12-rc17",
-  "engine": {
-    "node": "22.18",
-    "yarn": ">=1.22.0",
-    "npm": "please-use-yarn"
-  },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
## Summary

Adds a second-line refusal so a globally-installed Yarn 4 (or any non-1.x Yarn) **cannot run in this repo** even if Corepack routing is bypassed. Pearl already pins Yarn `1.22.22+sha512.<hash>` via the `packageManager` field in both trees — this PR makes the `engines` enforcement match.

Mirrors the pattern shipped in [valory-xyz/wildcard#129](https://github.com/valory-xyz/wildcard/pull/129) (small repo without Pearl's existing supply-chain track).

## Why this matters

Today the `packageManager` field is the primary defense: Corepack reads it on every `yarn` invocation (in CI and on dev machines that have run `corepack enable`) and routes to the hash-verified Yarn 1.22.22 binary.

**Without** `engines.yarn: "1.x"`:
- A developer who hasn't enabled Corepack runs whatever Yarn their global install happens to be
- If that's Yarn 4 (Berry), invoking it in this repo silently writes Berry-format `.yarnrc.yml` and `.yarn/install-state.gz`, applies Berry-only resolution rules, and can rewrite `yarn.lock` away from the v1 header — corrupting the lockfile we've spent the supply-chain track stabilizing

**With** `engines.yarn: "1.x"` plus the existing `engineStrict: true`:
- Yarn 4 refuses to install at all in this repo (it honors `engines.yarn` even without Corepack)
- The supply-chain gates are guarded against a class of "I forgot to set up my machine correctly" failure modes

## Changes

| File | Change |
|------|--------|
| `package.json` | `engines.yarn`: `">=1.22.0"` → `"1.x"`; also dropped the dead typo-named `engine` (singular) sibling field — npm only reads `engines`, the `engine` field has been a vestigial no-op |
| `frontend/package.json` | Added `engines` + `engineStrict: true` to match root's defensive posture. Previously the frontend tree had no engines enforcement at all. |

Net: **+7 / -6 LOC** across 2 files. Zero workflow changes — Pearl's CI workflows already activate Corepack with the integrity-verified `corepack prepare "$PM_SPEC" --activate` form, so they're satisfied either way.

## Why no workflow edits (vs the wildcard pattern)

The wildcard PR added `corepack enable` to 4 workflows because that repo had none. Pearl's `ci.yml` + `release_{linux,mac,win}.yml` already activate Corepack from PR #1954. The remaining non-CI workflows (`calculate-and-update-version.yml` etc.) only call `npm version` to bump strings — they don't run `yarn install`, so Corepack isn't needed there.

## Verified locally

- [x] `yarn install --frozen-lockfile` passes in both trees (Yarn 1.22.22 satisfies the `"1.x"` range)
- [x] `yarn typecheck` (frontend) passes
- [x] `yarn audit:prod` exits 0 in both trees
- [x] `yarn audit:install-hooks` exits 0 in both trees
- [x] `yarn deps:check-pinned` passes both trees

## Test plan

- [ ] CI green on this PR
- [ ] Sanity-check on a fresh checkout: with global Yarn 4 installed and Corepack disabled, `yarn` in this repo refuses to run citing the engines constraint (this is the actual behavior change being tested)

## Out of scope

- **Typo `engine` (singular) field cleanup is included** because it's adjacent and zero-risk (verified via grep — nothing in the repo reads it). Open to splitting if a reviewer prefers a smaller diff.