### PR TITLE
fix(OPE-1794): Fix issue with AgentSigner funding

### DIFF
--- a/frontend/components/AgentWallet/FundAgent/ConfirmTransfer.tsx
+++ b/frontend/components/AgentWallet/FundAgent/ConfirmTransfer.tsx
@@ -161,13 +161,21 @@ type ConfirmTransferProps = {
 /**
  * Prepares ChainFunds for a funding request.
  *
- * Converts user-entered amounts into keyed by token address amounts, allocating funds
- * to the service EOA first to cover its requirements, and sending any remainder to safe.
+ * Converts user-entered amounts into amounts keyed by token address, then splits
+ * each token between the service EOA and Safe by their respective requirements:
  *
- * When `forceEoaOnly` is true, native gas (AddressZero) bypasses the EOA-vs-Safe split
- * and routes 100% to the EOA — used when the user entered this flow from an
+ * - The EOA is funded up to its requirement (`eoaTokenRequirements`).
+ * - For native gas (AddressZero): the Safe receives only up to its own
+ *   requirement (`safeTokenRequirements`); any excess goes to the EOA. Only the
+ *   signer EOA spends native gas, so stranding excess native in the Safe leaves
+ *   the signer under-funded (re-triggering the low-balance alert) and surfaces
+ *   the gas as a portfolio asset.
+ * - For ERC20: the remainder beyond the EOA requirement goes to the Safe, the
+ *   agent's operating/investment wallet.
+ *
+ * When `forceEoaOnly` is true, native gas bypasses the Safe entirely and routes
+ * 100% to the EOA — used when the user entered this flow from an
  * INSUFFICIENT_SIGNER_GAS modal where the EOA is the wallet that needs funding.
- * ERC20 amounts still follow the regular split.
  */
 export const prepareAgentFundsForTransfer = ({
   fundsToTransfer,
@@ -175,6 +183,7 @@ export const prepareAgentFundsForTransfer = ({
   serviceSafe,
   serviceEoa,
   eoaTokenRequirements,
+  safeTokenRequirements,
   forceEoaOnly = false,
 }: {
   fundsToTransfer: TokenAmounts;
@@ -182,6 +191,7 @@ export const prepareAgentFundsForTransfer = ({
   serviceSafe: { address: Address };
   serviceEoa: { address: Address };
   eoaTokenRequirements: Maybe<TokenBalanceRecord>;
+  safeTokenRequirements: Maybe<TokenBalanceRecord>;
   forceEoaOnly?: boolean;
 }): ChainFunds => {
   const chainTokenConfig = TOKEN_CONFIG[asEvmChainId(middlewareHomeChainId)];
@@ -201,40 +211,49 @@ export const prepareAgentFundsForTransfer = ({
     }
   });
 
-  // Build agent funds fulfilling EOA requirements first, send remainder to Safe
   const eoaAddress = serviceEoa.address;
+  const safeAddress = serviceSafe.address;
   const agentFunds: Record<Address, TokenAmountMap> = {};
 
-  Object.entries(tokenAmountsByAddress).forEach(([tokenAddress, amount]) => {
-    const amountBigInt = BigInt(amount);
+  Object.entries(tokenAmountsByAddress).forEach(
+    ([untypedTokenAddress, amount]) => {
+      const tokenAddress = untypedTokenAddress as Address;
+      const amountBigInt = BigInt(amount);
+      const isNative = tokenAddress === AddressZero;
 
-    // Gas-error entry: route all native gas to the EOA regardless of the
-    // polled eoaTokenRequirements (which may report 0 if the EOA is fine
-    // for "normal operation" but not for the specific failed transaction).
-    if (forceEoaOnly && tokenAddress === AddressZero) {
-      set(agentFunds, `${eoaAddress}.${tokenAddress}`, amountBigInt.toString());
-      return;
-    }
-
-    const requiredForEoa = BigInt(
-      (eoaTokenRequirements?.[tokenAddress as Address] as string) || '0',
-    );
-    const allocateToEoa = bigintMin(amountBigInt, requiredForEoa);
-
-    if (allocateToEoa > 0n) {
-      set(
-        agentFunds,
-        `${eoaAddress}.${tokenAddress}`,
-        allocateToEoa.toString(),
+      // 1. Fund the EOA up to its own requirement.
+      const requiredForEoa = BigInt(
+        (eoaTokenRequirements?.[tokenAddress] as string) || '0',
       );
-    }
+      const allocateToEoa = bigintMin(amountBigInt, requiredForEoa);
+      const afterEoa = amountBigInt - allocateToEoa;
 
-    const remaining = amountBigInt - allocateToEoa;
-    if (remaining > 0n) {
-      const safeAddress = serviceSafe.address;
-      set(agentFunds, [safeAddress, tokenAddress], remaining.toString());
-    }
-  });
+      // 2. Distribute the remainder.
+      let toEoa = allocateToEoa;
+      let toSafe = 0n;
+
+      if (isNative) {
+        // The Safe receives native only up to its own requirement; the signer
+        // EOA spends all gas, so any excess native belongs there. A gas-error
+        // entry (forceEoaOnly) keeps 100% of native on the EOA.
+        const safeNativeTarget = forceEoaOnly
+          ? 0n
+          : BigInt((safeTokenRequirements?.[tokenAddress] as string) || '0');
+        toSafe = bigintMin(afterEoa, safeNativeTarget);
+        toEoa += afterEoa - toSafe; // native excess → signer EOA
+      } else {
+        // ERC20 remainder (requirement + any excess) goes to the Safe.
+        toSafe = afterEoa;
+      }
+
+      if (toEoa > 0n) {
+        set(agentFunds, [eoaAddress, tokenAddress], toEoa.toString());
+      }
+      if (toSafe > 0n) {
+        set(agentFunds, [safeAddress, tokenAddress], toSafe.toString());
+      }
+    },
+  );
 
   const fundsTo: ChainFunds = {
     [middlewareHomeChainId]: agentFunds,
@@ -254,7 +273,8 @@ export const ConfirmTransfer = ({
   );
   const { onFundAgent, isLoading, isSuccess, isError, error, resetMutation } =
     useConfirmTransfer();
-  const { eoaTokenRequirements } = useAgentFundingRequests();
+  const { eoaTokenRequirements, safeTokenRequirements } =
+    useAgentFundingRequests();
   const { fundEntrySource } = useAgentWallet();
   const { goto } = usePageState();
 
@@ -278,6 +298,7 @@ export const ConfirmTransfer = ({
       serviceSafe,
       serviceEoa,
       eoaTokenRequirements,
+      safeTokenRequirements,
       forceEoaOnly: fundEntrySource === 'gas-error',
     });
 
@@ -290,6 +311,7 @@ export const ConfirmTransfer = ({
     serviceSafe,
     serviceEoa,
     eoaTokenRequirements,
+    safeTokenRequirements,
     fundEntrySource,
   ]);
 

--- a/frontend/hooks/useAgentFundingRequests.tsx
+++ b/frontend/hooks/useAgentFundingRequests.tsx
@@ -56,7 +56,9 @@ const getFormattedTokensList = (
  */
 export const useAgentFundingRequests = () => {
   const { selectedAgentConfig, selectedService } = useServices();
-  const { serviceEoa } = useService(selectedService?.service_config_id);
+  const { serviceEoa, serviceSafes } = useService(
+    selectedService?.service_config_id,
+  );
   const { agentFundingRequests, isAgentFundingRequestsStale } =
     useBalanceAndRefillRequirementsContext();
 
@@ -117,11 +119,31 @@ export const useAgentFundingRequests = () => {
     return agentFundingRequests[eoaAddress] || null;
   }, [agentFundingRequests, isAgentFundingRequestsStale, serviceEoa?.address]);
 
+  // Split requirements for Agent Safe wallet (home chain only)
+  const safeTokenRequirements = useMemo(() => {
+    if (!agentFundingRequests) return null;
+    if (isAgentFundingRequestsStale) return null;
+
+    const safeAddress = serviceSafes?.find(
+      ({ evmChainId }) => evmChainId === selectedAgentConfig.evmHomeChainId,
+    )?.address;
+    if (!safeAddress) return null;
+
+    return agentFundingRequests[safeAddress] || null;
+  }, [
+    agentFundingRequests,
+    isAgentFundingRequestsStale,
+    serviceSafes,
+    selectedAgentConfig.evmHomeChainId,
+  ]);
+
   return {
     /** Consolidated requirements per token address: {[tokenAddress]: totalAmount} */
     agentTokenRequirements,
     /** Requirements for service EOA address only: {[tokenAddress]: amount} */
     eoaTokenRequirements,
+    /** Requirements for service Safe address only: {[tokenAddress]: amount} */
+    safeTokenRequirements,
     /** Formatted token requirements: "10 XDAI, 15 USDC and 100 OLAS" */
     agentTokenRequirementsFormatted,
     /** True if any required token amount is above zero, indicating a funding need. */

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "picomatch": "4.0.4",
     "postcss": "8.5.10",
     "tar": "7.5.15",
-    "ws": "8.20.1"
+    "ws": "8.21.0"
   },
   "dependencies": {
     "@ant-design/cssinjs": "1.24.0",

--- a/frontend/tests/components/AgentWallet/FundAgent/ConfirmTransfer.test.tsx
+++ b/frontend/tests/components/AgentWallet/FundAgent/ConfirmTransfer.test.tsx
@@ -110,7 +110,10 @@ const setupHappyPath = () => {
     serviceSafes: [{ address: DEFAULT_SAFE_ADDRESS, evmChainId: 100 }],
     serviceEoa: { address: DEFAULT_EOA_ADDRESS },
   });
-  mockUseAgentFundingRequests.mockReturnValue({ eoaTokenRequirements: {} });
+  mockUseAgentFundingRequests.mockReturnValue({
+    eoaTokenRequirements: {},
+    safeTokenRequirements: {},
+  });
   mockUseBalanceAndRefillRequirementsContext.mockReturnValue({
     refetch: jest.fn(),
   });

--- a/frontend/tests/components/AgentWallet/FundAgent/prepareAgentFundsForTransfer.test.ts
+++ b/frontend/tests/components/AgentWallet/FundAgent/prepareAgentFundsForTransfer.test.ts
@@ -7,6 +7,10 @@ import {
   DEFAULT_SAFE_ADDRESS,
 } from '../../../helpers/factories';
 
+// Gnosis OLAS (ERC20) — used to assert the ERC20 split path.
+const GNOSIS_OLAS_ADDRESS =
+  '0xcE11e14225575945b8E6Dc0D4F2dD4C570f79d9f' as Address;
+
 describe('prepareAgentFundsForTransfer', () => {
   const baseArgs = {
     middlewareHomeChainId: MiddlewareChainMap.GNOSIS,
@@ -14,72 +18,149 @@ describe('prepareAgentFundsForTransfer', () => {
     serviceEoa: { address: DEFAULT_EOA_ADDRESS as Address },
   };
 
-  describe('default split (forceEoaOnly=false)', () => {
-    it('allocates to EOA up to eoaTokenRequirements, remainder to safe', () => {
+  const eoaFunds = (result: ReturnType<typeof prepareAgentFundsForTransfer>) =>
+    result[MiddlewareChainMap.GNOSIS]![DEFAULT_EOA_ADDRESS as Address];
+  const safeFunds = (result: ReturnType<typeof prepareAgentFundsForTransfer>) =>
+    result[MiddlewareChainMap.GNOSIS]![DEFAULT_SAFE_ADDRESS as Address];
+
+  describe('native gas (default split, forceEoaOnly=false)', () => {
+    it('routes native excess to the EOA when the Safe has no native requirement', () => {
+      // Optimus-like: Safe wants 0 native. User funds 1 XDAI, EOA needs 0.3.
       const result = prepareAgentFundsForTransfer({
         ...baseArgs,
         fundsToTransfer: { XDAI: { amount: 1 } },
         eoaTokenRequirements: { [AddressZero]: '300000000000000000' },
+        safeTokenRequirements: {},
       });
 
-      const chainFunds = result[MiddlewareChainMap.GNOSIS]!;
-      expect(chainFunds[DEFAULT_EOA_ADDRESS as Address]?.[AddressZero]).toBe(
-        '300000000000000000',
-      );
-      expect(chainFunds[DEFAULT_SAFE_ADDRESS as Address]?.[AddressZero]).toBe(
-        '700000000000000000',
-      );
+      // Entire 1 XDAI lands on the signer EOA; nothing strands in the Safe.
+      expect(eoaFunds(result)?.[AddressZero]).toBe('1000000000000000000');
+      expect(safeFunds(result)).toBeUndefined();
     });
 
-    it('routes everything to safe when eoaTokenRequirements is empty', () => {
+    it('splits native by per-wallet requirement and routes the excess to the EOA', () => {
+      // Trader-like: EOA needs 0.2, Safe needs 0.8. User over-funds 1.5 XDAI.
+      const result = prepareAgentFundsForTransfer({
+        ...baseArgs,
+        fundsToTransfer: { XDAI: { amount: 1.5 } },
+        eoaTokenRequirements: { [AddressZero]: '200000000000000000' },
+        safeTokenRequirements: { [AddressZero]: '800000000000000000' },
+      });
+
+      // Safe gets exactly its requirement (0.8); EOA gets 0.2 + 0.5 excess = 0.7.
+      expect(eoaFunds(result)?.[AddressZero]).toBe('700000000000000000');
+      expect(safeFunds(result)?.[AddressZero]).toBe('800000000000000000');
+    });
+
+    it('honours both requirements exactly when funded with the combined amount (no excess)', () => {
+      const result = prepareAgentFundsForTransfer({
+        ...baseArgs,
+        fundsToTransfer: { XDAI: { amount: 1 } },
+        eoaTokenRequirements: { [AddressZero]: '200000000000000000' },
+        safeTokenRequirements: { [AddressZero]: '800000000000000000' },
+      });
+
+      expect(eoaFunds(result)?.[AddressZero]).toBe('200000000000000000');
+      expect(safeFunds(result)?.[AddressZero]).toBe('800000000000000000');
+    });
+
+    it('sends everything to the EOA when funded below the EOA requirement', () => {
+      const result = prepareAgentFundsForTransfer({
+        ...baseArgs,
+        fundsToTransfer: { XDAI: { amount: 0.1 } },
+        eoaTokenRequirements: { [AddressZero]: '300000000000000000' },
+        safeTokenRequirements: { [AddressZero]: '800000000000000000' },
+      });
+
+      expect(eoaFunds(result)?.[AddressZero]).toBe('100000000000000000');
+      expect(safeFunds(result)).toBeUndefined();
+    });
+
+    it('routes all native to the EOA when no requirements are available', () => {
       const result = prepareAgentFundsForTransfer({
         ...baseArgs,
         fundsToTransfer: { XDAI: { amount: 1 } },
         eoaTokenRequirements: {},
+        safeTokenRequirements: {},
       });
 
-      const chainFunds = result[MiddlewareChainMap.GNOSIS]!;
-      expect(chainFunds[DEFAULT_EOA_ADDRESS as Address]).toBeUndefined();
-      expect(chainFunds[DEFAULT_SAFE_ADDRESS as Address]?.[AddressZero]).toBe(
+      expect(eoaFunds(result)?.[AddressZero]).toBe('1000000000000000000');
+      expect(safeFunds(result)).toBeUndefined();
+    });
+  });
+
+  describe('ERC20 tokens (always remainder to Safe)', () => {
+    it('routes the ERC20 remainder (requirement + excess) to the Safe', () => {
+      const result = prepareAgentFundsForTransfer({
+        ...baseArgs,
+        fundsToTransfer: { OLAS: { amount: 1 } },
+        eoaTokenRequirements: {},
+        safeTokenRequirements: {},
+      });
+
+      expect(eoaFunds(result)).toBeUndefined();
+      expect(safeFunds(result)?.[GNOSIS_OLAS_ADDRESS]).toBe(
         '1000000000000000000',
+      );
+    });
+
+    it('funds the EOA up to its ERC20 requirement, remainder to the Safe', () => {
+      const result = prepareAgentFundsForTransfer({
+        ...baseArgs,
+        fundsToTransfer: { OLAS: { amount: 1 } },
+        eoaTokenRequirements: { [GNOSIS_OLAS_ADDRESS]: '400000000000000000' },
+        safeTokenRequirements: {},
+      });
+
+      expect(eoaFunds(result)?.[GNOSIS_OLAS_ADDRESS]).toBe(
+        '400000000000000000',
+      );
+      expect(safeFunds(result)?.[GNOSIS_OLAS_ADDRESS]).toBe(
+        '600000000000000000',
       );
     });
   });
 
   describe('forceEoaOnly=true (gas-error entry)', () => {
-    it('routes all native gas to EOA even when eoaTokenRequirements reports 0', () => {
+    it('routes all native gas to the EOA even when the Safe has a native requirement', () => {
       const result = prepareAgentFundsForTransfer({
         ...baseArgs,
         fundsToTransfer: { XDAI: { amount: 1 } },
-        // The polled requirements say EOA needs nothing — without
-        // forceEoaOnly, this is the bug path that routes funds to the safe.
-        eoaTokenRequirements: {},
+        eoaTokenRequirements: { [AddressZero]: '200000000000000000' },
+        safeTokenRequirements: { [AddressZero]: '800000000000000000' },
         forceEoaOnly: true,
       });
 
-      const chainFunds = result[MiddlewareChainMap.GNOSIS]!;
-      expect(chainFunds[DEFAULT_EOA_ADDRESS as Address]?.[AddressZero]).toBe(
-        '1000000000000000000',
-      );
-      expect(chainFunds[DEFAULT_SAFE_ADDRESS as Address]).toBeUndefined();
+      expect(eoaFunds(result)?.[AddressZero]).toBe('1000000000000000000');
+      expect(safeFunds(result)).toBeUndefined();
     });
 
-    it('routes all native gas to EOA when eoaTokenRequirements reports a smaller amount', () => {
+    it('routes all native gas to the EOA when eoaTokenRequirements reports 0', () => {
       const result = prepareAgentFundsForTransfer({
         ...baseArgs,
         fundsToTransfer: { XDAI: { amount: 1 } },
-        // Even though the polled requirements say EOA needs only 0.3, the
-        // user came here because the failed tx needed more — force all 1
-        // XDAI to the EOA.
-        eoaTokenRequirements: { [AddressZero]: '300000000000000000' },
+        eoaTokenRequirements: {},
+        safeTokenRequirements: {},
         forceEoaOnly: true,
       });
 
-      const chainFunds = result[MiddlewareChainMap.GNOSIS]!;
-      expect(chainFunds[DEFAULT_EOA_ADDRESS as Address]?.[AddressZero]).toBe(
+      expect(eoaFunds(result)?.[AddressZero]).toBe('1000000000000000000');
+      expect(safeFunds(result)).toBeUndefined();
+    });
+
+    it('still sends the ERC20 remainder to the Safe', () => {
+      const result = prepareAgentFundsForTransfer({
+        ...baseArgs,
+        fundsToTransfer: { OLAS: { amount: 1 } },
+        eoaTokenRequirements: {},
+        safeTokenRequirements: {},
+        forceEoaOnly: true,
+      });
+
+      expect(eoaFunds(result)).toBeUndefined();
+      expect(safeFunds(result)?.[GNOSIS_OLAS_ADDRESS]).toBe(
         '1000000000000000000',
       );
-      expect(chainFunds[DEFAULT_SAFE_ADDRESS as Address]).toBeUndefined();
     });
   });
 });

--- a/frontend/tests/hooks/useAgentFundingRequests.test.ts
+++ b/frontend/tests/hooks/useAgentFundingRequests.test.ts
@@ -62,12 +62,22 @@ const defaultServiceEoa = {
   owner: WALLET_OWNER.Agent as typeof WALLET_OWNER.Agent,
 };
 
+const defaultServiceSafes = [
+  {
+    address: DEFAULT_SAFE_ADDRESS,
+    evmChainId: GNOSIS_CHAIN_ID,
+    type: WALLET_TYPE.Safe as typeof WALLET_TYPE.Safe,
+    owner: WALLET_OWNER.Agent as typeof WALLET_OWNER.Agent,
+  },
+];
+
 type SetupMocksOptions = {
   agentFundingRequests?: AddressBalanceRecord;
   isAgentFundingRequestsStale?: boolean;
   selectedAgentConfig?: ReturnType<typeof useServices>['selectedAgentConfig'];
   selectedService?: ReturnType<typeof useServices>['selectedService'];
   serviceEoa?: typeof defaultServiceEoa | null;
+  serviceSafes?: typeof defaultServiceSafes;
 };
 
 function setupMocks(options: SetupMocksOptions = {}) {
@@ -80,6 +90,8 @@ function setupMocks(options: SetupMocksOptions = {}) {
 
   const serviceEoa =
     'serviceEoa' in options ? options.serviceEoa : defaultServiceEoa;
+  const serviceSafes =
+    'serviceSafes' in options ? options.serviceSafes : defaultServiceSafes;
 
   mockUseBalanceAndRefillRequirementsContext.mockReturnValue({
     agentFundingRequests,
@@ -93,6 +105,7 @@ function setupMocks(options: SetupMocksOptions = {}) {
 
   mockUseService.mockReturnValue({
     serviceEoa,
+    serviceSafes,
   } as ReturnType<typeof useService>);
 }
 
@@ -287,6 +300,71 @@ describe('useAgentFundingRequests', () => {
       const { result } = renderHook(() => useAgentFundingRequests());
 
       expect(result.current.eoaTokenRequirements).toBeNull();
+    });
+  });
+
+  describe('safeTokenRequirements', () => {
+    it('returns requirements for the service Safe address', () => {
+      const safeBalanceRecord = {
+        [AddressZero]: '800',
+        [UNKNOWN_TOKEN_ADDRESS]: '200',
+      };
+      const fundingRequests: AddressBalanceRecord = {
+        [DEFAULT_EOA_ADDRESS]: { [AddressZero]: '500' },
+        [DEFAULT_SAFE_ADDRESS]: safeBalanceRecord,
+      };
+      setupMocks({ agentFundingRequests: fundingRequests });
+
+      const { result } = renderHook(() => useAgentFundingRequests());
+
+      expect(result.current.safeTokenRequirements).toEqual(safeBalanceRecord);
+    });
+
+    it('returns null when there is no service Safe for the home chain', () => {
+      const fundingRequests: AddressBalanceRecord = {
+        [DEFAULT_SAFE_ADDRESS]: { [AddressZero]: '800' },
+      };
+      setupMocks({
+        agentFundingRequests: fundingRequests,
+        serviceSafes: [],
+      });
+
+      const { result } = renderHook(() => useAgentFundingRequests());
+
+      expect(result.current.safeTokenRequirements).toBeNull();
+    });
+
+    it('returns null when the Safe address is not in funding requests', () => {
+      const fundingRequests: AddressBalanceRecord = {
+        [DEFAULT_EOA_ADDRESS]: { [AddressZero]: '500' },
+      };
+      setupMocks({ agentFundingRequests: fundingRequests });
+
+      const { result } = renderHook(() => useAgentFundingRequests());
+
+      expect(result.current.safeTokenRequirements).toBeNull();
+    });
+
+    it('returns null when isAgentFundingRequestsStale is true', () => {
+      const fundingRequests: AddressBalanceRecord = {
+        [DEFAULT_SAFE_ADDRESS]: { [AddressZero]: '800' },
+      };
+      setupMocks({
+        agentFundingRequests: fundingRequests,
+        isAgentFundingRequestsStale: true,
+      });
+
+      const { result } = renderHook(() => useAgentFundingRequests());
+
+      expect(result.current.safeTokenRequirements).toBeNull();
+    });
+
+    it('returns null when agentFundingRequests is undefined', () => {
+      setupMocks({ agentFundingRequests: undefined });
+
+      const { result } = renderHook(() => useAgentFundingRequests());
+
+      expect(result.current.safeTokenRequirements).toBeNull();
     });
   });
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9479,10 +9479,10 @@ write-file-atomic@^6.0.0:
     imurmurhash "^0.1.4"
     signal-exit "^4.0.1"
 
-ws@8.18.0, ws@8.20.1, ws@^8.11.0:
-  version "8.20.1"
-  resolved "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz#91a9ae2b312ccf98e0a85ec499b48cef45ab0ddb"
-  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
+ws@8.18.0, ws@8.21.0, ws@^8.11.0:
+  version "8.21.0"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 xml-name-validator@^4.0.0:
   version "4.0.0"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "postcss": "8.5.10",
     "serialize-javascript": "7.0.5",
     "tmp": "0.2.4",
-    "ws": "8.20.1"
+    "ws": "8.21.0"
   },
   "dependencies": {
     "@ant-design/cssinjs": "1.24.0",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,6 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.6.27-rc2",
+  "version": "1.6.27-rc4",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-app"
-version = "1.6.27-rc2"
+version = "1.6.27-rc4"
 description = ""
 authors = [
     { name = "David Vilela", email = "dvilelaf@gmail.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -1144,7 +1144,7 @@ wheels = [
 
 [[package]]
 name = "olas-operate-app"
-version = "1.6.27rc2"
+version = "1.6.27rc4"
 source = { virtual = "." }
 dependencies = [
     { name = "olas-operate-middleware" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6716,10 +6716,10 @@ wrappy@1:
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@8.18.0, ws@8.20.1, ws@^7.4.6:
-  version "8.20.1"
-  resolved "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz#91a9ae2b312ccf98e0a85ec499b48cef45ab0ddb"
-  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
+ws@8.18.0, ws@8.21.0, ws@^7.4.6:
+  version "8.21.0"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 xmlbuilder@>=11.0.1, xmlbuilder@^15.1.1:
   version "15.1.1"


### PR DESCRIPTION
## Problem (Zendesk #1131 / OPE-1794)

Optimus user on Optimism had to fund the agent **twice**, and the funded ETH showed up in their **portfolio**.

Root cause: the Fund Agent flow ([`prepareAgentFundsForTransfer`](frontend/components/AgentWallet/FundAgent/ConfirmTransfer.tsx)) funded the signer EOA only up to its *current deficit*, then sent **all remaining funds — including any amount the user added above that deficit — to the Agent Safe**. For agents whose Safe needs zero native (Optimus: `fund_requirements` native `safe = 0`), the excess native stranded in the Safe:

- The signer kept only its bare minimum → re-depleted → low-balance alert fired again ("funded twice").
- The misrouted gas surfaced as a portfolio asset (the portfolio reflects Safe holdings).

This matches the backend triage: the agent correctly asks for native on the **signer** and **0 on the Safe**, but the FE's `/fund` body put the excess native on the Safe.

The team already fixed this for the **gas-error entry path** (`forceEoaOnly`, OPE-1617), but the **normal** low-balance entry still split native to the Safe.

## Fix

Make the split **requirement-aware per wallet**:

- EOA is funded up to its requirement.
- **Native:** the Safe receives only up to its **own** native requirement; any excess routes to the **signer EOA** (the only wallet that spends native gas).
- **ERC20:** remainder beyond the EOA requirement still goes to the Safe (agent operating/investment wallet).
- `forceEoaOnly` (gas-error entry) behavior preserved.

Exposed `safeTokenRequirements` from `useAgentFundingRequests` and threaded it through `ConfirmTransfer`. **Frontend-only** — the backend already reports correct per-wallet deficits; the FE just built the wrong `ChainFunds` map.

## Worked examples

### Example 1 — Optimus/Optimism (the ticket scenario)

Signer low. EOA deficit = **0.0002 ETH**, Safe native requirement = **0**. User overrides the pre-fill and enters **0.002 ETH**.

**Before (bug)** — `allocateToEoa = min(0.002, 0.0002) = 0.0002`; `remaining 0.0018 → Safe`
`/fund` → `{ optimism: { EOA: {ETH: 0.0002}, Safe: {ETH: 0.0018} } }`
→ signer keeps 0.0002 (bare min), 0.0018 strands in Safe (portfolio), warning re-fires.

**After (fix)** — Safe native target = 0, so the 0.0018 excess routes to the EOA
`/fund` → `{ optimism: { EOA: {ETH: 0.002} } }` (Safe absent)
→ signer fully funded, nothing strands, no second warning.

### Example 2 — Trader/Gnosis (Safe legitimately needs native) — must not break

EOA deficit = **2 XDAI**, Safe native req = **8 XDAI**. User over-funds **15 XDAI** (5 excess).

| | EOA (signer) | Safe |
|---|---|---|
| Before | 2 | **13** (8 needed + 5 excess) |
| After | **7** (2 + 5 excess) | **8** (exactly its requirement) |

Safe still gets its required 8 XDAI; the 5 excess becomes gas on the signer instead of inflating the Safe.

### Example 3 — ERC20 (USDC) — unchanged

Optimus USDC: EOA req = 0, Safe req = 16 USDC. User funds 20 USDC.

| | EOA | Safe |
|---|---|---|
| Before | 0 | 20 |
| After | 0 | 20 (16 req + 4 excess → Safe) |

ERC20 excess still flows to the Safe (investment capital).

### No-regression checks

| Scenario | Before | After |
|---|---|---|
| Optimus, exact pre-fill 0.0002 | EOA 0.0002, Safe 0 | **same** |
| Trader, exact pre-fill 10 XDAI | EOA 2, Safe 8 | **same** |
| Optimus gas-error entry (`forceEoaOnly`), 0.002 | EOA 0.002, Safe 0 | **same** |

Behavior only changes when the user funds **native above the wallets' requirements** — the over-funding case that caused the ticket.

## Files

- `frontend/hooks/useAgentFundingRequests.tsx` — expose `safeTokenRequirements`
- `frontend/components/AgentWallet/FundAgent/ConfirmTransfer.tsx` — requirement-aware split + wiring
- tests: `prepareAgentFundsForTransfer`, `useAgentFundingRequests`, `ConfirmTransfer`

## Testing

- 3 suites / 35 tests pass (native split, Safe-native split, ERC20, no-regression on exact-amount funding, `forceEoaOnly`)
- Full frontend suite green; `yarn lint:fix` 0 errors; typecheck clean
- CI: Frontend + Frontend Tests green. (`yarn audit` failure is pre-existing dependency vulnerabilities, unrelated — this PR touches no dependency files.)

## Log-verified evidence (Zendesk #1131, David's Optimus/Optimism)

Confirmed against the customer's logs — the actual on-chain transfers and end-state balances, not inference.

**Two user `/fund` POSTs, 10 min apart** (`cli1.log`, service `sc-1d224019`, EOA `0xAED9…704eAC`, Safe `0x7fe9…944080`):

| Time (UTC) | → Agent EOA (signer) | → Agent Safe | Sum |
|---|---|---|---|
| 06:50 (the 0.002 funding) | 0.0001308 ETH | **0.001869 ETH** | 0.002 ETH |
| 07:00 (2nd, pre-filled) | 0.000147 ETH | 0.00000094 ETH | ~0.000148 ETH |

**End-state balances snapshot** (`debug_data.json`): signer = **0.0002 ETH** (its bare minimum), Safe = **0.001870 ETH stranded** (native req = 0).

So of the 0.002 ETH sent for gas, only **0.000131 reached the signer**; **0.001869 was dumped in the Safe** — exactly the `remainder → Safe` split.

**Why the 2nd alert fired (answers "needs 0.0002, gets 0.0002, why retrigger?"):** the signer was only topped to its 0.0002 minimum, then the agent ran its rounds and **burned ~0.000147 ETH of signer gas in those 10 minutes** (checkpoint / staking-KPI / get-positions / strategy rounds, visible in the agent log) → dropped below threshold → re-alert. The buffer the user paid for (0.00187) was stranded in the Safe, which can't pay gas.

**The fix resolves it (verified on the real numbers):** after-logic → `allocateToEoa = min(0.002, 0.000131) = 0.000131`; `safeNativeTarget = 0` → `toSafe = 0`; excess `0.001869 → EOA`. The signer receives the full 0.002 (~10× its 10-min burn) → no quick re-trigger, nothing stranded.

**Extra harm found in the logs:** the Optimus agent flags the stranded Safe-ETH as a non-whitelisted asset and prepares to swap it — `Created swap action: ETH → USDC, funds_percentage: 1.0, 'Swap non-whitelisted ETH to USDC'`. So the old behaviour can also convert the user's gas money into USDC (and burn more gas doing it). Another reason native must never land in the Optimus Safe.


## ⚠️ Product decision to confirm

For **Safe-native agents** (Trader/Polymarket/Agents.Fun), over-funded native now goes to the **signer**, not the Safe. That's the correct reading of "fund gas → gas wallet," but if product would rather give those agents more operating capital on over-funding, the rule for them would differ.

## Out of scope / follow-ups

- Multi-instance agents: `eoaTokenRequirements`/`serviceEoa` resolve a single EOA (see `docs/features/multi-instance-agents.md`).
- The portfolio "is this intentional?" sub-question is moot once native stops landing in the Safe.
- Edge case: if requirements are stale (funding in-progress/cooldown → null), native routes entirely to the signer; self-corrects on the next funding poll (no fund loss).

