### PR TITLE
feat(agents): fully decommission Agents.fun

### DIFF
--- a/docs/features/autorun.md
+++ b/docs/features/autorun.md
@@ -488,7 +488,7 @@ Shared eligibility-wait implementation. Polls every 2s until eligibility leaves 
 ### `fetchDeployabilityForAgent(agentMeta, ctx)` — `utils/autoRunHelpers.ts`
 Checks whether a candidate agent is deployable without switching the UI selection. Mirrors `useDeployability` but fetches staking state directly via `agentMeta.agentConfig.serviceApi` (same pattern as `fetchAgentStakingRewardsInfo`). Called by `scanAndStartNext` for each candidate so the visible page never changes during a scan cycle.
 
-Returns `{ canRun: true }`, `{ canRun: false, isTransient: true }` (transient/loading — short retry), or `{ canRun: false }` (deterministic block). Checks in order: safe readiness, `isUnderConstruction`, geo restriction, another agent running, on-chain slots/staking state (via `getStakingContractDetails` + `getServiceStakingDetails`), initial funding, balance sufficiency. API errors return `isTransient: true` (scanner uses short retry rather than treating as permanent block).
+Returns `{ canRun: true }`, `{ canRun: false, isTransient: true }` (transient/loading — short retry), or `{ canRun: false }` (deterministic block). Checks in order: safe readiness, `isPhasedOut`, `isUnderConstruction`, geo restriction, another agent running, on-chain slots/staking state (via `getStakingContractDetails` + `getServiceStakingDetails`), initial funding, balance sufficiency. API errors return `isTransient: true` (scanner uses short retry rather than treating as permanent block). Kept in parity with `useDeployability`.
 
 ---
 

--- a/docs/features/deployability-and-lifecycle.md
+++ b/docs/features/deployability-and-lifecycle.md
@@ -6,7 +6,7 @@ The deployability and lifecycle system determines whether an agent can be starte
 
 The system has four layers:
 
-1. **Deployability check** — `useDeployability` evaluates ~10 conditions to produce a `canRun` boolean with a reason string
+1. **Deployability check** — `useDeployability` evaluates ~11 conditions to produce a `canRun` boolean with a reason string
 2. **Service start** — `useStartService` handles safe creation, service creation/update, and starting the service (shared by manual and auto-run)
 3. **Deployment workflow** — `useServiceDeployment` orchestrates the full manual start flow: polling control, status overrides, state refresh, and error handling
 4. **Stop** — `stopDeployment` stops a running service
@@ -41,7 +41,7 @@ SettingsService (backend config)
 
 ## Source of truth
 
-- `frontend/hooks/useDeployability.ts` — deployability decision tree (~10 branches, returns `canRun` + `reason`)
+- `frontend/hooks/useDeployability.ts` — deployability decision tree (~11 branches, returns `canRun` + `reason`)
 - `frontend/hooks/useStartService.ts` — shared service start logic (safe creation, service create/update, start)
 - `frontend/hooks/useServiceDeployment.ts` — manual deployment workflow (polling control, status overrides, error handling)
 - `frontend/utils/service.ts` — `updateServiceIfNeeded` (hash, env vars, fund requirements, agent release comparison), `isValidServiceId`
@@ -76,7 +76,7 @@ SettingsService (backend config)
 
 ### Deployability result shape
 
-Defined as `DeployabilityResult` in `frontend/hooks/useDeployability.ts`. Fields: `isLoading`, `canRun`, `reason` (why `canRun` is false, e.g., `'Low balance'`, `'Evicted'`), `loadingReason` (comma-separated loading sources).
+Defined as `DeployabilityResult` in `frontend/hooks/useDeployability.ts`. Fields: `isLoading`, `canRun`, `reason` (why `canRun` is false, e.g., `'Phased out'`, `'Under construction'`, `'Low balance'`, `'Evicted'`), `loadingReason` (comma-separated loading sources).
 
 ### SharedProvider context shape
 
