### PR TITLE
feat(OPE-1617): Standardize insufficient funds error across all the API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Common commands (full list in `package.json` scripts):
 - `yarn dev:frontend` — frontend only (port 3000)
 - `yarn dev:backend` — Python middleware
 - `yarn dev:hardhat` — local Hardhat node
-- `yarn test:frontend`, `yarn lint:frontend [--fix]`, `yarn quality-check:frontend`
+- `yarn test:frontend`, `yarn lint:frontend`, `yarn quality-check:frontend` (lint+typecheck), `yarn typequality-check:frontend` (typecheck only). For autofix, run `cd frontend && yarn lint:fix` — the root `lint:frontend` script doesn't forward `--fix`.
 - `yarn build:frontend`, `yarn build:pearl` (full app via `build_pearl.sh`), `yarn download-binaries`
 
 ## Architecture Details
@@ -37,6 +37,7 @@ The application uses a multi-layered communication architecture:
    - Notifications: `electronAPI.showNotification`
    - Logging / support: `electronAPI.{saveLogs,saveLogsForSupport,cleanupSupportLogs,logEvent,nextLogError,readFile,openPath,getAppVersion}`
    - Managed child windows: `electronAPI.{onRampWindow,web3AuthWindow,web3AuthSwapOwnerWindow,termsAndConditionsWindow}` (each window has `show`/`close` + result callbacks)
+   - OS wake-lock (keeps device awake during AutoRun): `electronAPI.wakeLock.{start,stop}`
    - In-app auto-updater: `electronAPI.autoUpdater.{checkForUpdates,downloadUpdate,cancelDownload,quitAndInstall,onUpdateAvailable,onDownloadProgress,onUpdateDownloaded,onUpdateError,onUpdateNotAvailable}`
    - Raw IPC escape hatch: `electronAPI.ipcRenderer.{send,on,invoke,removeListener}` — used sparingly; prefer the named APIs.
 
@@ -46,14 +47,15 @@ The application uses a multi-layered communication architecture:
    - 50+ FastAPI endpoints, mostly under `/api/v2/*` for services and `/api/*` for account/wallet/bridge/recovery/store.
 
 3. **Frontend State Management**:
-   - React Context providers in `/frontend/context/` (one provider per folder). Non-exhaustive list of load-bearing providers: `ServicesProvider`, `BalanceProvider`, `StakingContractDetailsProvider`, `StakingProgramProvider`, `MasterWalletProvider`, `PearlWalletProvider`, `RewardProvider`, `SetupProvider`, `SettingsProvider`, `StoreProvider`, `PageStateProvider`, `OnRampProvider`, `OnlineStatusProvider`, `MessageProvider`, `SupportModalProvider`, `ElectronApiProvider`, `AutoRunProvider`, `BalancesAndRefillRequirementsProvider`. Read `frontend/context/` before assuming a provider doesn't exist.
+   - React Context providers in `/frontend/context/` (one provider per folder). Non-exhaustive list of load-bearing providers: `ServicesProvider`, `BalanceProvider`, `StakingContractDetailsProvider`, `StakingProgramProvider`, `MasterWalletProvider`, `PearlWalletProvider`, `RewardProvider`, `SetupProvider`, `SettingsProvider`, `StoreProvider`, `PageStateProvider`, `OnRampProvider`, `OnlineStatusProvider`, `MessageProvider`, `SupportModalProvider`, `ElectronApiProvider`, `AutoRunProvider`, `BalancesAndRefillRequirementsProvider`, `SharedProvider`. Read `frontend/context/` before assuming a provider doesn't exist.
    - Electron-native persistence via `electron-store` (`electron/store.js`) — see Electron Store Schema below. All other state lives in `.operate/pearl_store.json` served by the Python backend.
 
 ### Service Templates & Agents
 
 Service configurations live in the `frontend/constants/serviceTemplates/` directory:
-- `serviceTemplates.ts` — combined `SERVICE_TEMPLATES` array (plus templates without their own file, e.g. `AGENTS_FUN_COMMON_TEMPLATE`)
+- `serviceTemplates.ts` — combined `SERVICE_TEMPLATES` array (plus templates without their own file, e.g. `AGENTS_FUN_COMMON_TEMPLATE`, `PETT_AI_SERVICE_TEMPLATE`)
 - `service/` — per-agent template files (`service/babydegen.ts` holds Modius/Optimus; `service/trader.ts` holds PredictTrader/Polystrat)
+- `agentUiReleases.ts` — `AGENT_UI_RELEASES` list shown on the Release Notes page
 - `index.ts` — barrel; `constants.ts` — shared constants
 
 Each service template has a `hash`, `name`, `description`, and versioning. Agents currently shipped: `PredictTrader`, `Modius`, `Optimus`, `AgentsFun`, `PettAi`, `Polystrat`. Chain-specific config (funding requirements, staking programs, NFTs) is in the template's `configurations` object. See `docs/agent-integration-checklist.md` for full agent-integration flow.
@@ -76,7 +78,7 @@ IPC handles: `store`, `store-get`, `store-set`, `store-delete`, `store-clear`. N
 ### Python Backend
 
 - `/operate/` is a **thin shim** — `pearl.py` (PyInstaller entry) and `tendermint.py` (Tendermint binary manager). No `__init__.py`; the real backend lives in `olas-operate-middleware`.
-- `olas-operate-middleware` is **version-pinned** in `pyproject.toml` (`==0.15.22` on `main`). Workflows occasionally swap that for a `git+https://github.com/valory-xyz/olas-operate-middleware.git@<sha>` revision pin during rc cycles (see `.github/workflows/calculate-and-update-version.yml`), but the steady-state pin is an exact PyPI release. Every pin bump can change API response shapes — see Backend Contract Types below. Installed source: `.venv/lib/python3.14/site-packages/operate/`.
+- `olas-operate-middleware` is **version-pinned** in `pyproject.toml` (`==0.15.25` on `main` — re-check the pin before relying on this). Workflows occasionally swap that for a `git+https://github.com/valory-xyz/olas-operate-middleware.git@<sha>` revision pin during rc cycles (see `.github/workflows/calculate-and-update-version.yml`), but the steady-state pin is an exact PyPI release. Every pin bump can change API response shapes — see Backend Contract Types below. Installed source: `.venv/lib/python3.14/site-packages/operate/`.
 - Dev entry: `uv run python -m operate.cli daemon`. Packaged: PyInstaller executable in `electron/bins/middleware/`, built from `operate/pearl.py` via `build_pearl.sh`. Includes Tendermint binary for consensus.
 
 ### Build Process
@@ -134,7 +136,7 @@ To test with a custom service hash: update the hash in the per-agent file under 
 
 ### Workflow
 
-Run `/pre-implementation-check` before writing frontend code. Run `/review-implementation` after each phase. Update tests in the same change as the source file — never defer. For features touching 4+ files, work in phases with `/review-implementation` between them. Run `yarn lint:frontend --fix` after every edit; don't accumulate lint errors.
+Run `/pre-implementation-check` before writing frontend code. Run `/review-implementation` after each phase. Update tests in the same change as the source file — never defer. For features touching 4+ files, work in phases with `/review-implementation` between them. Run `cd frontend && yarn lint:fix` after every edit; don't accumulate lint errors.
 
 ### Fix globally
 

--- a/frontend/components/AgentWallet/AgentWalletProvider.tsx
+++ b/frontend/components/AgentWallet/AgentWalletProvider.tsx
@@ -25,9 +25,18 @@ import { AvailableAsset } from '@/types/Wallet';
 
 import { STEPS, TransactionHistory } from './types';
 
