### PR TITLE
Release: v1.6.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,6 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.6.25",
+  "version": "1.6.26",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-app"
-version = "1.6.25"
+version = "1.6.26"
 description = ""
 authors = [
     { name = "David Vilela", email = "dvilelaf@gmail.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -1197,7 +1197,7 @@ wheels = [
 
 [[package]]
 name = "olas-operate-app"
-version = "1.6.25"
+version = "1.6.26"
 source = { virtual = "." }
 dependencies = [
     { name = "olas-operate-middleware" },


### PR DESCRIPTION
## Release v1.6.26

Re-cuts the v1.6.26 release through the correct `release/*` branch flow.

### Why
The original release branch `v1.6.26` (PR #2016) was **not** named `release/*`, so:
- `bump-release-version.yml` never fired → main stayed at `1.6.25` (the version bump never happened).
- `production-release.yml` skipped every job on merge (its gate requires `head.ref` to start with `release/`), so no build/release was produced. See run [27158201603](https://github.com/valory-xyz/olas-operate-app/actions/runs/27158201603).

### What
This branch was cut from `main` (which already contains the v1.6.26 code from PR #2016), so the only diff is the version bump to `1.6.26` produced by `bump-release-version.yml`.

Merging this into `main` satisfies the `production-release.yml` gate (`merged == true && head.ref` starts with `release/`) and triggers the mac/win/linux builds and the published v1.6.26 release.