@@ -111,37 +111,52 @@ The hook evaluates conditions in priority order. The first failing condition det
 2. Any dependency still loading
    → canRun: false, reason: 'Loading', loadingReason: 'Services, Balances, ...'
 
-3. selectedAgentConfig.isUnderConstruction
+3. selectedAgentConfig.isPhasedOut
+   → canRun: false, reason: 'Phased out'
+
+4. selectedAgentConfig.isUnderConstruction
    → canRun: false, reason: 'Under construction'
 
-4. isGeoLocationRestricted && isAgentGeoRestricted
+5. isGeoLocationRestricted && isAgentGeoRestricted
    → canRun: false, reason: 'Region restricted'
 
-5. isAnotherAgentRunning
+6. isAnotherAgentRunning
    → canRun: false, reason: 'Another agent running'
 
-6. hasEnoughServiceSlots === false && !isServiceStaked
+7. hasEnoughServiceSlots === false && !isServiceStaked
    → canRun: false, reason: 'No available slots'
 
-7. isAgentEvicted && !isEligibleForStaking
+8. isAgentEvicted && !isEligibleForStaking
    → canRun: false, reason: 'Evicted'
 
-8. isAgentsFunFieldUpdateRequired
+9. isAgentsFunFieldUpdateRequired
    → canRun: false, reason: 'Update required'
 
-9. isInitialFunded === false
-   → canRun: false, reason: 'Unfinished setup'
+10. isInitialFunded === false
+    → canRun: false, reason: 'Unfinished setup'
 
-10. !canStartSelectedAgent (from refill requirements)
+11. !canStartSelectedAgent (from refill requirements)
     → canRun: false, reason: 'Low balance'
 
-11. All checks pass
+12. All checks pass
     → canRun: true
 ```
 
 **Loading sources** checked (in order): Offline, Services, Balances (3 sub-checks: not enabled, loading, or no balances for selected agent), Staking, Geo, Safe, Setup (`isInitialFunded === undefined`).
 
 The `safeEligibility` parameter is optional. Currently only auto-run's `useSelectedEligibility` passes it — `useServiceDeployment` calls `useDeployability()` with no argument, so manual deployment is **not** pre-blocked by safe eligibility at this level (safe eligibility is instead checked inside `createSafeIfNeeded` during the start flow). When provided, it's checked first, even before loading state.
+
+### Phased-out agents (terminal retirement)
+
+`AgentConfig.isPhasedOut` marks an agent as permanently retired — existing instances can no longer be run, only their funds withdrawn (set on **Agents.fun**). It is distinct from `isUnderConstruction` (temporary/technical, also hides the staking section) and `shutdownDate` (sunsetting — the agent still runs until the date). Behavior when set:
+
+- **`useDeployability`** returns `canRun: false, reason: 'Phased out'` (step 3 above), disabling the Start button.
+- **Auto-run** excludes the instances two ways: `getDecommissionedInstances` (`AutoRunProvider/utils/utils.ts`) marks them `canRun: false, reason: 'Decommissioned'`, and the scanner's `fetchDeployabilityForAgent` (`autoRunHelpers.ts`) returns `'Phased out'` — kept in parity with `useDeployability`.
+- **Agent page** shows `AgentPhasedOutAlert` ("…has been phased out and is no longer supported. You can still withdraw funds from your Agent Wallet." + Withdraw CTA), rendered as the first/pre-empting branch in `AgentDisabledAlert`.
+- **Select Agent** maintenance alert drops the "Existing agents continue to run as usual." line (`FundingRequirementStep`).
+- **New-epoch notifications** are skipped (`useNotifyOnNewEpoch`).
+
+`isAgentEnabled` and `isAddingNewBlocked` are deliberately kept `true`, so the sidebar entry, the staking section, and balance polling (for the withdraw flow) remain available. A currently-running instance is **not** force-stopped — restart is blocked and the user off-ramps via Withdraw.
 
 ### Service start flow (`useStartService`)
 
@@ -251,7 +266,7 @@ On mount, SharedProvider queries recovery status once (via React Query with `sta
 
 ## Test-relevant notes
 
