### PR TITLE
chore(optimus): bump babydegen service template to optimus v0.12.0-rc1

### DIFF
--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -20,14 +20,14 @@ const BABYDEGEN_COMMON_TEMPLATE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeigc77ps4pbrbjjeyeipe5gk4zp66sv2rlvgead2ccaxejqqzjlkx4',
-  service_version: 'v0.10.1',
+  hash: 'bafybeigwhmxzzsf3ztwb4iyy4rj64rsavmjf73te6elhcm45tnthby7dea',
+  service_version: 'v0.12.0-rc1',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.10.1',
+      version: 'v0.12.0-rc1',
     },
   },
 };


### PR DESCRIPTION
## What

Bumps the `BABYDEGEN_COMMON_TEMPLATE` in `frontend/constants/serviceTemplates/service/babydegen.ts` (shared by the Modius and Optimus service templates):

- `hash` → `bafybeigwhmxzzsf3ztwb4iyy4rj64rsavmjf73te6elhcm45tnthby7dea`
- `service_version` → `v0.12.0-rc1`
- `agent_release.repository.version` → `v0.12.0-rc1`

Targets the optimus [v0.12.0-rc1](https://github.com/valory-xyz/optimus/releases/tag/v0.12.0-rc1) release.

## Base

Opened against `rajatverma/ope-1765-integrate-basius-agent` (basius agent integration), not `main`.

## Validation

- `npx tsx scripts/js/check_service_templates.ts` — ✅ version match, all `agent_runner` release binaries accessible, hash present in `packages.json`, and `optimus/service.yaml` resolvable on the IPFS gateway.
- `cd frontend && yarn quality-check` (lint + typecheck) — ✅ 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)