### PR TITLE
chore(electron): migrate Electron 33.4.11 → 41.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@electron/notarize": "2.5.0",
     "dotenv-cli": "7.4.4",
-    "electron": "33.4.11",
+    "electron": "41.7.0",
     "electron-builder": "26.8.2",
     "electron-builder-sandbox-fix": "1.1.1",
     "electron-context-menu": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,6 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.6.12-rc24",
+  "version": "1.6.12-rc26",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-app"
-version = "1.6.12-rc24"
+version = "1.6.12-rc26"
 description = ""
 authors = [
     { name = "David Vilela", email = "dvilelaf@gmail.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -1230,7 +1230,7 @@ wheels = [
 
 [[package]]
 name = "olas-operate-app"
-version = "1.6.12rc24"
+version = "1.6.12rc26"
 source = { virtual = "." }
 dependencies = [
     { name = "olas-operate-middleware" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1473,12 +1473,19 @@
   resolved "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz"
   integrity sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==
 
-"@types/node@*", "@types/node@^20.9.0":
+"@types/node@*":
   version "20.19.11"
   resolved "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz"
   integrity sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==
   dependencies:
     undici-types "~6.21.0"
+
+"@types/node@^24.9.0":
+  version "24.12.4"
+  resolved "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz#2709745569811dcbdc57c097fafdd387c6330382"
+  integrity sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==
+  dependencies:
+    undici-types "~7.16.0"
 
 "@types/pbkdf2@^3.0.0":
   version "3.1.2"
@@ -2803,13 +2810,13 @@ electron-updater@6.6.2:
     semver "^7.6.3"
     tiny-typed-emitter "^2.1.0"
 
-electron@33.4.11:
-  version "33.4.11"
-  resolved "https://registry.npmjs.org/electron/-/electron-33.4.11.tgz#225d7f106ed3edf788ced318c63858d8b8a446dc"
-  integrity sha512-xmdAs5QWRkInC7TpXGNvzo/7exojubk+72jn1oJL7keNeIlw7xNglf8TGtJtkR4rWC5FJq0oXiIXPS9BcK2Irg==
+electron@41.7.0:
+  version "41.7.0"
+  resolved "https://registry.npmjs.org/electron/-/electron-41.7.0.tgz#2438f061d41867f8631138c29f7157fb0e95ae42"
+  integrity sha512-U6KAKivjk6YQ0Z5+eloJBjwhbHRE206gvy1UBMw2bSluWtMh5waeXMvX6AT/Ujm5ymYXVJOp7g9N7vOFw16wBQ==
   dependencies:
     "@electron/get" "^2.0.0"
-    "@types/node" "^20.9.0"
+    "@types/node" "^24.9.0"
     extract-zip "^2.0.1"
 
 elliptic@6.6.1, elliptic@^6.5.2, elliptic@^6.5.7:
@@ -6178,6 +6185,11 @@ undici-types@~6.21.0:
   version "6.21.0"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
+
+undici-types@~7.16.0:
+  version "7.16.0"
+  resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz#ffccdff36aea4884cbfce9a750a0580224f58a46"
+  integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
 
 undici@7.25.0:
   version "7.25.0"


### PR DESCRIPTION
## What

Bumps Electron `33.4.11` → `41.7.0` — the second-largest Dependabot cluster (**17 alerts**). Single dependency change; no code changes required.

> [!IMPORTANT]
> **Open for review, but do not merge yet.** Base is `staging` (auto-retargeted after #1987 merged). The remaining un-ticked items in the Verification section below are the merge gate — specifically the **Tier 2 (DMG-installed `Electron Framework` integrity)** check and the **Tier 2.5 (cross-major auto-update from E33 → E41)** flow. Both must be exercised against the rc26 feature-release build ([artifacts here](https://github.com/valory-xyz/olas-operate-app/releases/tag/untagged-633170dd69551e16a57d)) before merge.

## Why 41.7.0

Supported majors are 40/41/42. 41 is the mature middle — 42 only just shipped. 41.7.0 is the latest 41.x patch.

## Breaking-changes audit (Electron 34→41)

Cross-referenced Pearl's full `electron/` API surface against Electron's official breaking-changes doc. **Zero code changes required.** Every removed/changed API is in surface Pearl doesn't use:

- utilityProcess, protocol (`ProtocolResponse.session`), desktopCapturer, webFrame routingId, serviceWorkers, shared-texture OSR, WebUSB/WebSerial, printing (`PrinterInfo`), `systemPreferences.isAeroGlassEnabled`, `app.commandLine` casing, `getBitmap()`, clipboard-from-renderer, removed Linux env vars (`ELECTRON_OZONE_PLATFORM_HINT`, `ORIGINAL_XDG_CURRENT_DESKTOP`), `plugin-crashed`.

The only Pearl touchpoint is `dialog.showSaveDialog`'s `defaultPath` (`electron/features/logs.js`) — a **Linux graceful-degradation** on older xdg-desktop-portals (filename may not pre-fill), not a break. Save-logs still works.

## Ecosystem deps — intentionally unchanged

- `electron-builder` 26.8.2 reads the electron version dynamically (no peer pin) — packages 41 fine.
- `electron-updater` / `@electron/notarize` / `electron-context-menu` / `electron-store` / `electron-log` are all electron-version-agnostic.

Minimal diff = clean review + easy bisection.

## Runtime jump

- Node 20 → **24** (ABI 145), Chrome ~130 → **146**.
- Native rebuild (sharp, via Next 15 — N-API prebuilt, ABI-stable) handled by electron-builder at package time.
- **Min macOS rises to 12** (Electron 38+ dropped macOS 11) — release note for macOS 11 users.

## ⚠️ macOS DMG packaging — re-verify size headroom

This bump changes the macOS bundle (Electron 41's `Electron Framework` differs in size from 33's). That matters because of a packaging trap we just hit on the **Next 15** rc24 build: when the bundle outgrows the hardcoded DMG filesystem `size` in `build.js`, `dmgbuild`'s `ditto` copy **silently truncates `Electron Framework`** out of the `.dmg` (electron-builder#8223). Build + sign + **notarize all still pass** (the `dist/` app is intact — only the DMG is broken), so CI stays green while shipping a `.dmg` that crashes at launch with dyld `Library not loaded: @rpath/Electron Framework.framework/Electron Framework`, surfacing to users as *"Apple could not verify Pearl"*. The `.zip` artifact is immune.

- The base branch (#1987) already bumps DMG `size` 2g → **4g** to fix this for the Next-15-grown bundle; this PR **inherits** that fix.
- **Action for this PR's Tier 2:** confirm 4g still has headroom for the Electron-41 bundle, and verify the **DMG-installed** app (not `dist/`, not `.zip`) has a non-zero `Electron Framework` binary.

## Reviewer-noted caveats (acknowledged, no code action)

- **`@types/node` straddles two majors.** Electron 41 pulls in `@types/node@^24.9.0`; Pearl's tree still targets `@types/node@^20.9.0`. yarn.lock keeps both resolved (20.19.11 and 24.12.4) so TS compilation is unaffected. Runtime is Node 24, but Pearl's TS is type-checked against Node 20 — a Node-24-only API would compile cleanly but fail at runtime. Pearl's `electron/` code only uses very stable Node APIs (`fs`, `path`, `child_process`, `http`, `tls`), so the practical risk is minimal. Tracked for awareness, not blocking.

## Verification

Done (headless):
- [x] `yarn install` + `--frozen-lockfile` consistent in both trees
- [x] electron 41.7.0 binary executes on macOS arm64 (Node 24 / Chrome 146)
- [x] all 16 `electron/` JS files parse clean
- [x] breaking-changes audit — no code changes
- [x] interactive dev-mode boot under Electron 41 on macOS arm64 — main window renders, backend connects over self-signed cert, devtools loads, no `ERR_*` in console (Tier 1.1)

Pending (interactive / build-time):
- [x] **Tier 1** (remaining sub-checks): Tray icon renders + IPC round-trip (Settings persists across restart) + cross-window IPC handlers — verified interactively on macOS arm64: Settings/password/backup-wallet persist across sessions (store IPC round-trip), Web3Auth child window opens (`ipcMain.handle('web3auth-window-show')` + `setWindowOpenHandler` chain works), Help Center external-link routing works (`shell.openExternal`); Tray inferred from clean `app.whenReady()` completion (no init errors).
- [ ] **Tier 2**: `yarn build:pearl` packaging + cross-platform release — left **unticked** because workflow-success ≠ artifact-integrity. `create-feature-release` run [#26396319256](https://github.com/valory-xyz/olas-operate-app/actions/runs/26396319256) succeeded on `00d27e609` (all 13 jobs green; both macOS archs report `notarization successful`; all 6 platform artifacts produced — macOS arm64+x64 DMG/ZIP ~510-540 MB, Linux arm64+x86_64 AppImage, Windows x64 .exe; release: [v1.6.12-rc26 draft](https://github.com/valory-xyz/olas-operate-app/releases/tag/untagged-633170dd69551e16a57d)) — **but this is precisely the signal that cannot distinguish a healthy DMG from one ditto silently truncated** (see DMG packaging note above). The build/sign/notarize chain is validated; artifact integrity stays gated on the Tier 2 (DMG integrity) sub-check below.
- [ ] **Tier 2 (DMG integrity)**: DMG-installed `Electron Framework` binary present + non-zero; `spctl -a -vvv -t install` returns `source=Notarized Developer ID` (see DMG packaging note above)
- [ ] **Tier 2 (sandbox-fix sanity)**: confirm `electron-builder-sandbox-fix@1.1.1` still patches correctly under Electron 41 — surfaces as a renderer-sandbox or IPC misbehaviour in the **packaged** app (the shim patches the boot path of the packaged sandbox, not dev). Verify by clicking through the packaged app's IPC-heavy paths (Settings persist, Tray status updates, OnRamp/Web3Auth child windows open).
- [ ] **Tier 2.5**: auto-update across the major (existing installs on E33 → E41). **Decision needed before un-drafting:** the user-recovery path for the subset of E33 installs whose Squirrel cross-major OTA may fail (macOS 11 deprecation, framework-size growth, Node ABI change). Either (a) release-notes "if your update fails, download from <link>" with a fresh installer fallback, or (b) confirm the standard release-gate already covers this.




