### PR TITLE
fix(ci): run uv lock when bumping pyproject.toml version

### DIFF
--- a/.github/workflows/calculate-and-update-version.yml
+++ b/.github/workflows/calculate-and-update-version.yml
@@ -282,6 +282,10 @@ jobs:
           CURRENT_VERSION=$(grep -E '^version = ' pyproject.toml | sed -E 's/^version = "(.+)"/\1/')
           if [ "$CURRENT_VERSION" != "$NEW_VERSION" ]; then
             sed -i -E "s/^version = \".*\"/version = \"$NEW_VERSION\"/" pyproject.toml
+            # uv.lock records the project's own version, so a sed bump
+            # without re-locking leaves uv.lock stale and breaks the
+            # next `uv sync --locked` in CI / release jobs.
+            uv lock
             echo "Updated pyproject.toml version from $CURRENT_VERSION to $NEW_VERSION"
           else
             echo "pyproject.toml version is already $NEW_VERSION, skipping update"


### PR DESCRIPTION
## Summary

The version-bump step in \`calculate-and-update-version.yml\` rewrites \`pyproject.toml\` via \`sed\` but never runs \`uv lock\`. \`uv.lock\` records the project's own version, so the lockfile drifts and the next \`uv sync --locked\` (in \`ci.yml\`, release jobs, etc.) fails with:

\`\`\`
The lockfile at \`uv.lock\` needs to be updated, but \`--locked\` was provided.
\`\`\`

This bit PR #1989 — the bumped version was \`1.6.12-rc22\` but \`uv.lock\` was still on \`rc17\`. The same recurrence shows up in commit \`39ac3c37\` ("chore: sync uv.lock project version to 1.6.12-rc18") where it was patched manually after the fact.

The middleware-dep update step in the same workflow already uses \`uv add\` (which re-locks), so this only affects pure version bumps.

## Fix

Add a single \`uv lock\` call inside the existing version-change branch. The subsequent commit step already stages \`uv.lock\` — it just had nothing to stage before.

## Test plan

- [ ] Trigger \`Create Feature Release\` (workflow_dispatch) against a test branch and confirm the bot commit includes both \`pyproject.toml\` and \`uv.lock\`.
- [ ] Confirm downstream \`ci.yml\` Backend job (\`uv sync --locked\`) passes against the bumped commit.
- [ ] Confirm the no-change path (\`CURRENT_VERSION == NEW_VERSION\`) still skips both edits.