-- `useDeployability` has ~10 prioritized branches — test each in isolation by mocking all dependencies. Priority order matters: safe eligibility blocks before loading, loading blocks before all runtime checks.
+- `useDeployability` has ~11 prioritized branches — test each in isolation by mocking all dependencies. Priority order matters: safe eligibility blocks before loading, loading blocks before all runtime checks, and `isPhasedOut` blocks before all other config/runtime checks (verify it pre-empts e.g. evicted/low-balance).
 - `useDeployability` loading sources — test each of the 7 loading conditions independently. The `loadingReason` string is comma-separated and reflects which sources are still loading.
 - `useDeployability` balance loading has 3 sub-checks: `!isBalancesAndFundingRequirementsEnabledForAllServices`, `isBalancesAndFundingRequirementsLoadingForAllServices`, and `!hasSelectedAgentBalances`. All three produce `'Balances'` in `loadingReason`.
 - `useDeployability` slot check — verify the `!isNil(hasEnoughServiceSlots)` guard: `undefined` should NOT trigger "No available slots", but `false` should (when not staked).

--- a/frontend/components/MainPage/Home/Overview/AgentInfo/AgentDisabledAlert/AgentPhasedOutAlert.tsx
+++ b/frontend/components/MainPage/Home/Overview/AgentInfo/AgentDisabledAlert/AgentPhasedOutAlert.tsx
@@ -1,0 +1,38 @@
+import { Button, Flex, Typography } from 'antd';
+
+import { STEPS } from '@/components/AgentWallet/types';
+import { Alert } from '@/components/ui';
+import { PAGES } from '@/constants';
+import { usePageState } from '@/hooks';
+
+const { Text } = Typography;
+
+export const AgentPhasedOutAlert = ({ agentName }: { agentName: string }) => {
+  const { goto } = usePageState();
+
+  return (
+    <Alert
+      type="warning"
+      showIcon
+      className="mt-16"
+      message={
+        <Flex align="center" gap={4}>
+          <Text className="text-sm">
+            {agentName} has been phased out and is no longer supported. You can
+            still withdraw funds from your Agent Wallet.
+          </Text>
+          <Button
+            onClick={() =>
+              goto(PAGES.AgentWallet, {
+                initialStep: STEPS.WITHDRAW_FROM_AGENT_WALLET,
+              })
+            }
+            size="small"
+          >
+            Withdraw
+          </Button>
+        </Flex>
+      }
+    />
+  );
+};

--- a/frontend/components/MainPage/Home/Overview/AgentInfo/AgentDisabledAlert/index.tsx
+++ b/frontend/components/MainPage/Home/Overview/AgentInfo/AgentDisabledAlert/index.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/hooks';
 
 import { AgentGeoBlockedAlert } from './AgentGeoBlockedAlert';
+import { AgentPhasedOutAlert } from './AgentPhasedOutAlert';
 import { AgentRunningAlert } from './AgentRunningAlert';
 import { ContractDeprecatedAlert } from './ContractDeprecatedAlert';
 import { EvictedAlert } from './EvictedAlert';