+/**
+ * `gas-error`: user entered the Fund Agent flow from an INSUFFICIENT_SIGNER_GAS
+ * modal. Native-gas funds must route 100% to the AgentEOA, not the Safe — see
+ * `prepareAgentFundsForTransfer` in `ConfirmTransfer.tsx`. Reset to `normal`
+ * once consumed (successful fund) or on dismiss.
+ */
+export type FundEntrySource = 'normal' | 'gas-error';
+
 type AgentWalletNavParams = {
   initialStep?: ValueOf<typeof STEPS>;
   initialFundValues?: TokenBalanceRecord;
+  initialFundEntrySource?: FundEntrySource;
 };
 
 const AgentWalletContext = createContext<{
@@ -42,6 +51,8 @@ const AgentWalletContext = createContext<{
   availableAssets: AvailableAsset[];
   fundInitialValues: Optional<TokenBalanceRecord>;
   setFundInitialValues: (values: TokenBalanceRecord) => void;
+  fundEntrySource: FundEntrySource;
+  setFundEntrySource: (source: FundEntrySource) => void;
 }>({
   walletStep: STEPS.AGENT_WALLET_SCREEN,
   updateStep: () => {},
@@ -54,6 +65,8 @@ const AgentWalletContext = createContext<{
   availableAssets: [],
   fundInitialValues: {},
   setFundInitialValues: () => {},
+  fundEntrySource: 'normal',
+  setFundEntrySource: () => {},
 });
 
 export const AgentWalletProvider = ({ children }: { children: ReactNode }) => {
@@ -73,6 +86,9 @@ export const AgentWalletProvider = ({ children }: { children: ReactNode }) => {
   const { availableAssets } = useAvailableAgentAssets();
   const [fundInitialValues, setFundInitialValues] =
     useState<TokenBalanceRecord>(params.initialFundValues ?? {});
+  const [fundEntrySource, setFundEntrySource] = useState<FundEntrySource>(
+    params.initialFundEntrySource ?? 'normal',
+  );
 
   const { evmHomeChainId: walletChainId } = selectedAgentConfig;
 
@@ -105,6 +121,12 @@ export const AgentWalletProvider = ({ children }: { children: ReactNode }) => {
 
   const updateStep = useCallback(
     (newStep: ValueOf<typeof STEPS>) => {
+      // Stepping away from FUND_AGENT clears the gas-error source so a
+      // subsequent normal entry (e.g. via AgentLowBalanceAlert) doesn't
+      // inherit the force-EOA routing.
+      if (newStep !== STEPS.FUND_AGENT) {
+        setFundEntrySource('normal');
+      }
       setWalletStep(newStep);
     },
     [setWalletStep],
@@ -126,6 +148,8 @@ export const AgentWalletProvider = ({ children }: { children: ReactNode }) => {
         // Initial values for funding agent wallet
         fundInitialValues,
         setFundInitialValues,
+        fundEntrySource,
+        setFundEntrySource,
       }}
     >
       {children}

--- a/frontend/components/AgentWallet/FundAgent/ConfirmTransfer.tsx
+++ b/frontend/components/AgentWallet/FundAgent/ConfirmTransfer.tsx
@@ -32,6 +32,8 @@ import { bigintMin } from '@/utils';
 import { asEvmChainId } from '@/utils/middlewareHelpers';
 import { parseUnits } from '@/utils/numberFormatters';
 
+import { useAgentWallet } from '../AgentWalletProvider';
+
 const { Title, Text } = Typography;
 
 const TransferInProgress = () => (
@@ -110,6 +112,7 @@ const useConfirmTransfer = () => {
   const { selectedService } = useServices();
   const { refetch } = useBalanceAndRefillRequirementsContext();
   const { updateBalances } = useBalanceContext();
+  const { setFundEntrySource } = useAgentWallet();
   const { isPending, isSuccess, isError, error, mutateAsync, reset } =
     useMutation<void, unknown, ChainFunds>({
       mutationFn: async (funds: ChainFunds) => {
@@ -119,6 +122,9 @@ const useConfirmTransfer = () => {
         await FundService.fundAgent({ funds, serviceConfigId });
       },
       onSuccess: () => {
+        // Gas-error entry has been satisfied; future entries (e.g. via
+        // AgentLowBalanceAlert) should use the default EOA-vs-Safe split.
+        setFundEntrySource('normal');
         // Refetch funding requirements and wallet balances because balances are changed
         refetch();
         updateBalances();
@@ -157,19 +163,26 @@ type ConfirmTransferProps = {
  *
  * Converts user-entered amounts into keyed by token address amounts, allocating funds
  * to the service EOA first to cover its requirements, and sending any remainder to safe.
+ *
+ * When `forceEoaOnly` is true, native gas (AddressZero) bypasses the EOA-vs-Safe split
+ * and routes 100% to the EOA — used when the user entered this flow from an
+ * INSUFFICIENT_SIGNER_GAS modal where the EOA is the wallet that needs funding.
+ * ERC20 amounts still follow the regular split.
  */
-const prepareAgentFundsForTransfer = ({
+export const prepareAgentFundsForTransfer = ({
   fundsToTransfer,
   middlewareHomeChainId,
   serviceSafe,
   serviceEoa,
   eoaTokenRequirements,
+  forceEoaOnly = false,
 }: {
   fundsToTransfer: TokenAmounts;
   middlewareHomeChainId: MiddlewareChain;
   serviceSafe: { address: Address };
   serviceEoa: { address: Address };
   eoaTokenRequirements: Maybe<TokenBalanceRecord>;
+  forceEoaOnly?: boolean;
 }): ChainFunds => {
   const chainTokenConfig = TOKEN_CONFIG[asEvmChainId(middlewareHomeChainId)];
   const tokenAmountsByAddress: TokenAmountMap = {};
@@ -193,11 +206,19 @@ const prepareAgentFundsForTransfer = ({
   const agentFunds: Record<Address, TokenAmountMap> = {};
 
   Object.entries(tokenAmountsByAddress).forEach(([tokenAddress, amount]) => {
+    const amountBigInt = BigInt(amount);
+
+    // Gas-error entry: route all native gas to the EOA regardless of the
+    // polled eoaTokenRequirements (which may report 0 if the EOA is fine
+    // for "normal operation" but not for the specific failed transaction).
+    if (forceEoaOnly && tokenAddress === AddressZero) {
+      set(agentFunds, `${eoaAddress}.${tokenAddress}`, amountBigInt.toString());
+      return;
+    }
+
     const requiredForEoa = BigInt(
       (eoaTokenRequirements?.[tokenAddress as Address] as string) || '0',
     );
-
-    const amountBigInt = BigInt(amount);
     const allocateToEoa = bigintMin(amountBigInt, requiredForEoa);
 
     if (allocateToEoa > 0n) {
@@ -234,6 +255,7 @@ export const ConfirmTransfer = ({
   const { onFundAgent, isLoading, isSuccess, isError, error, resetMutation } =
     useConfirmTransfer();
   const { eoaTokenRequirements } = useAgentFundingRequests();
+  const { fundEntrySource } = useAgentWallet();
   const { goto } = usePageState();
 
   const [isTransferStateModalVisible, setIsTransferStateModalVisible] =
@@ -256,6 +278,7 @@ export const ConfirmTransfer = ({
       serviceSafe,
       serviceEoa,
       eoaTokenRequirements,
+      forceEoaOnly: fundEntrySource === 'gas-error',
     });
 
     setIsTransferStateModalVisible(true);
@@ -267,6 +290,7 @@ export const ConfirmTransfer = ({
     serviceSafe,
     serviceEoa,
     eoaTokenRequirements,
+    fundEntrySource,
   ]);
 
   const handleClose = useCallback(() => {

--- a/frontend/components/AgentWallet/PartialWithdraw/PartialWithdrawScreen.tsx
+++ b/frontend/components/AgentWallet/PartialWithdraw/PartialWithdrawScreen.tsx
@@ -192,7 +192,8 @@ export const PartialWithdrawScreen = ({
     onPartialWithdraw,
     resetMutation,
   } = usePartialWithdraw();
-  const { setFundInitialValues, updateStep } = useAgentWallet();
+  const { setFundInitialValues, setFundEntrySource, updateStep } =
+    useAgentWallet();
 
   const [amounts, setAmounts] = useState<PartialWithdrawAmounts>(
     {} as PartialWithdrawAmounts,
@@ -274,6 +275,10 @@ export const PartialWithdrawScreen = ({
     caseType: 'agent-withdraw',
     onFund: (gasError) => {
       setFundInitialValues({ [AddressZero]: gasError.prefill_amount_wei });
+      // Partial-withdraw signer is the AgentEOA. Force all native gas to the
+      // EOA in the Fund Agent flow rather than letting the EOA-vs-Safe split
+      // route it to the Safe based on a stale eoaTokenRequirements poll.
+      setFundEntrySource('gas-error');
       updateStep(STEPS.FUND_AGENT);
     },
     onClose: closeModal,

--- a/frontend/components/AgentWallet/Withdraw/Withdraw.tsx
+++ b/frontend/components/AgentWallet/Withdraw/Withdraw.tsx
@@ -116,7 +116,8 @@ export const Withdraw = ({ onBack }: EnterWithdrawalAddressProps) => {
     onWithdrawFunds,
     resetMutation,
   } = useWithdrawFunds();
-  const { setFundInitialValues, updateStep } = useAgentWallet();
+  const { setFundInitialValues, setFundEntrySource, updateStep } =
+    useAgentWallet();
 
   const [isWithdrawModalVisible, setWithdrawModalVisible] = useState(false);
 
@@ -140,6 +141,10 @@ export const Withdraw = ({ onBack }: EnterWithdrawalAddressProps) => {
       // it by AddressZero — FundAgent maps AddressZero → the chain's native
       // symbol automatically via TOKEN_CONFIG.
       setFundInitialValues({ [AddressZero]: gasError.prefill_amount_wei });
+      // The withdrawal signer is the AgentEOA. Force all native gas to the
+      // EOA in the Fund Agent flow rather than letting the EOA-vs-Safe split
+      // route it to the Safe based on a stale eoaTokenRequirements poll.
+      setFundEntrySource('gas-error');
       updateStep(STEPS.FUND_AGENT);
     },
     onClose: closeWithdrawModal,

--- a/frontend/components/Bridge/BridgeInProgress/BridgeInProgress.tsx
+++ b/frontend/components/Bridge/BridgeInProgress/BridgeInProgress.tsx
@@ -58,6 +58,14 @@ export const BridgeInProgress = ({
   const symbols = transfers.map((transfer) => transfer.toSymbol);
 
   const [isBridgeRetrying, setIsBridgeRetrying] = useState(false);
+  // Set to true on first dismiss and intentionally never reset for the
+  // component's lifetime. The bridge-execute is a `useQuery`, so dismissing
+  // alone (without this flag) would trigger an immediate refetch — the same
+  // gas error would land in cache and re-open the modal on the next render.
+  // Recovery for the user is via the bridging-step retry CTA (which routes
+  // to NEED_REFILL), not by re-rendering this modal. A genuinely-new gas
+  // error on a follow-up bridge attempt is reachable by remounting (e.g.
+  // navigating away and back, which is the natural retry path).
   const [isGasModalDismissed, setIsGasModalDismissed] = useState(false);
   const refetchBridgeExecute = useRetryBridge();
 

--- a/frontend/components/Bridge/BridgeInProgress/BridgeInProgress.tsx
+++ b/frontend/components/Bridge/BridgeInProgress/BridgeInProgress.tsx
@@ -1,8 +1,14 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { Flex, Typography } from 'antd';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { Alert, CardFlex } from '@/components/ui';
-import { useBridgingSteps, usePageState } from '@/hooks';
+import { Alert, CardFlex, InsufficientSignerGasModal } from '@/components/ui';
+import { PAGES, REACT_QUERY_KEYS } from '@/constants';
+import {
+  useBridgingSteps,
+  useInsufficientGasModal,
+  usePageState,
+} from '@/hooks';
 import {
   BridgingStepStatus,
   CrossChainTransferDetails,
@@ -48,13 +54,40 @@ export const BridgeInProgress = ({
   mode = 'deposit',
 }: BridgeInProgressProps) => {
   const { goto } = usePageState();
+  const queryClient = useQueryClient();
   const symbols = transfers.map((transfer) => transfer.toSymbol);
 
   const [isBridgeRetrying, setIsBridgeRetrying] = useState(false);
+  const [isGasModalDismissed, setIsGasModalDismissed] = useState(false);
   const refetchBridgeExecute = useRetryBridge();
 
-  const { isBridging, isBridgingFailed, isBridgingCompleted, bridgeStatus } =
-    useBridgingSteps(symbols, quoteId);
+  const {
+    isBridging,
+    isBridgingFailed,
+    isBridgingCompleted,
+    bridgeStatus,
+    isBridgeExecuteError,
+    bridgeExecuteError,
+  } = useBridgingSteps(symbols, quoteId);
+
+  const gasModalProps = useInsufficientGasModal({
+    isError: isBridgeExecuteError && !isGasModalDismissed,
+    error: bridgeExecuteError,
+    caseType: 'bridge',
+    onFund: (gasError) => {
+      goto(PAGES.FundPearlWallet, {
+        prefillAmountWei: gasError.prefill_amount_wei,
+      });
+    },
+    onClose: () => setIsGasModalDismissed(true),
+    // The bridge execute is a useQuery, not a mutation. Removing it from the
+    // cache lets a retry refetch cleanly without re-rendering the modal on
+    // stale error state.
+    resetMutation: () =>
+      queryClient.removeQueries({
+        queryKey: REACT_QUERY_KEYS.BRIDGE_EXECUTE_KEY(quoteId),
+      }),
+  });
 
   const isRefillRequired = bridgeRetryOutcome === 'NEED_REFILL';
 
@@ -188,6 +221,7 @@ export const BridgeInProgress = ({
           />
         )}
       </CardFlex>
+      {gasModalProps && <InsufficientSignerGasModal {...gasModalProps} />}
     </Flex>
   );
 };

--- a/frontend/components/MainPage/Home/Overview/AgentInfo/AgentRunButton/AgentNotRunningButton.tsx
+++ b/frontend/components/MainPage/Home/Overview/AgentInfo/AgentRunButton/AgentNotRunningButton.tsx
@@ -36,8 +36,10 @@ export const AgentNotRunningButton = () => {
         initialFundEntrySource: 'gas-error',
       });
     },
+    // Dismissal clears `startError` → `isStartError` flips to false → the
+    // modal narrows out on the next render. No separate UI-only dismiss
+    // flag to manage, so `resetMutation` would be a no-op duplicate here.
     onClose: resetStart,
-    resetMutation: resetStart,
   });
 
   const onStart = async () => {

--- a/frontend/components/MainPage/Home/Overview/AgentInfo/AgentRunButton/AgentNotRunningButton.tsx
+++ b/frontend/components/MainPage/Home/Overview/AgentInfo/AgentRunButton/AgentNotRunningButton.tsx
@@ -1,6 +1,13 @@
 import { Button } from 'antd';
 
-import { useServiceDeployment } from '@/hooks';
+import { STEPS } from '@/components/AgentWallet/types';
+import { InsufficientSignerGasModal } from '@/components/ui';
+import { AddressZero, PAGES } from '@/constants';
+import {
+  useInsufficientGasModal,
+  usePageState,
+  useServiceDeployment,
+} from '@/hooks';
 
 import { AgentBusyButton } from './AgentBusyButton';
 
@@ -8,20 +15,56 @@ import { AgentBusyButton } from './AgentBusyButton';
  * Agent Not Running Button
  */
 export const AgentNotRunningButton = () => {
-  const { isLoading, isDeployable, handleStart } = useServiceDeployment();
+  const { goto } = usePageState();
+  const {
+    isLoading,
+    isDeployable,
+    handleStart,
+    isStartError,
+    startError,
+    resetStart,
+  } = useServiceDeployment();
+
+  const gasModalProps = useInsufficientGasModal({
+    isError: isStartError,
+    error: startError,
+    caseType: 'start-service',
+    onFund: (gasError) => {
+      goto(PAGES.AgentWallet, {
+        initialStep: STEPS.FUND_AGENT,
+        initialFundValues: { [AddressZero]: gasError.prefill_amount_wei },
+        initialFundEntrySource: 'gas-error',
+      });
+    },
+    onClose: resetStart,
+    resetMutation: resetStart,
+  });
+
+  const onStart = async () => {
+    try {
+      await handleStart();
+    } catch {
+      // The error is exposed via `startError` / `isStartError` so the host
+      // can render the gas modal. Non-gas errors surface as a toast from
+      // `useServiceDeployment`. Nothing else to do here.
+    }
+  };
 
   if (isLoading) {
     return <AgentBusyButton text="Loading" />;
   }
 
   return (
-    <Button
-      type="primary"
-      size="large"
-      disabled={!isDeployable}
-      onClick={isDeployable ? handleStart : undefined}
-    >
-      Start agent
-    </Button>
+    <>
+      <Button
+        type="primary"
+        size="large"
+        disabled={!isDeployable}
+        onClick={isDeployable ? onStart : undefined}
+      >
+        Start agent
+      </Button>
+      {gasModalProps && <InsufficientSignerGasModal {...gasModalProps} />}
+    </>
   );
 };

--- a/frontend/components/OnRamp/OnRampPaymentSteps/OnRampPaymentSteps.tsx
+++ b/frontend/components/OnRamp/OnRampPaymentSteps/OnRampPaymentSteps.tsx
@@ -1,10 +1,16 @@
+import { useQueryClient } from '@tanstack/react-query';
 import compact from 'lodash/compact';
 import { useEffect, useState } from 'react';
 
 import { AgentSetupCompleteModal } from '@/components/ui/AgentSetupCompleteModal';
+import { InsufficientSignerGasModal } from '@/components/ui/InsufficientSignerGasModal';
 import { TransactionSteps } from '@/components/ui/TransactionSteps';
 import { EvmChainId } from '@/constants/chains';
+import { PAGES } from '@/constants/pages';
+import { REACT_QUERY_KEYS } from '@/constants/reactQueryKeys';
+import { useInsufficientGasModal } from '@/hooks/useInsufficientGasModal';
 import { useOnRampContext } from '@/hooks/useOnRampContext';
+import { usePageState } from '@/hooks/usePageState';
 
 import { GetOnRampRequirementsParams, OnRampMode } from '../types';
 import { useBuyCryptoStep } from './useBuyCryptoStep';
@@ -37,12 +43,37 @@ export const OnRampPaymentSteps = ({
   // step 1: Buy crypto
   const buyCryptoStep = useBuyCryptoStep();
 
+  const { goto } = usePageState();
+  const queryClient = useQueryClient();
+  const [isGasModalDismissed, setIsGasModalDismissed] = useState(false);
+
   // step 2: Swap funds
   const {
     tokensToBeTransferred,
     tokensToBeBridged,
     step: swapStep,
+    quoteId,
+    isBridgeExecuteError,
+    bridgeExecuteError,
   } = useSwapFundsStep(onRampChainId, getOnRampRequirementsParams);
+
+  const gasModalProps = useInsufficientGasModal({
+    isError: isBridgeExecuteError && !isGasModalDismissed,
+    error: bridgeExecuteError,
+    caseType: 'bridge',
+    onFund: (gasError) => {
+      goto(PAGES.FundPearlWallet, {
+        prefillAmountWei: gasError.prefill_amount_wei,
+      });
+    },
+    onClose: () => setIsGasModalDismissed(true),
+    resetMutation: () => {
+      if (!quoteId) return;
+      queryClient.removeQueries({
+        queryKey: REACT_QUERY_KEYS.BRIDGE_EXECUTE_KEY(quoteId),
+      });
+    },
+  });
 
   // step 3 & 4: Create Master Safe and transfer funds
   const {
@@ -100,6 +131,7 @@ export const OnRampPaymentSteps = ({
         // same as we do it with for depositing with showOnRampCompleteModal
         mode === 'onboard' && isSetupCompleted && <AgentSetupCompleteModal />
       }
+      {gasModalProps && <InsufficientSignerGasModal {...gasModalProps} />}
     </>
   );
 };

--- a/frontend/components/OnRamp/OnRampPaymentSteps/OnRampPaymentSteps.tsx
+++ b/frontend/components/OnRamp/OnRampPaymentSteps/OnRampPaymentSteps.tsx
@@ -45,6 +45,12 @@ export const OnRampPaymentSteps = ({
 
   const { goto } = usePageState();
   const queryClient = useQueryClient();
+  // Set to true on first dismiss and intentionally never reset for the
+  // component's lifetime — same rationale as `BridgeInProgress`:
+  // bridge-execute is a `useQuery` and reopening the modal on every refetch
+  // of the same cached gas error is the wrong UX. The bridging-step retry
+  // CTA (NEED_REFILL outcome) is the recovery path; a fresh gas error after
+  // remount would re-show the modal as expected.
   const [isGasModalDismissed, setIsGasModalDismissed] = useState(false);
 
   // step 2: Swap funds

--- a/frontend/components/OnRamp/OnRampPaymentSteps/useSwapFundsStep.tsx
+++ b/frontend/components/OnRamp/OnRampPaymentSteps/useSwapFundsStep.tsx
@@ -138,6 +138,11 @@ type SwapFundsStep = {
   tokensToBeTransferred: TokenSymbol[];
   tokensToBeBridged: TokenSymbol[];
   step: TransactionStep;
+  /** Quote id used by the host to invalidate the bridge-execute query on retry. */
+  quoteId?: string;
+  /** Forwarded from `useBridgingSteps` so the host can render an InsufficientSignerGasModal. */
+  isBridgeExecuteError: boolean;
+  bridgeExecuteError: unknown;
 };
 
 const EMPTY_STATE: SwapFundsStep = {
@@ -148,6 +153,8 @@ const EMPTY_STATE: SwapFundsStep = {
     title: TITLE,
     subSteps: [],
   },
+  isBridgeExecuteError: false,
+  bridgeExecuteError: null,
 };
 
 const PROCESS_STATE: SwapFundsStep = {
@@ -158,11 +165,15 @@ const PROCESS_STATE: SwapFundsStep = {
     title: TITLE,
     subSteps: [{ description: 'Sending transaction...' }],
   },
+  isBridgeExecuteError: false,
+  bridgeExecuteError: null,
 };
 
 const getQuoteFailedErrorState = (onRetry: () => void): SwapFundsStep => ({
   tokensToBeTransferred: [],
   tokensToBeBridged: [],
+  isBridgeExecuteError: false,
+  bridgeExecuteError: null,
   step: {
     status: 'error',
     title: TITLE,
@@ -213,8 +224,14 @@ export const useSwapFundsStep = (
     return bridgeFundingRequirements.id;
   }, [isLoading, isOnRampingStepCompleted, bridgeFundingRequirements]);
 
-  const { isBridgingCompleted, isBridgingFailed, isBridging, bridgeStatus } =
-    useBridgingSteps(tokensToBeBridged, quoteId);
+  const {
+    isBridgingCompleted,
+    isBridgingFailed,
+    isBridging,
+    bridgeStatus,
+    isBridgeExecuteError,
+    bridgeExecuteError,
+  } = useBridgingSteps(tokensToBeBridged, quoteId);
 
   // If the swap step is already completed, we do not swap funds again
   useEffect(() => {
@@ -262,16 +279,31 @@ export const useSwapFundsStep = (
 
   if (!isSwappingFundsStepCompleted) {
     if (isLoading || isBridging) {
-      return { ...PROCESS_STATE, tokensToBeBridged };
+      return {
+        ...PROCESS_STATE,
+        tokensToBeBridged,
+        quoteId,
+        isBridgeExecuteError,
+        bridgeExecuteError,
+      };
     }
     if (hasError) {
-      return { ...getQuoteFailedErrorState(onRetry), tokensToBeBridged };
+      return {
+        ...getQuoteFailedErrorState(onRetry),
+        tokensToBeBridged,
+        quoteId,
+        isBridgeExecuteError,
+        bridgeExecuteError,
+      };
     }
   }
 
   return {
     tokensToBeTransferred,
     tokensToBeBridged,
+    quoteId,
+    isBridgeExecuteError,
+    bridgeExecuteError,
     step: {
       status: bridgeStepStatus,
       title: TITLE,

--- a/frontend/components/ui/InsufficientSignerGasModal.tsx
+++ b/frontend/components/ui/InsufficientSignerGasModal.tsx
@@ -10,7 +10,9 @@ import { Modal } from './Modal';
 export type InsufficientSignerGasCase =
   | 'agent-withdraw'
   | 'pearl-withdraw'
-  | 'fund-agent';
+  | 'fund-agent'
+  | 'start-service'
+  | 'bridge';
 
 const COPY: Record<
   InsufficientSignerGasCase,
@@ -30,6 +32,16 @@ const COPY: Record<
     title: 'Transfer Failed: Insufficient Balance',
     walletLabel: 'Pearl wallet',
     ctaLabel: 'Fund Agent',
+  },
+  'start-service': {
+    title: "Couldn't Start Agent: Insufficient Balance",
+    walletLabel: 'agent wallet',
+    ctaLabel: 'Fund Agent',
+  },
+  bridge: {
+    title: 'Bridging Failed: Insufficient Balance',
+    walletLabel: 'Pearl wallet',
+    ctaLabel: 'Fund Pearl Wallet',
   },
 };
 

--- a/frontend/hooks/useBridgingSteps.ts
+++ b/frontend/hooks/useBridgingSteps.ts
@@ -61,6 +61,7 @@ export const useBridgingSteps = (
     isLoading: isBridgeExecuteLoading,
     isFetching: isBridgeExecuteFetching,
     isError: isBridgeExecuteError,
+    error: bridgeExecuteError,
     data: bridgeExecuteData,
   } = useQuery({
     queryKey: REACT_QUERY_KEYS.BRIDGE_EXECUTE_KEY(quoteId!),
@@ -201,5 +202,9 @@ export const useBridgingSteps = (
     isBridgingFailed,
     isBridgingCompleted,
     bridgeStatus,
+    /** Rejection body from `/bridge/execute` when the query fails. May be an
+     * `InsufficientGasErrorBody` — host should narrow via `isInsufficientGasError`. */
+    bridgeExecuteError,
+    isBridgeExecuteError,
   };
 };

--- a/frontend/hooks/useServiceDeployment.ts
+++ b/frontend/hooks/useServiceDeployment.ts
@@ -1,8 +1,9 @@
 import { message } from 'antd';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { MasterEoa, MasterSafe, PAGES } from '@/constants';
 import { MiddlewareDeploymentStatusMap } from '@/constants/deployment';
+import { isInsufficientGasError } from '@/constants/errors';
 import { useBalanceContext } from '@/hooks/useBalanceContext';
 import { useDeployability } from '@/hooks/useDeployability';
 import { useElectronApi } from '@/hooks/useElectronApi';
@@ -137,12 +138,21 @@ export const useServiceDeployment = () => {
     updateBalances,
   ]);
 
+  // Surface the start-failure error (if any) so a host can render the
+  // InsufficientSignerGasModal when the error is an INSUFFICIENT_SIGNER_GAS
+  // body. We track this outside react-query because handleStart is a plain
+  // callback and existing callers (and tests) rely on its imperative shape.
+  const [startError, setStartError] = useState<unknown>(null);
+  const isStartError = startError !== null;
+  const resetStart = useCallback(() => setStartError(null), []);
+
   const handleStart = useCallback(async () => {
     if (!masterWallets?.[0]) return;
     if (!selectedStakingProgramId) {
       throw new Error('Staking program ID required');
     }
 
+    setStartError(null);
     pauseAllPolling();
     overrideSelectedServiceStatus(MiddlewareDeploymentStatusMap.DEPLOYING);
 
@@ -164,7 +174,15 @@ export const useServiceDeployment = () => {
       });
     } catch (error) {
       console.error('Error during start:', error);
-      showNotification?.('An error occurred while starting. Please try again.');
+      // For non-gas errors, surface a generic toast. Gas errors are surfaced
+      // via the InsufficientSignerGasModal on the host (AgentNotRunningButton)
+      // — a toast on top would duplicate the signal.
+      if (!isInsufficientGasError(error)) {
+        showNotification?.(
+          'An error occurred while starting. Please try again.',
+        );
+      }
+      setStartError(error);
       overrideSelectedServiceStatus(null);
       resumeAllPolling();
       throw error;
@@ -199,5 +217,12 @@ export const useServiceDeployment = () => {
     startService,
   ]);
 
-  return { isLoading, isDeployable, handleStart };
+  return {
+    isLoading,
+    isDeployable,
+    handleStart,
+    isStartError,
+    startError,
+    resetStart,
+  };
 };

--- a/frontend/service/Bridge.ts
+++ b/frontend/service/Bridge.ts
@@ -26,7 +26,13 @@ const getBridgeRefillRequirements = async (
   });
 
 /**
- * Execute bridge for the provided quote bundle id
+ * Execute bridge for the provided quote bundle id.
+ *
+ * On a non-OK response, throws the parsed JSON error body (or `{}` if the
+ * body isn't JSON). Callers that care about the `INSUFFICIENT_SIGNER_GAS`
+ * branch should narrow via `isInsufficientGasError(err)` from `@/constants`.
+ *
+ * @throws InsufficientGasErrorBody | Record<string, unknown>
  */
 const executeBridge = async (
   id: string,
@@ -37,11 +43,9 @@ const executeBridge = async (
     headers: { ...CONTENT_TYPE_JSON_UTF8 },
     body: JSON.stringify({ id }),
     signal,
-  }).then((response) => {
+  }).then(async (response) => {
     if (response.ok) return response.json();
-    throw new Error(
-      `Failed to execute bridge quote for the following quote id: ${id}`,
-    );
+    throw await response.json().catch(() => ({}));
   });
 
 /**

--- a/frontend/service/Services.ts
+++ b/frontend/service/Services.ts
@@ -163,9 +163,13 @@ const putService = async ({
   });
 
 /**
- * Starts a service
- * @param serviceTemplate
- * @returns Promise<Service>
+ * Starts a service.
+ *
+ * On a non-OK response, throws the parsed JSON error body (or `{}` if the
+ * body isn't JSON). Callers that care about the `INSUFFICIENT_SIGNER_GAS`
+ * branch should narrow via `isInsufficientGasError(err)` from `@/constants`.
+ *
+ * @throws InsufficientGasErrorBody | Record<string, unknown>
  */
 const startService = async (
   serviceConfigId: string,
@@ -173,11 +177,11 @@ const startService = async (
   fetch(`${BACKEND_URL_V2}/service/${serviceConfigId}`, {
     method: 'POST',
     headers: { ...CONTENT_TYPE_JSON_UTF8 },
-  }).then((response) => {
+  }).then(async (response) => {
     if (response.ok) {
       return response.json();
     }
-    throw new Error('Failed to start the service');
+    throw await response.json().catch(() => ({}));
   });
 
 const stopDeployment = async (

--- a/frontend/service/Services.ts
+++ b/frontend/service/Services.ts
@@ -165,11 +165,16 @@ const putService = async ({
 /**
  * Starts a service.
  *
- * On a non-OK response, throws the parsed JSON error body (or `{}` if the
- * body isn't JSON). Callers that care about the `INSUFFICIENT_SIGNER_GAS`
- * branch should narrow via `isInsufficientGasError(err)` from `@/constants`.
+ * On a non-OK response, throws an Error whose `.message` is the backend's
+ * error string (or a generic fallback) and which has the full parsed JSON
+ * body merged onto it as own properties — so:
+ *   - `${err}` / log lines stay diagnosable (was `[object Object]` when we
+ *     threw the body directly; AutoRun's `useAutoRunStartOperations`
+ *     stringifies the error into its `lastInfraError` reason).
+ *   - `isInsufficientGasError(err)` still narrows (the Error is
+ *     `typeof 'object'` with `error_code`/`chain`/`prefill_amount_wei`).
  *
- * @throws InsufficientGasErrorBody | Record<string, unknown>
+ * @throws Error & Partial<InsufficientGasErrorBody>
  */
 const startService = async (
   serviceConfigId: string,
@@ -181,7 +186,12 @@ const startService = async (
     if (response.ok) {
       return response.json();
     }
-    throw await response.json().catch(() => ({}));
+    const body = await response.json().catch(() => ({}));
+    const err = new Error(
+      (body as { error?: string })?.error || 'Failed to start the service',
+    );
+    Object.assign(err, body);
+    throw err;
   });
 
 const stopDeployment = async (

--- a/frontend/tests/components/AgentWallet/FundAgent/prepareAgentFundsForTransfer.test.ts
+++ b/frontend/tests/components/AgentWallet/FundAgent/prepareAgentFundsForTransfer.test.ts
@@ -1,0 +1,85 @@
+import { prepareAgentFundsForTransfer } from '../../../../components/AgentWallet/FundAgent/ConfirmTransfer';
+import { AddressZero } from '../../../../constants/address';
+import { MiddlewareChainMap } from '../../../../constants/chains';
+import { Address } from '../../../../types/Address';
+import {
+  DEFAULT_EOA_ADDRESS,
+  DEFAULT_SAFE_ADDRESS,
+} from '../../../helpers/factories';
+
+describe('prepareAgentFundsForTransfer', () => {
+  const baseArgs = {
+    middlewareHomeChainId: MiddlewareChainMap.GNOSIS,
+    serviceSafe: { address: DEFAULT_SAFE_ADDRESS as Address },
+    serviceEoa: { address: DEFAULT_EOA_ADDRESS as Address },
+  };
+
+  describe('default split (forceEoaOnly=false)', () => {
+    it('allocates to EOA up to eoaTokenRequirements, remainder to safe', () => {
+      const result = prepareAgentFundsForTransfer({
+        ...baseArgs,
+        fundsToTransfer: { XDAI: { amount: 1 } },
+        eoaTokenRequirements: { [AddressZero]: '300000000000000000' },
+      });
+
+      const chainFunds = result[MiddlewareChainMap.GNOSIS]!;
+      expect(chainFunds[DEFAULT_EOA_ADDRESS as Address]?.[AddressZero]).toBe(
+        '300000000000000000',
+      );
+      expect(chainFunds[DEFAULT_SAFE_ADDRESS as Address]?.[AddressZero]).toBe(
+        '700000000000000000',
+      );
+    });
+
+    it('routes everything to safe when eoaTokenRequirements is empty', () => {
+      const result = prepareAgentFundsForTransfer({
+        ...baseArgs,
+        fundsToTransfer: { XDAI: { amount: 1 } },
+        eoaTokenRequirements: {},
+      });
+
+      const chainFunds = result[MiddlewareChainMap.GNOSIS]!;
+      expect(chainFunds[DEFAULT_EOA_ADDRESS as Address]).toBeUndefined();
+      expect(chainFunds[DEFAULT_SAFE_ADDRESS as Address]?.[AddressZero]).toBe(
+        '1000000000000000000',
+      );
+    });
+  });
+
+  describe('forceEoaOnly=true (gas-error entry)', () => {
+    it('routes all native gas to EOA even when eoaTokenRequirements reports 0', () => {
+      const result = prepareAgentFundsForTransfer({
+        ...baseArgs,
+        fundsToTransfer: { XDAI: { amount: 1 } },
+        // The polled requirements say EOA needs nothing — without
+        // forceEoaOnly, this is the bug path that routes funds to the safe.
+        eoaTokenRequirements: {},
+        forceEoaOnly: true,
+      });
+
+      const chainFunds = result[MiddlewareChainMap.GNOSIS]!;
+      expect(chainFunds[DEFAULT_EOA_ADDRESS as Address]?.[AddressZero]).toBe(
+        '1000000000000000000',
+      );
+      expect(chainFunds[DEFAULT_SAFE_ADDRESS as Address]).toBeUndefined();
+    });
+
+    it('routes all native gas to EOA when eoaTokenRequirements reports a smaller amount', () => {
+      const result = prepareAgentFundsForTransfer({
+        ...baseArgs,
+        fundsToTransfer: { XDAI: { amount: 1 } },
+        // Even though the polled requirements say EOA needs only 0.3, the
+        // user came here because the failed tx needed more — force all 1
+        // XDAI to the EOA.
+        eoaTokenRequirements: { [AddressZero]: '300000000000000000' },
+        forceEoaOnly: true,
+      });
+
+      const chainFunds = result[MiddlewareChainMap.GNOSIS]!;
+      expect(chainFunds[DEFAULT_EOA_ADDRESS as Address]?.[AddressZero]).toBe(
+        '1000000000000000000',
+      );
+      expect(chainFunds[DEFAULT_SAFE_ADDRESS as Address]).toBeUndefined();
+    });
+  });
+});

--- a/frontend/tests/components/AgentWallet/PartialWithdraw/PartialWithdrawScreen.test.tsx
+++ b/frontend/tests/components/AgentWallet/PartialWithdraw/PartialWithdrawScreen.test.tsx
@@ -75,6 +75,7 @@ const onPartialWithdraw = jest.fn();
 const resetMutation = jest.fn();
 const setFundInitialValues = jest.fn();
 const updateStep = jest.fn();
+const setFundEntrySource = jest.fn();
 const onBack = jest.fn();
 
 const gnosisResponse = {
@@ -133,7 +134,11 @@ const setUpHookMocks = (
 describe('PartialWithdrawScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseAgentWallet.mockReturnValue({ setFundInitialValues, updateStep });
+    mockUseAgentWallet.mockReturnValue({
+      setFundInitialValues,
+      setFundEntrySource,
+      updateStep,
+    });
     mockUseServices.mockReturnValue({
       selectedAgentConfig: {
         evmHomeChainId: 100,
@@ -251,6 +256,7 @@ describe('PartialWithdrawScreen', () => {
     fireEvent.click(screen.getByTestId('gas-modal-fund'));
     expect(updateStep).toHaveBeenCalledWith(STEPS.FUND_AGENT);
     expect(setFundInitialValues).toHaveBeenCalled();
+    expect(setFundEntrySource).toHaveBeenCalledWith('gas-error');
   });
 
   // Try Again is the user-facing retry on the WithdrawalFailed modal —

--- a/frontend/tests/components/AgentWallet/Withdraw/Withdraw.test.tsx
+++ b/frontend/tests/components/AgentWallet/Withdraw/Withdraw.test.tsx
@@ -75,11 +75,13 @@ const mockUseAgentWallet = useAgentWallet as jest.Mock;
 describe('Withdraw (AgentWallet)', () => {
   const setFundInitialValues = jest.fn();
   const updateStep = jest.fn();
+  const setFundEntrySource = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseAgentWallet.mockReturnValue({
       setFundInitialValues,
+      setFundEntrySource,
       updateStep,
     });
     mockUseWithdrawFunds.mockReturnValue({
@@ -153,6 +155,7 @@ describe('Withdraw (AgentWallet)', () => {
     expect(setFundInitialValues).toHaveBeenCalledWith({
       [AddressZero]: '2500000000000000',
     });
+    expect(setFundEntrySource).toHaveBeenCalledWith('gas-error');
     expect(updateStep).toHaveBeenCalledWith(STEPS.FUND_AGENT);
   });
 
@@ -173,6 +176,7 @@ describe('Withdraw (AgentWallet)', () => {
       screen.queryByTestId('insufficient-gas-modal'),
     ).not.toBeInTheDocument();
     expect(setFundInitialValues).not.toHaveBeenCalled();
+    expect(setFundEntrySource).not.toHaveBeenCalled();
     expect(updateStep).not.toHaveBeenCalled();
   });
 

--- a/frontend/tests/components/Bridge/BridgeInProgress/BridgeInProgress.test.tsx
+++ b/frontend/tests/components/Bridge/BridgeInProgress/BridgeInProgress.test.tsx
@@ -37,6 +37,35 @@ jest.mock('../../../../components/ui', () => ({
     createElement('div', { 'data-testid': 'alert' }, message),
   CardFlex: ({ children }: { children: React.ReactNode }) =>
     createElement('div', null, children),
+  InsufficientSignerGasModal: (props: {
+    caseType: string;
+    onFund: () => void;
+    onClose: () => void;
+  }) =>
+    createElement(
+      'div',
+      { 'data-testid': 'insufficient-gas-modal' },
+      createElement(
+        'span',
+        { 'data-testid': 'gas-modal-case' },
+        props.caseType,
+      ),
+      createElement('button', {
+        'data-testid': 'gas-modal-fund',
+        onClick: props.onFund,
+      }),
+      createElement('button', {
+        'data-testid': 'gas-modal-close',
+        onClick: props.onClose,
+      }),
+    ),
+}));
+
+// Stub useQueryClient — BridgeInProgress only uses queryClient.removeQueries
+// inside the gas-modal reset callback, which doesn't fire in these tests.
+const mockRemoveQueries = jest.fn();
+jest.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ removeQueries: mockRemoveQueries }),
 }));
 
 // Mock BridgeTransferFlow
@@ -68,9 +97,12 @@ jest.mock(
 // Mock hooks
 const mockUseBridgingSteps = jest.fn();
 const mockUsePageState = jest.fn();
+const mockUseInsufficientGasModal = jest.fn();
 jest.mock('../../../../hooks', () => ({
   useBridgingSteps: (...args: unknown[]) => mockUseBridgingSteps(...args),
   usePageState: () => mockUsePageState(),
+  useInsufficientGasModal: (...args: unknown[]) =>
+    mockUseInsufficientGasModal(...args),
 }));
 
 const mockUseMasterSafeCreateAndTransferSteps = jest.fn();
@@ -131,6 +163,8 @@ type BridgingStepsReturn = {
   isBridgingFailed: boolean;
   isBridgingCompleted: boolean;
   bridgeStatus: BridgeStatuses | null;
+  isBridgeExecuteError: boolean;
+  bridgeExecuteError: unknown;
 };
 
 type MasterSafeStepsReturn = {
@@ -157,6 +191,8 @@ const defaultBridging: BridgingStepsReturn = {
   isBridgingFailed: false,
   isBridgingCompleted: false,
   bridgeStatus: null,
+  isBridgeExecuteError: false,
+  bridgeExecuteError: null,
 };
 
 const defaultMasterSafe: MasterSafeStepsReturn = {
@@ -183,6 +219,9 @@ const setupMocks = (
   });
   mockUsePageState.mockReturnValue({ goto: jest.fn() });
   mockRefetchBridgeExecute.mockResolvedValue(undefined);
+  // Default: the gas modal is not shown. Individual tests can override to
+  // assert the gas-modal path.
+  mockUseInsufficientGasModal.mockReturnValue(null);
 };
 
 const defaultProps: BridgeInProgressProps = {
@@ -569,6 +608,56 @@ describe('BridgeInProgress', () => {
       // The callback should forward to onBridgeRetryOutcome
       callbackArg('NEED_REFILL');
       expect(onBridgeRetryOutcome).toHaveBeenCalledWith('NEED_REFILL');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // InsufficientSignerGasModal hosting
+  // -------------------------------------------------------------------------
+  describe('insufficient-gas modal', () => {
+    it('renders the modal when useInsufficientGasModal returns props', () => {
+      setupMocks({ bridging: { isBridgeExecuteError: true } });
+      const onFund = jest.fn();
+      const onClose = jest.fn();
+      mockUseInsufficientGasModal.mockReturnValue({
+        caseType: 'bridge',
+        chain: 'ethereum',
+        prefillAmountWei: '1000000000000000000',
+        onFund,
+        onClose,
+      });
+
+      renderComponent();
+      expect(screen.getByTestId('insufficient-gas-modal')).toBeInTheDocument();
+      expect(screen.getByTestId('gas-modal-case')).toHaveTextContent('bridge');
+    });
+
+    it('forwards `bridge` caseType + bridgeExecuteError into useInsufficientGasModal', () => {
+      const bridgeExecuteError = {
+        error_code: 'INSUFFICIENT_SIGNER_GAS',
+        chain: 'ethereum',
+        prefill_amount_wei: '1000000000000000000',
+      };
+      setupMocks({
+        bridging: { isBridgeExecuteError: true, bridgeExecuteError },
+      });
+      renderComponent();
+
+      const lastCall = mockUseInsufficientGasModal.mock.calls.at(-1)!;
+      expect(lastCall[0]).toMatchObject({
+        caseType: 'bridge',
+        error: bridgeExecuteError,
+        isError: true,
+      });
+    });
+
+    it('does not render the modal when the gas hook returns null', () => {
+      setupMocks();
+      mockUseInsufficientGasModal.mockReturnValue(null);
+      renderComponent();
+      expect(
+        screen.queryByTestId('insufficient-gas-modal'),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/tests/components/MainPage/Home/Overview/AgentInfo/AgentRunButton/AgentNotRunningButton.test.tsx
+++ b/frontend/tests/components/MainPage/Home/Overview/AgentInfo/AgentRunButton/AgentNotRunningButton.test.tsx
@@ -1,0 +1,179 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { STEPS } from '../../../../../../../components/AgentWallet/types';
+import { AgentNotRunningButton } from '../../../../../../../components/MainPage/Home/Overview/AgentInfo/AgentRunButton/AgentNotRunningButton';
+import { AddressZero } from '../../../../../../../constants/address';
+import { PAGES } from '../../../../../../../constants/pages';
+import { usePageState, useServiceDeployment } from '../../../../../../../hooks';
+import { makeInsufficientGasError } from '../../../../../../helpers/factories';
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+jest.mock('../../../../../../../hooks', () => ({
+  useInsufficientGasModal:
+    require('../../../../../../../hooks/useInsufficientGasModal')
+      .useInsufficientGasModal,
+  usePageState: jest.fn(),
+  useServiceDeployment: jest.fn(),
+}));
+
+jest.mock('../../../../../../../components/ui', () => {
+  const {
+    insufficientGasModalMock,
+  } = require('../../../../../../helpers/insufficientGasModalMock');
+  return { InsufficientSignerGasModal: insufficientGasModalMock };
+});
+/* eslint-enable @typescript-eslint/no-var-requires */
+
+jest.mock(
+  '../../../../../../../components/MainPage/Home/Overview/AgentInfo/AgentRunButton/AgentBusyButton',
+  () => ({
+    AgentBusyButton: ({ text }: { text: string }) => (
+      <div data-testid="agent-busy-button">{text}</div>
+    ),
+  }),
+);
+
+const mockUseServiceDeployment = useServiceDeployment as jest.Mock;
+const mockUsePageState = usePageState as jest.Mock;
+const mockGoto = jest.fn();
+
+const renderWith = (
+  serviceDeployment: Partial<ReturnType<typeof useServiceDeployment>>,
+) => {
+  mockUseServiceDeployment.mockReturnValue({
+    isLoading: false,
+    isDeployable: true,
+    handleStart: jest.fn(),
+    isStartError: false,
+    startError: null,
+    resetStart: jest.fn(),
+    ...serviceDeployment,
+  } as unknown as ReturnType<typeof useServiceDeployment>);
+  mockUsePageState.mockReturnValue({
+    goto: mockGoto,
+  } as unknown as ReturnType<typeof usePageState>);
+  return render(<AgentNotRunningButton />);
+};
+
+describe('AgentNotRunningButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the busy button while loading', () => {
+    renderWith({ isLoading: true });
+    expect(screen.getByTestId('agent-busy-button')).toBeInTheDocument();
+  });
+
+  it('renders the start button when deployable', () => {
+    renderWith({ isDeployable: true });
+    expect(
+      screen.getByRole('button', { name: 'Start agent' }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the InsufficientSignerGasModal when start fails with INSUFFICIENT_SIGNER_GAS', () => {
+    renderWith({
+      isStartError: true,
+      startError: makeInsufficientGasError(),
+    });
+    expect(screen.getByTestId('insufficient-gas-modal')).toBeInTheDocument();
+    expect(screen.getByTestId('gas-modal-case')).toHaveTextContent(
+      'start-service',
+    );
+    expect(screen.getByTestId('gas-modal-chain')).toHaveTextContent('gnosis');
+    expect(screen.getByTestId('gas-modal-amount')).toHaveTextContent(
+      '750000000000000000',
+    );
+  });
+
+  it('does not render the modal for non-gas start errors', () => {
+    renderWith({
+      isStartError: true,
+      startError: new Error('Network timeout'),
+    });
+    expect(
+      screen.queryByTestId('insufficient-gas-modal'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('navigates to AgentWallet with FUND_AGENT + gas-error fund source when Fund CTA clicked', () => {
+    renderWith({
+      isStartError: true,
+      startError: makeInsufficientGasError({
+        prefill_amount_wei: '2500000000000000',
+      }),
+    });
+    fireEvent.click(screen.getByTestId('gas-modal-fund'));
+    expect(mockGoto).toHaveBeenCalledWith(PAGES.AgentWallet, {
+      initialStep: STEPS.FUND_AGENT,
+      initialFundValues: { [AddressZero]: '2500000000000000' },
+      initialFundEntrySource: 'gas-error',
+    });
+  });
+
+  it('resets mutation state on dismiss', () => {
+    const resetStart = jest.fn();
+    renderWith({
+      isStartError: true,
+      startError: makeInsufficientGasError(),
+      resetStart,
+    });
+    fireEvent.click(screen.getByTestId('gas-modal-close'));
+    expect(resetStart).toHaveBeenCalled();
+  });
+
+  it('invokes handleStart when the Start button is clicked', async () => {
+    const handleStart = jest.fn().mockResolvedValue(undefined);
+    renderWith({ handleStart });
+    fireEvent.click(screen.getByRole('button', { name: 'Start agent' }));
+    await waitFor(() => expect(handleStart).toHaveBeenCalled());
+  });
+
+  it('swallows handleStart rejections (the error is surfaced via startError)', async () => {
+    const handleStart = jest.fn().mockRejectedValue(new Error('boom'));
+    renderWith({ handleStart });
+    fireEvent.click(screen.getByRole('button', { name: 'Start agent' }));
+    await waitFor(() => expect(handleStart).toHaveBeenCalled());
+    // No unhandled rejection → if it threw, this test would fail with an
+    // unhandled-promise jest error.
+  });
+
+  // Full state-transition sweep — guards against the dismiss→retry bug class
+  // where stale error state re-renders the wrong modal on the second attempt.
+  it('full sequence: trigger → gas error → dismiss → retry runs handleStart again with state reset', async () => {
+    const handleStart = jest.fn().mockResolvedValue(undefined);
+    const resetStart = jest.fn();
+    const { rerender } = renderWith({
+      handleStart,
+      isStartError: true,
+      startError: makeInsufficientGasError(),
+      resetStart,
+    });
+
+    // 1. Modal visible on the error frame
+    expect(screen.getByTestId('insufficient-gas-modal')).toBeInTheDocument();
+
+    // 2. Dismiss → resetStart fires
+    fireEvent.click(screen.getByTestId('gas-modal-close'));
+    expect(resetStart).toHaveBeenCalled();
+
+    // 3. Simulate the parent updating state (resetStart cleared startError)
+    mockUseServiceDeployment.mockReturnValue({
+      isLoading: false,
+      isDeployable: true,
+      handleStart,
+      isStartError: false,
+      startError: null,
+      resetStart,
+    } as unknown as ReturnType<typeof useServiceDeployment>);
+    rerender(<AgentNotRunningButton />);
+
+    // 4. Modal no longer rendered; Start button re-clickable
+    expect(
+      screen.queryByTestId('insufficient-gas-modal'),
+    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Start agent' }));
+    await waitFor(() => expect(handleStart).toHaveBeenCalledTimes(1));
+  });
+});

--- a/frontend/tests/components/OnRamp/OnRampPaymentSteps/OnRampPaymentSteps.test.tsx
+++ b/frontend/tests/components/OnRamp/OnRampPaymentSteps/OnRampPaymentSteps.test.tsx
@@ -67,6 +67,24 @@ jest.mock('../../../../components/ui/AgentSetupCompleteModal', () => ({
     createElement('div', { 'data-testid': 'setup-complete-modal' }),
 }));
 
+// OnRampPaymentSteps mounts an InsufficientSignerGasModal driven by
+// useInsufficientGasModal. These existing tests don't exercise the gas-error
+// path — return null so the modal never mounts, and stub the supporting
+// react-query / page-state / ui imports so they don't fail at import time.
+jest.mock('../../../../hooks/useInsufficientGasModal', () => ({
+  useInsufficientGasModal: () => null,
+}));
+jest.mock('../../../../hooks/usePageState', () => ({
+  usePageState: () => ({ goto: jest.fn() }),
+}));
+jest.mock('../../../../components/ui/InsufficientSignerGasModal', () => ({
+  InsufficientSignerGasModal: () =>
+    createElement('div', { 'data-testid': 'insufficient-gas-modal' }),
+}));
+jest.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ removeQueries: jest.fn() }),
+}));
+
 // ---------------------------------------------------------------------------
 // Import after mocks
 // ---------------------------------------------------------------------------

--- a/frontend/tests/components/OnRamp/OnRampPaymentSteps/useSwapFundsStep.test.ts
+++ b/frontend/tests/components/OnRamp/OnRampPaymentSteps/useSwapFundsStep.test.ts
@@ -185,6 +185,8 @@ const setupMocks = (overrides: SetupOverrides = {}) => {
     isBridgingFailed: overrides.isBridgingFailed ?? false,
     isBridging: overrides.isBridging ?? false,
     bridgeStatus: overrides.bridgeStatus,
+    isBridgeExecuteError: false,
+    bridgeExecuteError: null,
   });
 
   return { updateIsSwappingStepCompleted, refetchBridgeRefillRequirements };
@@ -1104,6 +1106,8 @@ function setupMocksWithoutBridgeUtils(overrides: SetupOverrides) {
     isBridgingFailed: overrides.isBridgingFailed ?? false,
     isBridging: overrides.isBridging ?? false,
     bridgeStatus: overrides.bridgeStatus,
+    isBridgeExecuteError: false,
+    bridgeExecuteError: null,
   });
 
   return { updateIsSwappingStepCompleted, refetchBridgeRefillRequirements };

--- a/frontend/tests/hooks/useServiceDeployment.test.ts
+++ b/frontend/tests/hooks/useServiceDeployment.test.ts
@@ -450,6 +450,40 @@ describe('useServiceDeployment', () => {
           }),
         ).rejects.toThrow('Start failed');
       });
+
+      it('exposes the gas error via startError WITHOUT firing the generic toast', async () => {
+        // INSUFFICIENT_SIGNER_GAS rejections are surfaced via the modal at
+        // the host (AgentNotRunningButton) — duplicating with a toast would
+        // confuse the user. Asserts both branches of the toast guard at once.
+        const gasError = Object.assign(new Error('Insufficient gas'), {
+          error_code: 'INSUFFICIENT_SIGNER_GAS',
+          chain: 'gnosis',
+          prefill_amount_wei: '750000000000000000',
+        });
+        mockStartServiceFn.mockRejectedValue(gasError);
+
+        const { result } = renderHook(() => useServiceDeployment());
+        // Catch the rejection inside `act` so React flushes the state
+        // update (setStartError) before we read `result.current` below.
+        let caught: unknown;
+        await act(async () => {
+          try {
+            await result.current.handleStart();
+          } catch (e) {
+            caught = e;
+          }
+        });
+        expect(caught).toBe(gasError);
+
+        expect(mockShowNotification).not.toHaveBeenCalled();
+        expect(result.current.isStartError).toBe(true);
+        expect(result.current.startError).toBe(gasError);
+
+        // resetStart clears both flag and stored error.
+        act(() => result.current.resetStart());
+        expect(result.current.isStartError).toBe(false);
+        expect(result.current.startError).toBeNull();
+      });
     });
 
     describe('state update error handling', () => {

--- a/frontend/tests/service/Bridge.test.ts
+++ b/frontend/tests/service/Bridge.test.ts
@@ -187,13 +187,18 @@ describe('BridgeService', () => {
       });
     });
 
-    it('throws an error when response is not ok', async () => {
+    it('rejects with the parsed JSON body when response is not ok', async () => {
+      const errorBody = {
+        error_code: 'INSUFFICIENT_SIGNER_GAS',
+        chain: 'ethereum',
+        prefill_amount_wei: '1000000000000000000',
+      };
       jest
         .spyOn(global, 'fetch')
-        .mockReturnValue(mockJsonResponse({}, false, 500));
+        .mockReturnValue(mockJsonResponse(errorBody, false, 400));
 
-      await expect(BridgeService.executeBridge(MOCK_QUOTE_ID)).rejects.toThrow(
-        `Failed to execute bridge quote for the following quote id: ${MOCK_QUOTE_ID}`,
+      await expect(BridgeService.executeBridge(MOCK_QUOTE_ID)).rejects.toEqual(
+        errorBody,
       );
     });
 

--- a/frontend/tests/service/Services.test.ts
+++ b/frontend/tests/service/Services.test.ts
@@ -457,8 +457,9 @@ describe('ServicesService', () => {
       );
     });
 
-    it('rejects with the parsed JSON body when response is not ok', async () => {
+    it('rejects with an Error whose message + properties carry the JSON body', async () => {
       const errorBody = {
+        error: 'Service start failed due to insufficient funds.',
         error_code: 'INSUFFICIENT_SIGNER_GAS',
         chain: 'gnosis',
         prefill_amount_wei: '750000000000000000',
@@ -467,9 +468,28 @@ describe('ServicesService', () => {
         .spyOn(global, 'fetch')
         .mockReturnValue(mockJsonResponse(errorBody, false, 400));
 
-      await expect(
-        ServicesService.startService(DEFAULT_SERVICE_CONFIG_ID),
-      ).rejects.toEqual(errorBody);
+      const err = (await ServicesService.startService(
+        DEFAULT_SERVICE_CONFIG_ID,
+      ).catch((e) => e)) as Error & typeof errorBody;
+      expect(err).toBeInstanceOf(Error);
+      // .message is the backend's error string (so AutoRun's
+      // `lastInfraError = `${error}`` stays diagnosable).
+      expect(err.message).toBe(errorBody.error);
+      // Body fields are merged so `isInsufficientGasError` still narrows.
+      expect(err.error_code).toBe('INSUFFICIENT_SIGNER_GAS');
+      expect(err.chain).toBe('gnosis');
+      expect(err.prefill_amount_wei).toBe('750000000000000000');
+    });
+
+    it('falls back to a generic message when the error body has no `error` field', async () => {
+      jest
+        .spyOn(global, 'fetch')
+        .mockReturnValue(mockJsonResponse({}, false, 500));
+      const err = (await ServicesService.startService(
+        DEFAULT_SERVICE_CONFIG_ID,
+      ).catch((e) => e)) as Error;
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toBe('Failed to start the service');
     });
   });
 

--- a/frontend/tests/service/Services.test.ts
+++ b/frontend/tests/service/Services.test.ts
@@ -457,14 +457,19 @@ describe('ServicesService', () => {
       );
     });
 
-    it('throws error on non-ok response', async () => {
+    it('rejects with the parsed JSON body when response is not ok', async () => {
+      const errorBody = {
+        error_code: 'INSUFFICIENT_SIGNER_GAS',
+        chain: 'gnosis',
+        prefill_amount_wei: '750000000000000000',
+      };
       jest
         .spyOn(global, 'fetch')
-        .mockReturnValue(mockJsonResponse({}, false, 500));
+        .mockReturnValue(mockJsonResponse(errorBody, false, 400));
 
       await expect(
         ServicesService.startService(DEFAULT_SERVICE_CONFIG_ID),
-      ).rejects.toThrow('Failed to start the service');
+      ).rejects.toEqual(errorBody);
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -105,6 +105,6 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.6.23-rc2",
+  "version": "1.6.23-rc3",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -105,6 +105,6 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.6.23-rc3",
+  "version": "1.6.23-rc4",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -105,6 +105,6 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.6.23-rc1",
+  "version": "1.6.23-rc2",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -105,6 +105,6 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.6.23-rc5",
+  "version": "1.6.23-rc6",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -105,6 +105,6 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.6.23-rc4",
+  "version": "1.6.23-rc5",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-app"
-version = "1.6.23-rc2"
+version = "1.6.23-rc3"
 description = ""
 authors = [
     { name = "David Vilela", email = "dvilelaf@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-app"
-version = "1.6.23-rc3"
+version = "1.6.23-rc4"
 description = ""
 authors = [
     { name = "David Vilela", email = "dvilelaf@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-app"
-version = "1.6.23-rc5"
+version = "1.6.23-rc6"
 description = ""
 authors = [
     { name = "David Vilela", email = "dvilelaf@gmail.com" },
@@ -34,4 +34,4 @@ python-preference = "only-system"
 # this block once the middleware ships a versioned release containing
 # https://github.com/valory-xyz/olas-operate-middleware/pull/445.
 [tool.uv.sources]
-olas-operate-middleware = { git = "https://github.com/valory-xyz/olas-operate-middleware.git", rev = "832a751bc004fdb2b2be58cd634bec2153e31702" }
+olas-operate-middleware = { git = "https://github.com/valory-xyz/olas-operate-middleware.git", rev = "e2d037ce6e76d576d1480f5aeb7e720afeba2833" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,10 @@ package = false
 # provenance we had under Poetry). Drop this only if we want to
 # opt every release into uv-managed interpreters.
 python-preference = "only-system"
+
+# Override the PyPI middleware pin to the OPE-1617 PR #445 head while QA
+# validates the structured INSUFFICIENT_SIGNER_GAS error contract. Drop
+# this block once the middleware ships a versioned release containing
+# https://github.com/valory-xyz/olas-operate-middleware/pull/445.
+[tool.uv.sources]
+olas-operate-middleware = { git = "https://github.com/valory-xyz/olas-operate-middleware.git", rev = "c40e3c33f529a9af77c7a1c3a17cfbaf70df424e" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-app"
-version = "1.6.23-rc1"
+version = "1.6.23-rc2"
 description = ""
 authors = [
     { name = "David Vilela", email = "dvilelaf@gmail.com" },
@@ -34,4 +34,4 @@ python-preference = "only-system"
 # this block once the middleware ships a versioned release containing
 # https://github.com/valory-xyz/olas-operate-middleware/pull/445.
 [tool.uv.sources]
-olas-operate-middleware = { git = "https://github.com/valory-xyz/olas-operate-middleware.git", rev = "c40e3c33f529a9af77c7a1c3a17cfbaf70df424e" }
+olas-operate-middleware = { git = "https://github.com/valory-xyz/olas-operate-middleware.git", rev = "832a751bc004fdb2b2be58cd634bec2153e31702" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-app"
-version = "1.6.23-rc4"
+version = "1.6.23-rc5"
 description = ""
 authors = [
     { name = "David Vilela", email = "dvilelaf@gmail.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -216,15 +216,6 @@ wheels = [
 ]
 
 [[package]]
-name = "base58"
-version = "2.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7f/45/8ae61209bb9015f516102fa559a2914178da1d5868428bd86a1b4421141d/base58-2.1.1.tar.gz", hash = "sha256:c5d0cb3f5b6e81e8e35da5754388ddcc6d0d14b6c6a132cb93d69ed580a7278c", size = 6528, upload-time = "2021-10-30T22:12:17.858Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/45/ec96b29162a402fc4c1c5512d114d7b3787b9d1c2ec241d9568b4816ee23/base58-2.1.1-py3-none-any.whl", hash = "sha256:11a36f4d3ce51dfc1043f3218591ac4eb1ceb172919cebe05b52a5bcc8d245c2", size = 5621, upload-time = "2021-10-30T22:12:16.658Z" },
-]
-
-[[package]]
 name = "based58"
 version = "0.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1160,21 +1151,6 @@ wheels = [
 ]
 
 [[package]]
-name = "multiaddr"
-version = "0.0.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "base58" },
-    { name = "netaddr" },
-    { name = "six" },
-    { name = "varint" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/12/f4/fa5353022ad8e0fd364bfa8b474f9562c36ce1305fad31fe52b849e30795/multiaddr-0.0.9.tar.gz", hash = "sha256:30b2695189edc3d5b90f1c303abb8f02d963a3a4edf2e7178b975eb417ab0ecf", size = 24726, upload-time = "2019-12-23T07:06:21.146Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/59/df732566d951c33f00a4022fc5bf9c5d1661b1c2cdaf56e75a1a5fa8f829/multiaddr-0.0.9-py2.py3-none-any.whl", hash = "sha256:5c0f862cbcf19aada2a899f80ef896ddb2e85614e0c8f04dd287c06c69dac95b", size = 16281, upload-time = "2019-12-23T07:06:18.915Z" },
-]
-
-[[package]]
 name = "multidict"
 version = "6.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1220,17 +1196,8 @@ wheels = [
 ]
 
 [[package]]
-name = "netaddr"
-version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/54/90/188b2a69654f27b221fba92fda7217778208532c962509e959a9cee5229d/netaddr-1.3.0.tar.gz", hash = "sha256:5c3c3d9895b551b763779ba7db7a03487dc1f8e3b385af819af341ae9ef6e48a", size = 2260504, upload-time = "2024-05-28T21:30:37.743Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/cc/f4fe2c7ce68b92cbf5b2d379ca366e1edae38cccaad00f69f529b460c3ef/netaddr-1.3.0-py3-none-any.whl", hash = "sha256:c2c6a8ebe5554ce33b7d5b3a306b71bbb373e000bbbf2350dd5213cc56e3dbbe", size = 2262023, upload-time = "2024-05-28T21:30:34.191Z" },
-]
-
-[[package]]
 name = "olas-operate-app"
-version = "1.6.23rc5"
+version = "1.6.23rc6"
 source = { virtual = "." }
 dependencies = [
     { name = "olas-operate-middleware" },
@@ -1247,7 +1214,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "olas-operate-middleware", git = "https://github.com/valory-xyz/olas-operate-middleware.git?rev=832a751bc004fdb2b2be58cd634bec2153e31702" },
+    { name = "olas-operate-middleware", git = "https://github.com/valory-xyz/olas-operate-middleware.git?rev=e2d037ce6e76d576d1480f5aeb7e720afeba2833" },
     { name = "open-aea-cli-ipfs", specifier = "==2.2.5" },
     { name = "open-aea-ledger-cosmos", specifier = "==2.2.5" },
     { name = "open-aea-ledger-ethereum", specifier = "==2.2.5" },
@@ -1259,27 +1226,23 @@ dev = [{ name = "pyinstaller", specifier = "==6.20.0" }]
 
 [[package]]
 name = "olas-operate-middleware"
-version = "0.15.24"
-source = { git = "https://github.com/valory-xyz/olas-operate-middleware.git?rev=832a751bc004fdb2b2be58cd634bec2153e31702#832a751bc004fdb2b2be58cd634bec2153e31702" }
+version = "0.15.27"
+source = { git = "https://github.com/valory-xyz/olas-operate-middleware.git?rev=e2d037ce6e76d576d1480f5aeb7e720afeba2833#e2d037ce6e76d576d1480f5aeb7e720afeba2833" }
 dependencies = [
     { name = "aiohttp" },
     { name = "argon2-cffi" },
     { name = "clea" },
     { name = "cryptography" },
-    { name = "cytoolz" },
     { name = "deepdiff" },
     { name = "fastapi" },
     { name = "flask" },
     { name = "halo" },
-    { name = "multiaddr" },
     { name = "open-aea-cli-ipfs" },
     { name = "open-aea-ledger-cosmos" },
     { name = "open-aea-ledger-ethereum" },
     { name = "open-autonomy", extra = ["cli", "docker"] },
     { name = "psutil" },
-    { name = "pyinstaller" },
     { name = "requests" },
-    { name = "typing-extensions" },
     { name = "uvicorn" },
     { name = "werkzeug" },
 ]
@@ -2136,12 +2099,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/e6/bf/f6544ba992ddb9a60
 wheels = [
     { url = "https://files.pythonhosted.org/packages/01/be/72532be3da7acc5fdfbccdb95215cd04f995a0886532a5b423f929cda4cc/uvicorn-0.48.0-py3-none-any.whl", hash = "sha256:48097851328b87ec36117d3d575234519eb58c2b22d79666e9bbc6c49a761dad", size = 71410, upload-time = "2026-05-24T12:08:40.258Z" },
 ]
-
-[[package]]
-name = "varint"
-version = "1.0.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a8/fe/1ea0ba0896dfa47186692655b86db3214c4b7c9e0e76c7b1dc257d101ab1/varint-1.0.2.tar.gz", hash = "sha256:a6ecc02377ac5ee9d65a6a8ad45c9ff1dac8ccee19400a5950fb51d594214ca5", size = 1886, upload-time = "2016-02-24T20:42:38.5Z" }
 
 [[package]]
 name = "virtualenv"

--- a/uv.lock
+++ b/uv.lock
@@ -1230,7 +1230,7 @@ wheels = [
 
 [[package]]
 name = "olas-operate-app"
-version = "1.6.23rc1"
+version = "1.6.23rc2"
 source = { virtual = "." }
 dependencies = [
     { name = "olas-operate-middleware" },
@@ -1247,7 +1247,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "olas-operate-middleware", git = "https://github.com/valory-xyz/olas-operate-middleware.git?rev=c40e3c33f529a9af77c7a1c3a17cfbaf70df424e" },
+    { name = "olas-operate-middleware", git = "https://github.com/valory-xyz/olas-operate-middleware.git?rev=832a751bc004fdb2b2be58cd634bec2153e31702" },
     { name = "open-aea-cli-ipfs", specifier = "==2.2.5" },
     { name = "open-aea-ledger-cosmos", specifier = "==2.2.5" },
     { name = "open-aea-ledger-ethereum", specifier = "==2.2.5" },
@@ -1259,8 +1259,8 @@ dev = [{ name = "pyinstaller", specifier = "==6.20.0" }]
 
 [[package]]
 name = "olas-operate-middleware"
-version = "0.15.23"
-source = { git = "https://github.com/valory-xyz/olas-operate-middleware.git?rev=c40e3c33f529a9af77c7a1c3a17cfbaf70df424e#c40e3c33f529a9af77c7a1c3a17cfbaf70df424e" }
+version = "0.15.24"
+source = { git = "https://github.com/valory-xyz/olas-operate-middleware.git?rev=832a751bc004fdb2b2be58cd634bec2153e31702#832a751bc004fdb2b2be58cd634bec2153e31702" }
 dependencies = [
     { name = "aiohttp" },
     { name = "argon2-cffi" },

--- a/uv.lock
+++ b/uv.lock
@@ -216,6 +216,15 @@ wheels = [
 ]
 
 [[package]]
+name = "base58"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/45/8ae61209bb9015f516102fa559a2914178da1d5868428bd86a1b4421141d/base58-2.1.1.tar.gz", hash = "sha256:c5d0cb3f5b6e81e8e35da5754388ddcc6d0d14b6c6a132cb93d69ed580a7278c", size = 6528, upload-time = "2021-10-30T22:12:17.858Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/45/ec96b29162a402fc4c1c5512d114d7b3787b9d1c2ec241d9568b4816ee23/base58-2.1.1-py3-none-any.whl", hash = "sha256:11a36f4d3ce51dfc1043f3218591ac4eb1ceb172919cebe05b52a5bcc8d245c2", size = 5621, upload-time = "2021-10-30T22:12:16.658Z" },
+]
+
+[[package]]
 name = "based58"
 version = "0.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1151,6 +1160,21 @@ wheels = [
 ]
 
 [[package]]
+name = "multiaddr"
+version = "0.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "base58" },
+    { name = "netaddr" },
+    { name = "six" },
+    { name = "varint" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/f4/fa5353022ad8e0fd364bfa8b474f9562c36ce1305fad31fe52b849e30795/multiaddr-0.0.9.tar.gz", hash = "sha256:30b2695189edc3d5b90f1c303abb8f02d963a3a4edf2e7178b975eb417ab0ecf", size = 24726, upload-time = "2019-12-23T07:06:21.146Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/59/df732566d951c33f00a4022fc5bf9c5d1661b1c2cdaf56e75a1a5fa8f829/multiaddr-0.0.9-py2.py3-none-any.whl", hash = "sha256:5c0f862cbcf19aada2a899f80ef896ddb2e85614e0c8f04dd287c06c69dac95b", size = 16281, upload-time = "2019-12-23T07:06:18.915Z" },
+]
+
+[[package]]
 name = "multidict"
 version = "6.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1196,6 +1220,15 @@ wheels = [
 ]
 
 [[package]]
+name = "netaddr"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/90/188b2a69654f27b221fba92fda7217778208532c962509e959a9cee5229d/netaddr-1.3.0.tar.gz", hash = "sha256:5c3c3d9895b551b763779ba7db7a03487dc1f8e3b385af819af341ae9ef6e48a", size = 2260504, upload-time = "2024-05-28T21:30:37.743Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/cc/f4fe2c7ce68b92cbf5b2d379ca366e1edae38cccaad00f69f529b460c3ef/netaddr-1.3.0-py3-none-any.whl", hash = "sha256:c2c6a8ebe5554ce33b7d5b3a306b71bbb373e000bbbf2350dd5213cc56e3dbbe", size = 2262023, upload-time = "2024-05-28T21:30:34.191Z" },
+]
+
+[[package]]
 name = "olas-operate-app"
 version = "1.6.23rc1"
 source = { virtual = "." }
@@ -1214,7 +1247,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "olas-operate-middleware", specifier = "==0.15.26" },
+    { name = "olas-operate-middleware", git = "https://github.com/valory-xyz/olas-operate-middleware.git?rev=c40e3c33f529a9af77c7a1c3a17cfbaf70df424e" },
     { name = "open-aea-cli-ipfs", specifier = "==2.2.5" },
     { name = "open-aea-ledger-cosmos", specifier = "==2.2.5" },
     { name = "open-aea-ledger-ethereum", specifier = "==2.2.5" },
@@ -1226,29 +1259,29 @@ dev = [{ name = "pyinstaller", specifier = "==6.20.0" }]
 
 [[package]]
 name = "olas-operate-middleware"
-version = "0.15.26"
-source = { registry = "https://pypi.org/simple" }
+version = "0.15.23"
+source = { git = "https://github.com/valory-xyz/olas-operate-middleware.git?rev=c40e3c33f529a9af77c7a1c3a17cfbaf70df424e#c40e3c33f529a9af77c7a1c3a17cfbaf70df424e" }
 dependencies = [
     { name = "aiohttp" },
     { name = "argon2-cffi" },
     { name = "clea" },
     { name = "cryptography" },
+    { name = "cytoolz" },
     { name = "deepdiff" },
     { name = "fastapi" },
     { name = "flask" },
     { name = "halo" },
+    { name = "multiaddr" },
     { name = "open-aea-cli-ipfs" },
     { name = "open-aea-ledger-cosmos" },
     { name = "open-aea-ledger-ethereum" },
     { name = "open-autonomy", extra = ["cli", "docker"] },
     { name = "psutil" },
+    { name = "pyinstaller" },
     { name = "requests" },
+    { name = "typing-extensions" },
     { name = "uvicorn" },
     { name = "werkzeug" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/73/dd02fb907ac538008606aa9c5d1024b065843fa4465eb801da1ee563cdf6/olas_operate_middleware-0.15.26.tar.gz", hash = "sha256:3b06496099d9754cc6354114bd4efa75fb92202155b5b4cda0d407b9fd6ab1c9", size = 283388, upload-time = "2026-06-03T10:01:48.233Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/14/c835b073019d4e8a6c28b706d2cd98248c309d6ecf524d1e5da9a5209ce7/olas_operate_middleware-0.15.26-py3-none-any.whl", hash = "sha256:cea7afe8aa2597af7969ff02e22d3a8cdb628d38afa9478ca17ab38304211613", size = 341530, upload-time = "2026-06-03T10:01:46.222Z" },
 ]
 
 [[package]]
@@ -2103,6 +2136,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/e6/bf/f6544ba992ddb9a60
 wheels = [
     { url = "https://files.pythonhosted.org/packages/01/be/72532be3da7acc5fdfbccdb95215cd04f995a0886532a5b423f929cda4cc/uvicorn-0.48.0-py3-none-any.whl", hash = "sha256:48097851328b87ec36117d3d575234519eb58c2b22d79666e9bbc6c49a761dad", size = 71410, upload-time = "2026-05-24T12:08:40.258Z" },
 ]
+
+[[package]]
+name = "varint"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/fe/1ea0ba0896dfa47186692655b86db3214c4b7c9e0e76c7b1dc257d101ab1/varint-1.0.2.tar.gz", hash = "sha256:a6ecc02377ac5ee9d65a6a8ad45c9ff1dac8ccee19400a5950fb51d594214ca5", size = 1886, upload-time = "2016-02-24T20:42:38.5Z" }
 
 [[package]]
 name = "virtualenv"

--- a/uv.lock
+++ b/uv.lock
@@ -1230,7 +1230,7 @@ wheels = [
 
 [[package]]
 name = "olas-operate-app"
-version = "1.6.23rc4"
+version = "1.6.23rc5"
 source = { virtual = "." }
 dependencies = [
     { name = "olas-operate-middleware" },

--- a/uv.lock
+++ b/uv.lock
@@ -1230,7 +1230,7 @@ wheels = [
 
 [[package]]
 name = "olas-operate-app"
-version = "1.6.23rc2"
+version = "1.6.23rc3"
 source = { virtual = "." }
 dependencies = [
     { name = "olas-operate-middleware" },

--- a/uv.lock
+++ b/uv.lock
@@ -1230,7 +1230,7 @@ wheels = [
 
 [[package]]
 name = "olas-operate-app"
-version = "1.6.23rc3"
+version = "1.6.23rc4"
 source = { virtual = "." }
 dependencies = [
     { name = "olas-operate-middleware" },


### PR DESCRIPTION
## Summary

Implements [OPE-1617](https://linear.app/valory-xyz/issue/OPE-1617) — extends `INSUFFICIENT_SIGNER_GAS` modal coverage to every FE entry point that hits the newly-wrapped backend endpoints in [olas-operate-middleware#445](https://github.com/valory-xyz/olas-operate-middleware/pull/445), and fixes a routing bug where the existing Fund Agent flow was sending native gas to the Safe instead of the AgentEOA.

## Scenarios

Steps 1–4 are identical across every case — the mutation rejects with the `INSUFFICIENT_SIGNER_GAS` body, `useInsufficientGasModal` narrows it, the modal renders. Variation lives in step 5+ (what the Fund CTA does):

| Case | Signer | Modal copy | Fund CTA navigates to | `fundEntrySource` set? |
|---|---|---|---|---|
| `agent-withdraw` (Withdraw, PartialWithdraw) | AgentEOA | "Withdrawal Failed… fund **agent wallet** with at least X XDAI" | `STEPS.FUND_AGENT` inside AgentWallet | ✅ `'gas-error'` |
| **`start-service`** (AgentNotRunningButton) | AgentEOA | "Couldn't Start Agent… fund **agent wallet**" | `PAGES.AgentWallet` with `initialStep: FUND_AGENT` | ✅ `'gas-error'` via navParams |
| `pearl-withdraw` (Pearl EnterWithdrawalAddress) | MasterEOA | "Withdrawal Failed… fund **Pearl wallet**" | `PAGES.FundPearlWallet` | ❌ N/A (Master EOA auto-funds from Pearl Wallet) |
| `fund-agent` (ConfirmTransfer's own gas error) | MasterEOA | "Transfer Failed… fund **Pearl wallet**" | `PAGES.FundPearlWallet` | ❌ N/A |
| **`bridge`** (BridgeInProgress, OnRamp) | MasterEOA | "Bridging Failed… fund **Pearl wallet**" | `PAGES.FundPearlWallet` | ❌ N/A |

Bolded rows are new in this PR. They slot into the existing two patterns (AgentEOA path / MasterEOA path) with no new mechanics.

## Bug fix — Fund Agent flow routed gas to the Safe instead of the AgentEOA

`prepareAgentFundsForTransfer` allocated EOA up to `eoaTokenRequirements[token]` and sent the remainder to the Safe. When the user entered Fund Agent from a gas-error modal, the `eoaTokenRequirements` poll often reported `0` for native gas (EOA balance is "enough for normal operation" but not for the specific failed transaction), so 100% of the prefilled amount landed on the Safe.

Fix: `AgentWalletProvider` now tracks a `fundEntrySource` flag. When set to `'gas-error'`, `prepareAgentFundsForTransfer` skips the EOA-vs-Safe split for native gas and sends all of it to the AgentEOA. The flag is set in:
- `Withdraw.tsx` / `PartialWithdrawScreen.tsx` on the gas modal Fund CTA (direct mutator call)
- `AgentNotRunningButton.tsx` via `navParams.initialFundEntrySource` (sets it on provider mount, since the start button is outside the provider)

Reset to `'normal'` on:
- Successful fund (in `useConfirmTransfer.onSuccess`)
- Step change away from `FUND_AGENT`
- Provider unmount

## Supporting changes

- `Services.ts` (`startService`) and `Bridge.ts` (`executeBridge`) now throw the parsed JSON body on non-OK responses so callers can narrow via `isInsufficientGasError`.
- `useServiceDeployment` exposes `isStartError` / `startError` / `resetStart`.
- `useBridgingSteps` exposes `isBridgeExecuteError` / `bridgeExecuteError`.
- `InsufficientSignerGasModal` adds the `start-service` and `bridge` cases.
- `BridgeInProgress` / `OnRampPaymentSteps` reset query state via `queryClient.removeQueries` since the underlying execute is a `useQuery`, not a `useMutation`.

## Out of scope

- **MasterEOA gas-error routing.** Master EOA is funded by the funding-job; the existing fund-Pearl-Wallet path remains correct.
- **`/fund_recovery/execute`.** Currently returns 200 with stringified errors (`errors: ["chain=X drain_eoa: InsufficientFundsException"]`) — no structured payload. A separate BE ticket is needed to expose structured per-chain gas-error entries before the FE can plumb this.
- **AutoRun background gas errors.** Stays on the existing `agent_blocked` start-status classification — no modal in a background flow.
- **Bridge status-poll `provider_data`.** The status endpoint's `provider_data` field exposes the gas-error payload for previously-failed bundles, but this PR handles the primary `/bridge/execute` rejection path only.

## Test plan

- [x] Unit: `prepareAgentFundsForTransfer.test.ts` — default split + `forceEoaOnly` routing.
- [x] Component: `AgentNotRunningButton.test.tsx` — full trigger → error → dismiss → re-trigger state-transition sweep.
- [x] Updated: `BridgeInProgress.test.tsx` + `OnRampPaymentSteps.test.tsx` — gas-modal hosting + `useInsufficientGasModal` contract.
- [x] Updated: `Services.test.ts` + `Bridge.test.ts` — service modules reject with parsed JSON body.
- [x] Updated: `Withdraw.test.tsx` + `PartialWithdrawScreen.test.tsx` — assert `setFundEntrySource('gas-error')` on the gas-modal Fund CTA.
- [ ] **QA manual validation against the MW PR #445 sha pin** — exercise each row of the scenarios table end-to-end.

## Release

The middleware pin stays at PR #445 head sha (`c40e3c33`) until QA validates the structured error contract end-to-end. Once `olas-operate-middleware` ships a versioned release containing PR #445, the `[tool.uv.sources]` block in `pyproject.toml` is dropped and the version pin in `dependencies` is bumped to that release in a follow-up.

## Mock
<img width="853" height="761" alt="Sc2M" src="https://github.com/user-attachments/assets/2029f782-b04f-4060-83db-f4e8f574e52c" />

<img width="613" height="545" alt="Sc3PM" src="https://github.com/user-attachments/assets/3b14ab1d-4e57-43a5-ba3d-a3219ded585d" />

<img width="706" height="669" alt="Scr4" src="https://github.com/user-attachments/assets/9e6fce45-a403-4f3e-b3de-f094003ff58a" />
