### PR TITLE
feat(predict): Polystrat metrics-unavailable banner + unblock onboarding

### DIFF
--- a/frontend/components/MainPage/Home/Overview/Performance.tsx
+++ b/frontend/components/MainPage/Home/Overview/Performance.tsx
@@ -23,6 +23,16 @@ const NoMetricsAlert = () => (
   />
 );
 
+const MetricsUnavailableAlert = () => (
+  <Alert
+    message="Performance metrics aren't available in this app version"
+    type="info"
+    centered
+    showIcon
+    className="text-sm"
+  />
+);
+
 type RequiresProfileOpenAlertProps = {
   title: string;
   message: string;
@@ -161,7 +171,9 @@ export const Performance = ({
 
       <CardFlex $noBorder>
         <Flex vertical gap={24}>
-          {isLoading ? (
+          {selectedAgentConfig.arePerformanceMetricsUnavailable ? (
+            <MetricsUnavailableAlert />
+          ) : isLoading ? (
             <Flex justify="center" className="mt-24">
               <Spin />
             </Flex>

--- a/frontend/config/agents.ts
+++ b/frontend/config/agents.ts
@@ -126,6 +126,7 @@ export const AGENT_CONFIG: {
       'Trade sizes adapt to market conditions and agent confidence.',
     servicePublicId: 'valory/polymarket_trader:0.1.0',
     isGeoLocationRestricted: true,
+    arePerformanceMetricsUnavailable: true,
     erc20Tokens: [TokenSymbolMap.USDC, TokenSymbolMap.pUSD],
   },
   [AgentMap.Optimus]: {

--- a/frontend/config/agents.ts
+++ b/frontend/config/agents.ts
@@ -103,7 +103,6 @@ export const AGENT_CONFIG: {
   },
   [AgentMap.Polystrat]: {
     isAgentEnabled: true,
-    isAddingNewBlocked: true,
     requiresSetup: true,
     isX402Enabled: X402_ENABLED_FLAGS[AgentMap.Polystrat],
     name: 'Polystrat',

--- a/frontend/tests/components/MainPage/Home/Overview/Performance.test.tsx
+++ b/frontend/tests/components/MainPage/Home/Overview/Performance.test.tsx
@@ -1,0 +1,92 @@
+import { useQuery } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { Performance } from '../../../../../components/MainPage/Home/Overview/Performance';
+import { useService, useServices } from '../../../../../hooks';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+jest.mock('../../../../../hooks', () => ({
+  useService: jest.fn(),
+  useServices: jest.fn(),
+}));
+
+jest.mock('@tanstack/react-query', () => ({
+  ...jest.requireActual('@tanstack/react-query'),
+  useQuery: jest.fn(),
+}));
+
+jest.mock('../../../../../components/ui', () => ({
+  Alert: ({ message }: { message: React.ReactNode }) => (
+    <div data-testid="alert">{message}</div>
+  ),
+  CardFlex: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  InfoTooltip: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  Tooltip: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+const mockUseService = useService as jest.Mock;
+const mockUseServices = useServices as jest.Mock;
+const mockUseQuery = useQuery as jest.Mock;
+
+const BANNER_TEXT = /Performance metrics aren't available in this app version/i;
+
+const setServices = (agentConfigOverrides: Record<string, unknown> = {}) =>
+  mockUseServices.mockReturnValue({
+    selectedService: { service_config_id: 'config-1' },
+    selectedAgentConfig: {
+      defaultBehavior: 'Trade sizes adapt to market conditions.',
+      ...agentConfigOverrides,
+    },
+  });
+
+describe('Performance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseService.mockReturnValue({ isServiceActive: false });
+    mockUseQuery.mockReturnValue({
+      data: {
+        metrics: [
+          { name: 'ROI', value: '5%', is_primary: true, description: null },
+        ],
+        agent_behavior: null,
+        timestamp: null,
+      },
+      isLoading: false,
+    });
+  });
+
+  it('shows the metrics-unavailable banner instead of metrics when the flag is set', () => {
+    setServices({ arePerformanceMetricsUnavailable: true });
+    render(<Performance openProfile={jest.fn()} />);
+
+    expect(screen.getByText(BANNER_TEXT)).toBeInTheDocument();
+    expect(screen.queryByText('ROI')).toBeNull();
+  });
+
+  it('still renders the agent behavior section when metrics are unavailable', () => {
+    setServices({ arePerformanceMetricsUnavailable: true });
+    render(<Performance openProfile={jest.fn()} />);
+
+    expect(screen.getByText('Agent behavior')).toBeInTheDocument();
+    expect(
+      screen.getByText('Trade sizes adapt to market conditions.'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows performance metrics and no banner when the flag is not set', () => {
+    setServices();
+    render(<Performance openProfile={jest.fn()} />);
+
+    expect(screen.queryByText(BANNER_TEXT)).toBeNull();
+    expect(screen.getByText('ROI')).toBeInTheDocument();
+  });
+});

--- a/frontend/types/Agent.ts
+++ b/frontend/types/Agent.ts
@@ -83,6 +83,13 @@ export type AgentConfig = {
   servicePublicId: string;
   /** Whether the agent is geo-location restricted */
   isGeoLocationRestricted?: boolean;
+  /**
+   * Temporarily hides performance metrics and shows an
+   * "unavailable in this app version" banner instead. Set while the agent's
+   * subgraph is not yet indexed (e.g. Polystrat on the new Safe structure);
+   * remove or set to false to restore the metrics view.
+   */
+  arePerformanceMetricsUnavailable?: boolean;
   /** ERC20 tokens (beyond native + OLAS) to display and track for this agent */
   erc20Tokens?: TokenSymbol[];
 } & needsOpenProfileEachAgentRun;


### PR DESCRIPTION
## What

Pearl-side changes for [OPE-1757](https://linear.app/valory-xyz/issue/OPE-1757), in two parts:

### 1. Metrics-unavailable banner
The Polystrat subgraph is not yet indexed with the new Safe structure, so performance metrics are temporarily unavailable. In **Overview → Performance**, Polystrat now shows an info banner — **"Performance metrics aren't available in this app version"** — in place of the metrics, keeping the Agent behavior section (matches the Figma "Overview: Alert" design).

- New optional `AgentConfig.arePerformanceMetricsUnavailable` flag (`types/Agent.ts`), set `true` on **Polystrat only** (`config/agents.ts`).
- `Performance.tsx` renders the banner instead of metrics when the flag is set.
- **Easy revert:** remove the flag (or set `false`) once the subgraph is indexed.

### 2. Unblock new-agent onboarding
Removed `isAddingNewBlocked` from the Polystrat config so users (new or existing) can create a new Polystrat agent. This clears the maintenance alert, the disabled list item, and the `canSelectAgent` gate. The **geo-location restriction is unchanged** (separate, intentional gate).

## Testing

- New `Performance.test.tsx` (banner shows + metrics hidden when flagged; agent behavior persists; metrics show with no banner when unflagged).
- Existing config + AgentOnboarding suites pass (47 tests). No test asserted Polystrat was blocked; Optimus/AgentsFun still carry `isAddingNewBlocked`, so the "blocked list is non-empty" test stays green.
- `yarn typecheck` and `eslint` clean.

> Companion to predict-ui changes (agent-ui-monorepo#110), which handle the in-agent dashboard side of the same ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)