@@ -63,6 +64,16 @@ export const AgentDisabledAlert = () => {
     key: string;
     content: ReactNode;
   }>(() => {
+    // Terminal retirement pre-empts every other disabled-state alert.
+    if (selectedAgentConfig.isPhasedOut) {
+      return {
+        key: 'phased-out',
+        content: (
+          <AgentPhasedOutAlert agentName={selectedAgentConfig.displayName} />
+        ),
+      };
+    }
+
     if (selectedAgentConfig?.isGeoLocationRestricted && isAgentGeoRestricted) {
       return { key: 'geo-blocked', content: <AgentGeoBlockedAlert /> };
     }

--- a/frontend/components/MainPage/hooks/useNotifyOnNewEpoch.ts
+++ b/frontend/components/MainPage/hooks/useNotifyOnNewEpoch.ts
@@ -54,8 +54,9 @@ export const useNotifyOnNewEpoch = () => {
     // if active staking contract info is still loading
     if (isSelectedStakingContractDetailsLoading) return;
 
-    // if agent config is under construction
+    // if agent config is under construction or phased out
     if (selectedAgentConfig.isUnderConstruction) return;
+    if (selectedAgentConfig.isPhasedOut) return;
 
     // if initial funding is not done
     if (isInitialFunded === false) return;
@@ -97,6 +98,7 @@ export const useNotifyOnNewEpoch = () => {
     epochStatusNotification,
     epoch,
     selectedAgentConfig.isUnderConstruction,
+    selectedAgentConfig.isPhasedOut,
     canStartAgent,
     isBalancesAndFundingRequirementsLoading,
     showNotification,

--- a/frontend/components/SetupPage/AgentOnboarding/FundingRequirementStep.tsx
+++ b/frontend/components/SetupPage/AgentOnboarding/FundingRequirementStep.tsx
@@ -45,10 +45,12 @@ const MaintenanceAlert = ({
   agentName,
   reason,
   url,
+  isPhasedOut,
 }: {
   agentName: string;
   reason?: string;
   url?: string;
+  isPhasedOut?: boolean;
 }) => (
   <Alert
     type="warning"
@@ -62,7 +64,10 @@ const MaintenanceAlert = ({
         </Text>
         <Text className="text-sm">
           New {agentName} agents cannot be created at this time
-          {reason && ` ${reason}`}. Existing agents continue to run as usual.
+          {reason && ` ${reason}`}.
+          {/* Phased-out agents no longer run, so omit the "existing agents
+          continue to run" reassurance. */}
+          {!isPhasedOut && ' Existing agents continue to run as usual.'}
         </Text>
         {url && (
           <Link
@@ -249,6 +254,7 @@ export const FundingRequirementStep = ({
     category,
     isUnderConstruction,
     isAddingNewBlocked,
+    isPhasedOut,
   } = AGENT_CONFIG[agentType];
   const { name, displayName } = asEvmChainDetails(middlewareHomeChainId);
 
@@ -257,6 +263,7 @@ export const FundingRequirementStep = ({
   ) : isAddingNewBlocked ? (
     <MaintenanceAlert
       agentName={agentName}
+      isPhasedOut={isPhasedOut}
       reason={
         agentType === AgentMap.Polystrat
           ? 'due to recent Polymarket protocol updates'

--- a/frontend/config/agents.ts
+++ b/frontend/config/agents.ts
@@ -161,6 +161,7 @@ export const AGENT_CONFIG: {
     isUnderConstruction: false,
     isComingSoon: false,
     isAddingNewBlocked: true,
+    isPhasedOut: true,
     requiresSetup: true,
     isX402Enabled: X402_ENABLED_FLAGS[AgentMap.AgentsFun],
     name: 'Agents.fun',

--- a/frontend/context/AutoRunProvider/utils/autoRunHelpers.ts
+++ b/frontend/context/AutoRunProvider/utils/autoRunHelpers.ts
@@ -330,6 +330,10 @@ export const fetchDeployabilityForAgent = async (
   }
 
   // 2. Static agent-config flags (no API needed).
+  if (agentMeta.agentConfig.isPhasedOut) {
+    return { canRun: false, reason: 'Phased out' };
+  }
+
   if (agentMeta.agentConfig.isUnderConstruction) {
     return { canRun: false, reason: 'Under construction' };
   }

--- a/frontend/context/AutoRunProvider/utils/utils.ts
+++ b/frontend/context/AutoRunProvider/utils/utils.ts
@@ -163,6 +163,7 @@ export const getDecommissionedInstances = (configuredAgents: AgentMeta[]) =>
     .filter(
       (agent) =>
         agent.agentConfig.isUnderConstruction ||
+        agent.agentConfig.isPhasedOut ||
         agent.agentConfig.isAgentEnabled === false,
     )
     .map((agent) => agent.serviceConfigId);

--- a/frontend/hooks/useDeployability.ts
+++ b/frontend/hooks/useDeployability.ts
@@ -132,6 +132,11 @@ export const useDeployability = ({
       };
     }
 
+    // If the agent has been phased out, it can no longer be run
+    if (selectedAgentConfig.isPhasedOut) {
+      return { isLoading, canRun: false, reason: 'Phased out' };
+    }
+
     // If service is under construction
     if (selectedAgentConfig.isUnderConstruction) {
       return { isLoading, canRun: false, reason: 'Under construction' };
@@ -193,6 +198,7 @@ export const useDeployability = ({
     isServiceStaked,
     safeEligibility,
     selectedAgentConfig.isGeoLocationRestricted,
+    selectedAgentConfig.isPhasedOut,
     selectedAgentConfig.isUnderConstruction,
     loadingReason,
   ]);

--- a/frontend/tests/components/MainPage/Home/Overview/AgentInfo/AgentDisabledAlert/AgentPhasedOutAlert.test.tsx
+++ b/frontend/tests/components/MainPage/Home/Overview/AgentInfo/AgentDisabledAlert/AgentPhasedOutAlert.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { STEPS } from '../../../../../../../components/AgentWallet/types';
+import { AgentPhasedOutAlert } from '../../../../../../../components/MainPage/Home/Overview/AgentInfo/AgentDisabledAlert/AgentPhasedOutAlert';
+import { PAGES } from '../../../../../../../constants';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+jest.mock('../../../../../../../components/ui', () => ({
+  Alert: ({ message }: { message: React.ReactNode }) => (
+    <div data-testid="alert">{message}</div>
+  ),
+}));
+
+const mockGoto = jest.fn();
+jest.mock('../../../../../../../hooks', () => ({
+  usePageState: () => ({ goto: mockGoto }),
+}));
+
+describe('AgentPhasedOutAlert', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the phased-out message with the provided agent name', () => {
+    render(<AgentPhasedOutAlert agentName="Agents.fun" />);
+    expect(
+      screen.getByText(
+        /Agents.fun has been phased out and is no longer supported\. You can still withdraw funds from your Agent Wallet\./,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the Withdraw button', () => {
+    render(<AgentPhasedOutAlert agentName="Agents.fun" />);
+    expect(
+      screen.getByRole('button', { name: 'Withdraw' }),
+    ).toBeInTheDocument();
+  });
+
+  it('navigates to AgentWallet page with withdraw step when Withdraw is clicked', () => {
+    render(<AgentPhasedOutAlert agentName="Agents.fun" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Withdraw' }));
+    expect(mockGoto).toHaveBeenCalledWith(PAGES.AgentWallet, {
+      initialStep: STEPS.WITHDRAW_FROM_AGENT_WALLET,
+    });
+  });
+});

--- a/frontend/tests/components/MainPage/hooks/useNotifyOnNewEpoch.test.ts
+++ b/frontend/tests/components/MainPage/hooks/useNotifyOnNewEpoch.test.ts
@@ -75,7 +75,7 @@ const createPassingMockState = () => ({
     isEligibleForRewards: false,
   },
   services: {
-    selectedAgentConfig: { isUnderConstruction: false },
+    selectedAgentConfig: { isUnderConstruction: false, isPhasedOut: false },
     selectedService: { service_config_id: DEFAULT_SERVICE_CONFIG_ID },
   },
   service: {
@@ -166,6 +166,16 @@ describe('useNotifyOnNewEpoch', () => {
     it('does not notify when selectedAgentConfig.isUnderConstruction is true', () => {
       const state = createPassingMockState();
       state.services.selectedAgentConfig.isUnderConstruction = true;
+      applyMocks(state);
+
+      renderHook(() => useNotifyOnNewEpoch());
+
+      expect(mockShowNotification).not.toHaveBeenCalled();
+    });
+
+    it('does not notify when selectedAgentConfig.isPhasedOut is true', () => {
+      const state = createPassingMockState();
+      state.services.selectedAgentConfig.isPhasedOut = true;
       applyMocks(state);
 
       renderHook(() => useNotifyOnNewEpoch());

--- a/frontend/tests/components/SetupPage/AgentOnboarding/FundingRequirementStep.test.tsx
+++ b/frontend/tests/components/SetupPage/AgentOnboarding/FundingRequirementStep.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { FundingRequirementStep } from '../../../../components/SetupPage/AgentOnboarding/FundingRequirementStep';
+import { AgentMap } from '../../../../constants';
+
+// ---------------------------------------------------------------------------
+// Mocks — keep the heavy presentational deps light so we can assert the copy
+// rendered by the blocking MaintenanceAlert. The blocking path never reaches
+// the funding-requirement hooks, so a stub is enough.
+// ---------------------------------------------------------------------------
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('../../../../components/AgentIntroduction', () => ({
+  IntroductionAnimatedContainer: ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) => <div>{children}</div>,
+}));
+
+jest.mock('../../../../components/ui', () => ({
+  Alert: ({ message }: { message: React.ReactNode }) => (
+    <div data-testid="alert">{message}</div>
+  ),
+}));
+
+jest.mock('../../../../hooks', () => ({
+  useInitialFundingRequirements: () => ({}),
+}));
+
+describe('FundingRequirementStep — maintenance alert copy', () => {
+  it('omits the "existing agents continue to run" line for a phased-out agent', () => {
+    render(<FundingRequirementStep agentType={AgentMap.AgentsFun} />);
+
+    expect(
+      screen.getByText(/Agents.fun is currently unavailable/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/New Agents.fun agents cannot be created at this time/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Existing agents continue to run as usual/),
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps the "existing agents continue to run" line for a blocked-but-not-phased-out agent', () => {
+    // PettAi blocks new instances (isAddingNewBlocked) but is sunsetting via
+    // shutdownDate, not phased out — so existing instances still run.
+    render(<FundingRequirementStep agentType={AgentMap.PettAi} />);
+
+    expect(
+      screen.getByText(/cannot be created at this time/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Existing agents continue to run as usual/),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/config/agents.test.ts
+++ b/frontend/tests/config/agents.test.ts
@@ -47,6 +47,14 @@ describe('AGENT_CONFIG', () => {
     expect(typeof config.requiresSetup).toBe('boolean');
   });
 
+  it.each(
+    Object.entries(AGENT_CONFIG).filter(
+      ([, config]) => 'isPhasedOut' in config,
+    ),
+  )('%s.isPhasedOut is a boolean', (_, config) => {
+    expect(typeof config.isPhasedOut).toBe('boolean');
+  });
+
   it('additionalRequirements values are finite numbers', () => {
     for (const config of Object.values(AGENT_CONFIG)) {
       if (!config.additionalRequirements) continue;
@@ -117,6 +125,28 @@ describe('PettAi creation blocking and deprecation', () => {
       ([agentType]) => agentType === AgentMap.PettAi,
     );
     expect(pettAiEntry).toBeDefined();
+  });
+});
+
+describe('Agents.fun phase-out', () => {
+  it('is marked phased out', () => {
+    expect(AGENT_CONFIG[AgentMap.AgentsFun].isPhasedOut).toBe(true);
+  });
+
+  it('stays enabled and listed so the sidebar entry and withdraw flow remain reachable', () => {
+    expect(AGENT_CONFIG[AgentMap.AgentsFun].isAgentEnabled).toBe(true);
+    const entry = ACTIVE_AGENTS.find(
+      ([agentType]) => agentType === AgentMap.AgentsFun,
+    );
+    expect(entry).toBeDefined();
+  });
+
+  it('still blocks creation of new instances', () => {
+    expect(AGENT_CONFIG[AgentMap.AgentsFun].isAddingNewBlocked).toBe(true);
+  });
+
+  it('is not under construction (keeps staking section visible)', () => {
+    expect(AGENT_CONFIG[AgentMap.AgentsFun].isUnderConstruction).toBe(false);
   });
 });
 

--- a/frontend/tests/context/AutoRunProvider/utils/autoRunHelpers.test.ts
+++ b/frontend/tests/context/AutoRunProvider/utils/autoRunHelpers.test.ts
@@ -872,6 +872,19 @@ describe('fetchDeployabilityForAgent', () => {
     expect(result.reason).toBe('Under construction');
   });
 
+  it('returns canRun=false when agent is phased out', async () => {
+    const meta = {
+      ...makeAgentMeta(),
+      agentConfig: {
+        ...makeAgentMeta().agentConfig,
+        isPhasedOut: true,
+      },
+    };
+    const result = await fetchDeployabilityForAgent(meta, makeCtx());
+    expect(result.canRun).toBe(false);
+    expect(result.reason).toBe('Phased out');
+  });
+
   it('returns canRun=false when agent is geo-restricted', async () => {
     const meta = {
       ...makeAgentMeta(),

--- a/frontend/tests/context/AutoRunProvider/utils/utils.test.ts
+++ b/frontend/tests/context/AutoRunProvider/utils/utils.test.ts
@@ -255,6 +255,24 @@ describe('getDecommissionedInstances', () => {
     ]);
   });
 
+  it('returns serviceConfigIds of agents that are phased out', () => {
+    const agents = [
+      {
+        ...makeAutoRunAgentMeta(
+          AgentMap.AgentsFun,
+          AGENT_CONFIG[AgentMap.AgentsFun],
+        ),
+        agentConfig: {
+          ...AGENT_CONFIG[AgentMap.AgentsFun],
+          isPhasedOut: true,
+        },
+      },
+    ];
+    expect(getDecommissionedInstances(agents)).toEqual([
+      DEFAULT_SERVICE_CONFIG_ID,
+    ]);
+  });
+
   it('returns serviceConfigIds of agents that are not enabled', () => {
     const agents = [
       {

--- a/frontend/tests/hooks/useDeployability.test.ts
+++ b/frontend/tests/hooks/useDeployability.test.ts
@@ -295,6 +295,40 @@ describe('useDeployability', () => {
     });
   });
 
+  describe('phased out', () => {
+    it('returns canRun=false with "Phased out" reason', () => {
+      setupDefaults();
+      mockUseServices.mockReturnValue({
+        ...defaultServices,
+        selectedAgentConfig: {
+          ...defaultServices.selectedAgentConfig,
+          isPhasedOut: true,
+        },
+      } as unknown as ReturnType<typeof useServices>);
+      const { result } = renderHook(() => useDeployability());
+      expect(result.current.canRun).toBe(false);
+      expect(result.current.reason).toBe('Phased out');
+    });
+
+    it('takes priority over evicted and low balance', () => {
+      setupDefaults({
+        staking: { isAgentEvicted: true, isEligibleForStaking: false },
+        balance: {
+          allowStartAgentByServiceConfigId: jest.fn().mockReturnValue(false),
+        },
+      });
+      mockUseServices.mockReturnValue({
+        ...defaultServices,
+        selectedAgentConfig: {
+          ...defaultServices.selectedAgentConfig,
+          isPhasedOut: true,
+        },
+      } as unknown as ReturnType<typeof useServices>);
+      const { result } = renderHook(() => useDeployability());
+      expect(result.current.reason).toBe('Phased out');
+    });
+  });
+
   describe('under construction (branch 3)', () => {
     it('returns canRun=false with "Under construction" reason', () => {
       setupDefaults();

--- a/frontend/types/Agent.ts
+++ b/frontend/types/Agent.ts
@@ -57,6 +57,14 @@ export type AgentConfig = {
   isAddingNewBlocked?: boolean;
   /** Human-readable shutdown date for deprecation banner, e.g. 'June 15, 2026' */
   shutdownDate?: string;
+  /**
+   * Terminal retirement. Blocks running existing instances (Start disabled,
+   * excluded from auto-run, no new-epoch nudges) and shows a "phased out — you
+   * can still withdraw" alert. Keep `isAgentEnabled: true` so the instance stays
+   * in the sidebar and the withdraw flow remains reachable. Distinct from
+   * `shutdownDate` (sunsetting — still runs until the date).
+   */
+  isPhasedOut?: boolean;
   /** Whether the agent is enabled and can be shown in the UI */
   isAgentEnabled: boolean;
   /** If agent is enabled but not yet available to use */

--- a/package.json
+++ b/package.json
@@ -108,6 +108,6 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.6.27-rc2",
+  "version": "1.6.27-rc3",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-app"
-version = "1.6.27-rc2"
+version = "1.6.27-rc3"
 description = ""
 authors = [
     { name = "David Vilela", email = "dvilelaf@gmail.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -1144,7 +1144,7 @@ wheels = [
 
 [[package]]
 name = "olas-operate-app"
-version = "1.6.27rc2"
+version = "1.6.27rc3"
 source = { virtual = "." }
 dependencies = [
     { name = "olas-operate-middleware" },


### PR DESCRIPTION
## What & why

**OPE-1793.** Agents.fun is being retired. New-instance creation was already blocked; this moves it to a terminal **phased-out** state — existing instances can no longer be run, only their funds withdrawn.

## Changes

New `isPhasedOut` flag on `AgentConfig` (set on Agents.fun), wired through existing seams:

- **Block running** — `useDeployability` returns `canRun: false` (reason `Phased out`), disabling the Start button
- **Agent-page alert** — new `AgentPhasedOutAlert` (*"…has been phased out and is no longer supported. You can still withdraw funds from your Agent Wallet."* + Withdraw CTA), rendered as the first/pre-empting branch in `AgentDisabledAlert`
- **Select Agent copy** — drops *"Existing agents continue to run as usual."* from the maintenance alert when an agent is phased out
- **Auto-run** — excludes phased-out instances (`getDecommissionedInstances`)
- **Notifications** — skips new-epoch nudges for phased-out agents

Keeps `isAgentEnabled` / `isAddingNewBlocked` true so the sidebar entry, staking section and withdraw flow stay reachable (per design).

## Design fidelity

Verified all three states in-app against Figma:
- Select Agent: "Agents.fun is currently unavailable / New Agents.fun agents cannot be created at this time."
- Agent page: disabled **Start agent**, phased-out alert + right-aligned **Withdraw**, single alert (no stacking)
- Withdraw → existing "Withdraw & Decommission Agent" flow

## Not in scope

- Currently-running instances are **not** force-stopped — restart is blocked; users off-ramp via Withdraw (matches the existing PettBro/decommission precedent).
- Select-screen header/title/"InfoFi" tag deltas in the mock were filler — unchanged.

<img width="976" height="767" alt="Sc2" src="https://github.com/user-attachments/assets/c2ab11a0-1fd6-4683-bd84-718ba799d23e" />

<img width="1267" height="586" alt="S51 PM" src="https://github.com/user-attachments/assets/41587295-fc88-46cc-be4c-98f5a7ddee8b" />

<img width="1211" height="789" alt="Scr6PM" src="https://github.com/user-attachments/assets/10437e69-6c76-48a1-9e3c-30711e47da74" />

