### PR TITLE
chore(optimus): bump babydegen service template to optimus v0.12.0-rc3

### DIFF
--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -19,14 +19,14 @@ const BABYDEGEN_COMMON_TEMPLATE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeigwhmxzzsf3ztwb4iyy4rj64rsavmjf73te6elhcm45tnthby7dea',
-  service_version: 'v0.12.0-rc1',
+  hash: 'bafybeie2zrvd5mfswtktaagjtvhamnl4lv53hetu6skrzytv73sxn6joie',
+  service_version: 'v0.12.0-rc3',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.12.0-rc1',
+      version: 'v0.12.0-rc3',
     },
   },
 };


### PR DESCRIPTION
## What

Bumps the `BABYDEGEN_COMMON_TEMPLATE` in `frontend/constants/serviceTemplates/service/babydegen.ts` (shared by the Modius and Optimus service templates):

- `hash` → `bafybeie2zrvd5mfswtktaagjtvhamnl4lv53hetu6skrzytv73sxn6joie`
- `service_version` → `v0.12.0-rc3`
- `agent_release.repository.version` → `v0.12.0-rc3`

Targets the optimus [v0.12.0-rc3](https://github.com/valory-xyz/optimus/releases/tag/v0.12.0-rc3) release (bumps from the previously-set `v0.12.0-rc1`).

## Base

Opened against `rajatverma/ope-1765-integrate-basius-agent` (basius agent integration), not `main`.

## Validation

- `npx tsx scripts/js/check_service_templates.ts` — ✅ version match (`v0.12.0-rc3`), all `agent_runner` release binaries accessible, hash present in `packages.json`, and `optimus/service.yaml` resolvable on the IPFS gateway.
- `cd frontend && yarn quality-check` (lint + typecheck) — ✅ 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)