### PR TITLE
fix(pett_ai): remove PettBro deprecation banner

### DIFF
--- a/frontend/config/agents.ts
+++ b/frontend/config/agents.ts
@@ -208,7 +208,6 @@ export const AGENT_CONFIG: {
   [AgentMap.PettAi]: {
     isAgentEnabled: true,
     isAddingNewBlocked: true,
-    shutdownDate: 'June 15, 2026',
     requiresSetup: false,
     isX402Enabled: X402_ENABLED_FLAGS[AgentMap.PettAi],
     name: 'Pett.ai',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "picomatch": "4.0.4",
     "postcss": "8.5.10",
     "tar": "7.5.15",
-    "ws": "8.20.1"
+    "ws": "8.21.0"
   },
   "dependencies": {
     "@ant-design/cssinjs": "1.24.0",

--- a/frontend/tests/components/SetupPage/AgentOnboarding/FundingRequirementStep.test.tsx
+++ b/frontend/tests/components/SetupPage/AgentOnboarding/FundingRequirementStep.test.tsx
@@ -48,8 +48,8 @@ describe('FundingRequirementStep — maintenance alert copy', () => {
   });
 
   it('keeps the "existing agents continue to run" line for a blocked-but-not-phased-out agent', () => {
-    // PettAi blocks new instances (isAddingNewBlocked) but is sunsetting via
-    // shutdownDate, not phased out — so existing instances still run.
+    // PettAi blocks new instances (isAddingNewBlocked) but is not phased out —
+    // so existing instances still run.
     render(<FundingRequirementStep agentType={AgentMap.PettAi} />);
 
     expect(

--- a/frontend/tests/config/agents.test.ts
+++ b/frontend/tests/config/agents.test.ts
@@ -109,8 +109,8 @@ describe('PettAi creation blocking and deprecation', () => {
     expect(AGENT_CONFIG[AgentMap.PettAi].isAddingNewBlocked).toBe(true);
   });
 
-  it('has shutdownDate set to June 15, 2026', () => {
-    expect(AGENT_CONFIG[AgentMap.PettAi].shutdownDate).toBe('June 15, 2026');
+  it('has no shutdownDate (deprecation banner removed)', () => {
+    expect(AGENT_CONFIG[AgentMap.PettAi].shutdownDate).toBeUndefined();
   });
 
   it('PettAi still appears in ACTIVE_AGENTS', () => {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9479,10 +9479,10 @@ write-file-atomic@^6.0.0:
     imurmurhash "^0.1.4"
     signal-exit "^4.0.1"
 
-ws@8.18.0, ws@8.20.1, ws@^8.11.0:
-  version "8.20.1"
-  resolved "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz#91a9ae2b312ccf98e0a85ec499b48cef45ab0ddb"
-  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
+ws@8.18.0, ws@8.21.0, ws@^8.11.0:
+  version "8.21.0"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 xml-name-validator@^4.0.0:
   version "4.0.0"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "postcss": "8.5.10",
     "serialize-javascript": "7.0.5",
     "tmp": "0.2.4",
-    "ws": "8.20.1"
+    "ws": "8.21.0"
   },
   "dependencies": {
     "@ant-design/cssinjs": "1.24.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6716,10 +6716,10 @@ wrappy@1:
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@8.18.0, ws@8.20.1, ws@^7.4.6:
-  version "8.20.1"
-  resolved "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz#91a9ae2b312ccf98e0a85ec499b48cef45ab0ddb"
-  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
+ws@8.18.0, ws@8.21.0, ws@^7.4.6:
+  version "8.21.0"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 xmlbuilder@>=11.0.1, xmlbuilder@^15.1.1:
   version "15.1.1"


### PR DESCRIPTION
## What

Removes the deprecation banner from PettBro:

> PettBro by Pett.ai is being phased out and will be disabled on June 15, 2026. You can withdraw funds from the Agent Wallet.

## How

- Dropped `shutdownDate: 'June 15, 2026'` from the PettAi entry in `frontend/config/agents.ts`. The banner (`AgentDeprecationAlert` in `AgentInfo/index.tsx`) is gated entirely on `selectedAgentConfig.shutdownDate`, so this de-triggers it.
- The reusable `AgentDeprecationAlert` component and the `shutdownDate` type field/wiring are left intact for future reuse.
- Updated the affected tests (`agents.test.ts` now asserts `shutdownDate` is undefined) and a stale comment in `FundingRequirementStep.test.tsx`.

## Note

PettAi keeps `isAddingNewBlocked: true`, so new instances stay blocked from creation and existing ones keep running — only the deprecation banner is removed.

## Verification

- Affected test suites pass (37/37)
- `yarn lint:fix` — 0 errors
- `yarn typecheck` — clean

---

## Bundled CI fix: bump `ws` to 8.21.0

CI on this branch (and the base `release/v1.7.1`) was failing the `yarn audit (both trees)` supply-chain gate on a pre-existing high advisory:

- **`ws` `>=8.0.0 <8.21.0`** — GHSA-96hv-2xvq-fx4p (DoS), fixed in `8.21.0`.

The root/frontend trees pinned `ws@8.20.1` via `resolutions`. Bumped both resolutions to `8.21.0` and regenerated both lockfiles (diff scoped to the `ws` block). `yarn audit:prod` now passes in both trees with no allowlist entry. Unrelated to the banner change, but folded in here to get CI green; also clears the failure for the base release branch.
