### PR TITLE
ci(release): pre-create draft release to prevent duplicate drafts

### DIFF
--- a/.github/workflows/create-feature-release.yml
+++ b/.github/workflows/create-feature-release.yml
@@ -83,22 +83,29 @@ jobs:
       version_strategy: ${{ inputs.action == 'new' && 'increment' || 'override' }}
     secrets: inherit
 
-  run-release:
+  ensure-draft-release:
     needs: calculate-version
+    uses: ./.github/workflows/ensure-draft-release.yml
+    with:
+      release_tag: ${{ needs.calculate-version.outputs.new_tag }}
+    secrets: inherit
+
+  run-release:
+    needs: [calculate-version, ensure-draft-release]
     uses: ./.github/workflows/release_mac.yml
     with:
       tag: ${{ needs.calculate-version.outputs.new_tag }}
     secrets: inherit
 
   run-release-win:
-    needs: calculate-version
+    needs: [calculate-version, ensure-draft-release]
     uses: ./.github/workflows/release_win.yml
     with:
       tag: ${{ needs.calculate-version.outputs.new_tag }}
     secrets: inherit
 
   run-release-linux:
-    needs: calculate-version
+    needs: [calculate-version, ensure-draft-release]
     uses: ./.github/workflows/release_linux.yml
     with:
       tag: ${{ needs.calculate-version.outputs.new_tag }}

--- a/.github/workflows/ensure-draft-release.yml
+++ b/.github/workflows/ensure-draft-release.yml
@@ -1,0 +1,39 @@
+name: Ensure draft release exists
+
+# Pre-create the draft GitHub Release for a given tag so the parallel
+# Mac/Linux/Windows build jobs all find the same existing draft when
+# electron-builder publishes. Without this, each electron-builder
+# instance races to look up + create a draft for the same tag, producing
+# duplicate drafts with assets split between them.
+#
+# Idempotent: if a draft for the tag already exists, it's reused.
+
+on:
+  workflow_call:
+    inputs:
+      release_tag:
+        description: "GitHub Release tag (e.g., v1.2.3 — the unsuffixed tag electron-builder publishes to)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  ensure-draft-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Ensure draft release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Draft release $RELEASE_TAG already exists; reusing it."
+          else
+            gh release create "$RELEASE_TAG" --draft --title "$RELEASE_TAG" --notes ""
+            echo "Created draft release $RELEASE_TAG."
+          fi

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -107,22 +107,29 @@ jobs:
           git tag -a "$SIGNED_TAG" -m "Production Release $SIGNED_TAG"
           git push origin "$SIGNED_TAG"
 
-  run-release:
+  ensure-draft-release:
     needs: [compute-release-tag, create-signed-tag]
+    uses: ./.github/workflows/ensure-draft-release.yml
+    with:
+      release_tag: ${{ needs.compute-release-tag.outputs.release_tag }}
+    secrets: inherit
+
+  run-release:
+    needs: [compute-release-tag, create-signed-tag, ensure-draft-release]
     uses: ./.github/workflows/release_mac.yml
     with:
       tag: ${{ needs.compute-release-tag.outputs.signed_tag }}
     secrets: inherit
 
   run-release-linux:
-    needs: [compute-release-tag, create-signed-tag]
+    needs: [compute-release-tag, create-signed-tag, ensure-draft-release]
     uses: ./.github/workflows/release_linux.yml
     with:
       tag: ${{ needs.compute-release-tag.outputs.signed_tag }}
     secrets: inherit
 
   run-release-win:
-    needs: [compute-release-tag, create-signed-tag]
+    needs: [compute-release-tag, create-signed-tag, ensure-draft-release]
     uses: ./.github/workflows/release_win.yml
     with:
       tag: ${{ needs.compute-release-tag.outputs.signed_tag }}


### PR DESCRIPTION
## Summary

- The production and feature release workflows fan out to Mac/Linux/Windows builders in parallel. Each electron-builder instance independently asks the GitHub API for a draft release at the release tag and creates one if not found — producing **two draft releases for the same tag** with assets split between them when concurrent jobs race the lookup (e.g. v1.6.19 ended up with 7 assets in one draft and 10 in another in [this run](https://github.com/valory-xyz/olas-operate-app/actions/runs/26501380789/attempts/1)).
- Adds a reusable `ensure-draft-release.yml` workflow that idempotently pre-creates the draft for the unsuffixed `vX.Y.Z` tag.
- Both `production-release.yml` and `create-feature-release.yml` now run it before the build fan-out, so every electron-builder instance finds the same existing draft and uploads to it instead of racing to create its own.

## Notes

- The reusable workflow is idempotent: `gh release view` first, only `gh release create --draft` on miss. Safe for re-runs.
- For drafts, `gh release create` without `--target` does not create a real git tag — it's created at publish time, matching current behavior.
- Pre-existing split drafts from prior runs need a one-time manual cleanup; the fix prevents recurrence going forward.

## Test plan

- [ ] Trigger a feature release via `Create Feature Release` workflow and confirm exactly one draft release is created with all Mac/Linux/Windows assets attached.
- [ ] Merge a `release/*` → `main` PR to exercise `Production Release` and confirm the same.
- [ ] Re-run a release workflow after a successful run and confirm the existing draft is reused (not duplicated) and assets are overwritten cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)