### PR TITLE
feat(OPE-1803): re-enable all new staking contracts (full mechanism, all agents)

### DIFF
--- a/frontend/config/activityCheckers.ts
+++ b/frontend/config/activityCheckers.ts
@@ -105,28 +105,27 @@ export const GNOSIS_STAKING_PROGRAMS_ACTIVITY_CHECKERS: Record<
       '0x95b37c45BADAf4668c18d00501948196761736b1',
     ),
   // Omenstrat (decoupled-activity) — shared V2 requester activity checker.
-  // HIDDEN FOR QA (OPE-1803) — re-enable with the ids + program entries.
-  // [STAKING_PROGRAM_IDS.OmenstratI]: getRequesterActivityCheckerContract(
-  //   '0x3514EeA47C03dF8d9FdD68A469908755d2870c48',
-  // ),
-  // [STAKING_PROGRAM_IDS.OmenstratII]: getRequesterActivityCheckerContract(
-  //   '0x3514EeA47C03dF8d9FdD68A469908755d2870c48',
-  // ),
-  // [STAKING_PROGRAM_IDS.OmenstratIII]: getRequesterActivityCheckerContract(
-  //   '0x3514EeA47C03dF8d9FdD68A469908755d2870c48',
-  // ),
-  // [STAKING_PROGRAM_IDS.OmenstratIV]: getRequesterActivityCheckerContract(
-  //   '0x3514EeA47C03dF8d9FdD68A469908755d2870c48',
-  // ),
-  // [STAKING_PROGRAM_IDS.OmenstratV]: getRequesterActivityCheckerContract(
-  //   '0x3514EeA47C03dF8d9FdD68A469908755d2870c48',
-  // ),
-  // [STAKING_PROGRAM_IDS.OmenstratVI]: getRequesterActivityCheckerContract(
-  //   '0x3514EeA47C03dF8d9FdD68A469908755d2870c48',
-  // ),
-  // [STAKING_PROGRAM_IDS.OmenstratVII]: getRequesterActivityCheckerContract(
-  //   '0x3514EeA47C03dF8d9FdD68A469908755d2870c48',
-  // ),
+  [STAKING_PROGRAM_IDS.OmenstratI]: getRequesterActivityCheckerContract(
+    '0x3514EeA47C03dF8d9FdD68A469908755d2870c48',
+  ),
+  [STAKING_PROGRAM_IDS.OmenstratII]: getRequesterActivityCheckerContract(
+    '0x3514EeA47C03dF8d9FdD68A469908755d2870c48',
+  ),
+  [STAKING_PROGRAM_IDS.OmenstratIII]: getRequesterActivityCheckerContract(
+    '0x3514EeA47C03dF8d9FdD68A469908755d2870c48',
+  ),
+  [STAKING_PROGRAM_IDS.OmenstratIV]: getRequesterActivityCheckerContract(
+    '0x3514EeA47C03dF8d9FdD68A469908755d2870c48',
+  ),
+  [STAKING_PROGRAM_IDS.OmenstratV]: getRequesterActivityCheckerContract(
+    '0x3514EeA47C03dF8d9FdD68A469908755d2870c48',
+  ),
+  [STAKING_PROGRAM_IDS.OmenstratVI]: getRequesterActivityCheckerContract(
+    '0x3514EeA47C03dF8d9FdD68A469908755d2870c48',
+  ),
+  [STAKING_PROGRAM_IDS.OmenstratVII]: getRequesterActivityCheckerContract(
+    '0x3514EeA47C03dF8d9FdD68A469908755d2870c48',
+  ),
 } as const;
 
 export const BASE_STAKING_PROGRAMS_ACTIVITY_CHECKERS: Record<
@@ -213,16 +212,15 @@ export const OPTIMISM_STAKING_PROGRAMS_ACTIVITY_CHECKERS: Record<
     '0x7Fd1F4b764fA41d19fe3f63C85d12bf64d2bbf68',
   ),
   // Optimus (decoupled-activity) — shared V2 requester activity checker.
-  // HIDDEN FOR QA (OPE-1803) — re-enable with the ids + program entries.
-  // [STAKING_PROGRAM_IDS.OptimusI]: getRequesterActivityCheckerContract(
-  //   '0x408dCA2b565f5eC7779C181870feFb51Ed67C3F4',
-  // ),
-  // [STAKING_PROGRAM_IDS.OptimusII]: getRequesterActivityCheckerContract(
-  //   '0x408dCA2b565f5eC7779C181870feFb51Ed67C3F4',
-  // ),
-  // [STAKING_PROGRAM_IDS.OptimusIII]: getRequesterActivityCheckerContract(
-  //   '0x408dCA2b565f5eC7779C181870feFb51Ed67C3F4',
-  // ),
+  [STAKING_PROGRAM_IDS.OptimusI]: getRequesterActivityCheckerContract(
+    '0x408dCA2b565f5eC7779C181870feFb51Ed67C3F4',
+  ),
+  [STAKING_PROGRAM_IDS.OptimusII]: getRequesterActivityCheckerContract(
+    '0x408dCA2b565f5eC7779C181870feFb51Ed67C3F4',
+  ),
+  [STAKING_PROGRAM_IDS.OptimusIII]: getRequesterActivityCheckerContract(
+    '0x408dCA2b565f5eC7779C181870feFb51Ed67C3F4',
+  ),
 } as const;
 
 export const POLYGON_STAKING_PROGRAMS_ACTIVITY_CHECKERS: Record<
@@ -239,14 +237,13 @@ export const POLYGON_STAKING_PROGRAMS_ACTIVITY_CHECKERS: Record<
     '0x0e998DaAedaCD59ba2F65558a29417b69f05D972',
   ),
   // Polystrat (decoupled-activity) — shared V2 requester activity checker.
-  // HIDDEN FOR QA (OPE-1803) — re-enable with the ids + program entries.
-  // [STAKING_PROGRAM_IDS.PolystratI]: getRequesterActivityCheckerContract(
-  //   '0x5B70A66fe68c4c86FFd724B58cc56049c70e9D3D',
-  // ),
-  // [STAKING_PROGRAM_IDS.PolystratII]: getRequesterActivityCheckerContract(
-  //   '0x5B70A66fe68c4c86FFd724B58cc56049c70e9D3D',
-  // ),
-  // [STAKING_PROGRAM_IDS.PolystratIII]: getRequesterActivityCheckerContract(
-  //   '0x5B70A66fe68c4c86FFd724B58cc56049c70e9D3D',
-  // ),
+  [STAKING_PROGRAM_IDS.PolystratI]: getRequesterActivityCheckerContract(
+    '0x5B70A66fe68c4c86FFd724B58cc56049c70e9D3D',
+  ),
+  [STAKING_PROGRAM_IDS.PolystratII]: getRequesterActivityCheckerContract(
+    '0x5B70A66fe68c4c86FFd724B58cc56049c70e9D3D',
+  ),
+  [STAKING_PROGRAM_IDS.PolystratIII]: getRequesterActivityCheckerContract(
+    '0x5B70A66fe68c4c86FFd724B58cc56049c70e9D3D',
+  ),
 } as const;

--- a/frontend/config/stakingPrograms/gnosis.ts
+++ b/frontend/config/stakingPrograms/gnosis.ts
@@ -42,23 +42,20 @@ const GNOSIS_STAKING_PROGRAMS_CONTRACT_ADDRESSES: Record<string, Address> = {
     '0xB2303F9913f11131A74F4b05099Ced2043cc72C4',
   [STAKING_PROGRAM_IDS.PearlBetaMechMarketplace8]:
     '0x12bdd401Ac300482f4017C64c6c930ee40424c08',
-  // HIDDEN FOR QA (OPE-1803) — new Omenstrat (PredictTrader) contracts. Re-enable
-  // with the ids in stakingProgram.ts, the program entries below, and the checker
-  // entries in activityCheckers.ts.
-  // [STAKING_PROGRAM_IDS.OmenstratI]:
-  //   '0x1E215da0541B4a77a66e21F17413A877B84Ab129',
-  // [STAKING_PROGRAM_IDS.OmenstratII]:
-  //   '0xC2BbfC0d2F5a341DcdCc9f3B78FAF7B04f0244ff',
-  // [STAKING_PROGRAM_IDS.OmenstratIII]:
-  //   '0xABD4f159a088E7f18FEE8241cF9367f1d746780f',
-  // [STAKING_PROGRAM_IDS.OmenstratIV]:
-  //   '0xc9940B9dACA9FDf1B0cD6dE8e3D25ddDC8C9fd0D',
-  // [STAKING_PROGRAM_IDS.OmenstratV]:
-  //   '0x93aAA7155942700cad74c250263fB2D0c6F72B27',
-  // [STAKING_PROGRAM_IDS.OmenstratVI]:
-  //   '0xB7ab6F7e6993Df1f0c6A9B177B169Faf4b0C9CCa',
-  // [STAKING_PROGRAM_IDS.OmenstratVII]:
-  //   '0xB801FD1728Eef27418FE03720b1FF3E769F35152',
+  [STAKING_PROGRAM_IDS.OmenstratI]:
+    '0x1E215da0541B4a77a66e21F17413A877B84Ab129',
+  [STAKING_PROGRAM_IDS.OmenstratII]:
+    '0xC2BbfC0d2F5a341DcdCc9f3B78FAF7B04f0244ff',
+  [STAKING_PROGRAM_IDS.OmenstratIII]:
+    '0xABD4f159a088E7f18FEE8241cF9367f1d746780f',
+  [STAKING_PROGRAM_IDS.OmenstratIV]:
+    '0xc9940B9dACA9FDf1B0cD6dE8e3D25ddDC8C9fd0D',
+  [STAKING_PROGRAM_IDS.OmenstratV]:
+    '0x93aAA7155942700cad74c250263fB2D0c6F72B27',
+  [STAKING_PROGRAM_IDS.OmenstratVI]:
+    '0xB7ab6F7e6993Df1f0c6A9B177B169Faf4b0C9CCa',
+  [STAKING_PROGRAM_IDS.OmenstratVII]:
+    '0xB801FD1728Eef27418FE03720b1FF3E769F35152',
 } as const;
 
 export const GNOSIS_STAKING_PROGRAMS: StakingProgramMap = {
@@ -514,9 +511,6 @@ export const GNOSIS_STAKING_PROGRAMS: StakingProgramMap = {
       ],
     ),
   },
-  /* HIDDEN FOR QA (OPE-1803) — new Omenstrat contracts (decoupled activity).
-     Re-enable by uncommenting the ids in stakingProgram.ts, the address entries
-     above, the checker entries in activityCheckers.ts, and this block.
   [STAKING_PROGRAM_IDS.OmenstratI]: {
     chainId: EvmChainIdMap.Gnosis,
     name: 'Omenstrat I',
@@ -723,5 +717,4 @@ export const GNOSIS_STAKING_PROGRAMS: StakingProgramMap = {
       ],
     ),
   },
-  */
 } as const;

--- a/frontend/config/stakingPrograms/optimism.ts
+++ b/frontend/config/stakingPrograms/optimism.ts
@@ -11,8 +11,7 @@ import { Address } from '@/types';
 import { deriveStakingProgramId } from '@/utils';
 
 import { OPTIMISM_STAKING_PROGRAMS_ACTIVITY_CHECKERS } from '../activityCheckers';
-// NOTE: re-add `import { MECHS, MechType } from '../mechs';` when re-enabling the
-// hidden Optimus marketplace programs below (OPE-1803).
+import { MECHS, MechType } from '../mechs';
 import { TokenSymbolMap } from '../tokens';
 import type { StakingProgramConfig } from '.';
 
@@ -26,14 +25,12 @@ export const OPTIMISM_STAKING_PROGRAMS_CONTRACT_ADDRESSES: Record<
     '0x0f69f35652B1acdbD769049334f1AC580927E139',
   [OPTIMISM_STAKING_PROGRAM_IDS.OptimusAlpha4]:
     '0x6891Cf116f9a3bDbD1e89413118eF81F69D298C3',
-  // HIDDEN FOR QA (OPE-1803) — new Optimus contracts. Re-enable with the ids in
-  // stakingProgram.ts, the program entries below, and the checker entries.
-  // [OPTIMISM_STAKING_PROGRAM_IDS.OptimusI]:
-  //   '0xCDA7deEf16f6b1BfC1bB5C89B7E4FAa91D9ebF7b',
-  // [OPTIMISM_STAKING_PROGRAM_IDS.OptimusII]:
-  //   '0x746281b8fbDbd008729Dc9382392810F771B1BfD',
-  // [OPTIMISM_STAKING_PROGRAM_IDS.OptimusIII]:
-  //   '0x5a4317A5695aD6E86744eFC824414cF899f07C68',
+  [OPTIMISM_STAKING_PROGRAM_IDS.OptimusI]:
+    '0xCDA7deEf16f6b1BfC1bB5C89B7E4FAa91D9ebF7b',
+  [OPTIMISM_STAKING_PROGRAM_IDS.OptimusII]:
+    '0x746281b8fbDbd008729Dc9382392810F771B1BfD',
+  [OPTIMISM_STAKING_PROGRAM_IDS.OptimusIII]:
+    '0x5a4317A5695aD6E86744eFC824414cF899f07C68',
 };
 
 export const OPTIMISM_STAKING_PROGRAMS: {
@@ -118,9 +115,6 @@ export const OPTIMISM_STAKING_PROGRAMS: {
       ],
     ),
   },
-  /* HIDDEN FOR QA (OPE-1803) — new Optimus contracts (decoupled activity).
-     Re-enable by uncommenting the ids in stakingProgram.ts, the address entries
-     above, the checker entries in activityCheckers.ts, and this block.
   [OPTIMISM_STAKING_PROGRAM_IDS.OptimusI]: {
     chainId: EvmChainIdMap.Optimism,
     name: 'Optimus I',
@@ -205,5 +199,4 @@ export const OPTIMISM_STAKING_PROGRAMS: {
       ],
     ),
   },
-  */
 };

--- a/frontend/config/stakingPrograms/polygon.ts
+++ b/frontend/config/stakingPrograms/polygon.ts
@@ -19,14 +19,12 @@ export const POLYGON_STAKING_PROGRAMS_CONTRACT_ADDRESSES: Record<
     '0x22D58680F643333F93205B956a4Aa1dC203a16Ad',
   [STAKING_PROGRAM_IDS.PolygonBeta3]:
     '0x8887C2852986e7cbaC99B6065fFe53074A6BCC26',
-  // HIDDEN FOR QA (OPE-1803) — new Polystrat contracts. Re-enable with the ids in
-  // stakingProgram.ts, the program entries below, and the checker entries.
-  // [STAKING_PROGRAM_IDS.PolystratI]:
-  //   '0x35C9C87a8caD9B7fd9d367Eb4Fd287365688E000',
-  // [STAKING_PROGRAM_IDS.PolystratII]:
-  //   '0xD7F69649691039E86F15153c7BD567aA0049d122',
-  // [STAKING_PROGRAM_IDS.PolystratIII]:
-  //   '0x7dbF10769CA7528ec9aA440b668C716Caf08e7EA',
+  [STAKING_PROGRAM_IDS.PolystratI]:
+    '0x35C9C87a8caD9B7fd9d367Eb4Fd287365688E000',
+  [STAKING_PROGRAM_IDS.PolystratII]:
+    '0xD7F69649691039E86F15153c7BD567aA0049d122',
+  [STAKING_PROGRAM_IDS.PolystratIII]:
+    '0x7dbF10769CA7528ec9aA440b668C716Caf08e7EA',
 };
 
 export const POLYGON_STAKING_PROGRAMS: StakingProgramMap = {
@@ -117,9 +115,6 @@ export const POLYGON_STAKING_PROGRAMS: StakingProgramMap = {
       ],
     ),
   },
-  /* HIDDEN FOR QA (OPE-1803) — new Polystrat contracts (decoupled activity).
-     Re-enable by uncommenting the ids in stakingProgram.ts, the address entries
-     above, the checker entries in activityCheckers.ts, and this block.
   [STAKING_PROGRAM_IDS.PolystratI]: {
     chainId: EvmChainIdMap.Polygon,
     name: 'Polystrat I',
@@ -210,5 +205,4 @@ export const POLYGON_STAKING_PROGRAMS: StakingProgramMap = {
       ],
     ),
   },
-  */
 };

--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -15,28 +15,7 @@ import { STAKING_PROGRAM_IDS } from '../../stakingProgram';
 import { X402_ENABLED_FLAGS } from '../../x402';
 import { KPI_DESC_PREFIX } from '../constants';
 
-// Modius + Optimus share this (reverted to the version on `staging`; the new
-// staking contracts for these agents are hidden for now). Basius ships the
-// newer build with its own hash below.
 const BABYDEGEN_COMMON_TEMPLATE: Pick<
-  ServiceTemplate,
-  'hash' | 'service_version' | 'agent_release'
-> = {
-  hash: 'bafybeigc77ps4pbrbjjeyeipe5gk4zp66sv2rlvgead2ccaxejqqzjlkx4',
-  service_version: 'v0.10.1',
-  agent_release: {
-    is_aea: true,
-    repository: {
-      owner: 'valory-xyz',
-      name: 'optimus',
-      version: 'v0.10.1',
-    },
-  },
-};
-
-// Basius ships its own (latest) build — kept separate so reverting the shared
-// babydegen hash for Modius/Optimus doesn't drag Basius back.
-const BASIUS_TEMPLATE_RELEASE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
@@ -490,5 +469,5 @@ export const BASIUS_SERVICE_TEMPLATE: ServiceTemplate = {
       provision_type: EnvProvisionType.FIXED,
     },
   },
-  ...BASIUS_TEMPLATE_RELEASE,
+  ...BABYDEGEN_COMMON_TEMPLATE,
 } as const;

--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -52,6 +52,25 @@ const BASIUS_TEMPLATE_RELEASE: Pick<
   },
 };
 
+// Optimus ships its own build — separated from the shared babydegen hash so
+// Optimism-specific mech config (priority mech 195 on Optimism, prediction-offline
+// tool) doesn't get applied to Modius too.
+const OPTIMUS_TEMPLATE_RELEASE: Pick<
+  ServiceTemplate,
+  'hash' | 'service_version' | 'agent_release'
+> = {
+  hash: 'bafybeieh7ipqea66s2p3km52fwnkeosileg5rqwecmon4azuohwbxvowye',
+  service_version: 'v0.12.0-rc12',
+  agent_release: {
+    is_aea: true,
+    repository: {
+      owner: 'valory-xyz',
+      name: 'optimus',
+      version: 'v0.12.0-rc12',
+    },
+  },
+};
+
 export const MODIUS_SERVICE_TEMPLATE: ServiceTemplate = {
   agentType: AgentMap.Modius,
   name: 'Optimus',
@@ -350,7 +369,7 @@ export const OPTIMUS_SERVICE_TEMPLATE: ServiceTemplate = {
       provision_type: EnvProvisionType.FIXED,
     },
   },
-  ...BABYDEGEN_COMMON_TEMPLATE,
+  ...OPTIMUS_TEMPLATE_RELEASE,
 } as const;
 
 export const BASIUS_SERVICE_TEMPLATE: ServiceTemplate = {

--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -41,13 +41,13 @@ const BASIUS_TEMPLATE_RELEASE: Pick<
   'hash' | 'service_version' | 'agent_release'
 > = {
   hash: 'bafybeieyje3avjjhlk2qtxswu7uvukaqnsvzmlfvgy3qzarxyv3cd6viru',
-  service_version: 'v0.12.0-rc11',
+  service_version: 'v0.12.2',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.12.0-rc11',
+      version: 'v0.12.2',
     },
   },
 };
@@ -60,13 +60,13 @@ const OPTIMUS_TEMPLATE_RELEASE: Pick<
   'hash' | 'service_version' | 'agent_release'
 > = {
   hash: 'bafybeih52axldd5orb2pjavmxb6lxnke4tdggrlqotyk6oam6ipa5zeiyy',
-  service_version: 'v0.12.1',
+  service_version: 'v0.12.2',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.12.1',
+      version: 'v0.12.2',
     },
   },
 };

--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -60,13 +60,13 @@ const OPTIMUS_TEMPLATE_RELEASE: Pick<
   'hash' | 'service_version' | 'agent_release'
 > = {
   hash: 'bafybeieh7ipqea66s2p3km52fwnkeosileg5rqwecmon4azuohwbxvowye',
-  service_version: 'v0.12.0-rc12',
+  service_version: 'v0.12.1',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.12.0-rc12',
+      version: 'v0.12.1',
     },
   },
 };

--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -53,8 +53,8 @@ const BASIUS_TEMPLATE_RELEASE: Pick<
 };
 
 // Optimus ships its own build — separated from the shared babydegen hash so
-// Optimism-specific mech config (priority mech 195 on Optimism, prediction-offline
-// tool) doesn't get applied to Modius too.
+// Optimism-specific mech config (priority mech 195 on Optimism,
+// prediction-offline-v1 tool) doesn't get applied to Modius too.
 const OPTIMUS_TEMPLATE_RELEASE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
@@ -304,6 +304,13 @@ export const OPTIMUS_SERVICE_TEMPLATE: ServiceTemplate = {
       name: 'Staking chain',
       description: '',
       value: 'optimism',
+      provision_type: EnvProvisionType.FIXED,
+    },
+    MECH_TOOL: {
+      name: 'Mech tool',
+      description:
+        'Tool name requested from mech 195. Bumped to `prediction-offline-v1` because the upstream prediction_request_v1 package renamed all tool names to `*-v1` (see mech 5a557e5b). The previous `prediction-offline` no longer exists in any current mech-predict service.',
+      value: 'prediction-offline-v1',
       provision_type: EnvProvisionType.FIXED,
     },
     ACTIVITY_CHECKER_CONTRACT_ADDRESS: {

--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -40,7 +40,7 @@ const BASIUS_TEMPLATE_RELEASE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeicp74th4cghtcnk4nvdhfnxwodwuuv3vrisk6ijetf7ausk7xsama',
+  hash: 'bafybeieyje3avjjhlk2qtxswu7uvukaqnsvzmlfvgy3qzarxyv3cd6viru',
   service_version: 'v0.12.0-rc11',
   agent_release: {
     is_aea: true,
@@ -59,7 +59,7 @@ const OPTIMUS_TEMPLATE_RELEASE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeieh7ipqea66s2p3km52fwnkeosileg5rqwecmon4azuohwbxvowye',
+  hash: 'bafybeih52axldd5orb2pjavmxb6lxnke4tdggrlqotyk6oam6ipa5zeiyy',
   service_version: 'v0.12.1',
   agent_release: {
     is_aea: true,

--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -308,8 +308,7 @@ export const OPTIMUS_SERVICE_TEMPLATE: ServiceTemplate = {
     },
     MECH_TOOL: {
       name: 'Mech tool',
-      description:
-        'Tool name requested from mech 195. Bumped to `prediction-offline-v1` because the upstream prediction_request_v1 package renamed all tool names to `*-v1` (see mech 5a557e5b). The previous `prediction-offline` no longer exists in any current mech-predict service.',
+      description: '',
       value: 'prediction-offline-v1',
       provision_type: EnvProvisionType.FIXED,
     },

--- a/frontend/constants/serviceTemplates/service/trader.ts
+++ b/frontend/constants/serviceTemplates/service/trader.ts
@@ -11,14 +11,14 @@ import { X402_ENABLED_FLAGS } from '../../x402';
 import { KPI_DESC_PREFIX } from '../constants';
 
 export const PREDICT_SERVICE_TEMPLATE: ServiceTemplate = {
-  hash: 'bafybeib77mnuixonl54u2d23ilvah67n2svenmu76b6mn7wkg3emgg5ity',
-  service_version: 'v0.40.0-rc3',
+  hash: 'bafybeifuphhsarhdvymixytqmndwj4cwzs7azkgytvrzrkllgc4zqq3qoq',
+  service_version: 'v0.40.0-rc4',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'trader',
-      version: 'v0.40.0-rc3',
+      version: 'v0.40.0-rc4',
     },
   },
   agentType: AgentMap.PredictTrader,
@@ -144,14 +144,14 @@ export const PREDICT_SERVICE_TEMPLATE: ServiceTemplate = {
 } as const;
 
 export const PREDICT_POLYMARKET_SERVICE_TEMPLATE: ServiceTemplate = {
-  hash: 'bafybeiap63bhbkiu7lyqjxejolu7ltfxnyfeupebyio7z6fz7o5v7t5wae',
-  service_version: 'v0.40.0-rc3',
+  hash: 'bafybeiapvnpaw3gw342263wcngsrvoldf5bf7ovrl4n3ljybhapk4qlism',
+  service_version: 'v0.40.0-rc4',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'trader',
-      version: 'v0.40.0-rc3',
+      version: 'v0.40.0-rc4',
     },
   },
   agentType: AgentMap.Polystrat,

--- a/frontend/constants/serviceTemplates/service/trader.ts
+++ b/frontend/constants/serviceTemplates/service/trader.ts
@@ -11,14 +11,14 @@ import { X402_ENABLED_FLAGS } from '../../x402';
 import { KPI_DESC_PREFIX } from '../constants';
 
 export const PREDICT_SERVICE_TEMPLATE: ServiceTemplate = {
-  hash: 'bafybeibhhl7wvslgjzvzo6lhjbr3yw5eyjmlnqm7ls66hmcr46qw4s472i',
-  service_version: 'v0.39.1-rc2',
+  hash: 'bafybeidjkz5vzts3sneeq5bs73djyus65yzsv7nmom766wivxhkfonjnhy',
+  service_version: 'v0.40.0-rc2',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'trader',
-      version: 'v0.39.1-rc2',
+      version: 'v0.40.0-rc2',
     },
   },
   agentType: AgentMap.PredictTrader,
@@ -144,14 +144,14 @@ export const PREDICT_SERVICE_TEMPLATE: ServiceTemplate = {
 } as const;
 
 export const PREDICT_POLYMARKET_SERVICE_TEMPLATE: ServiceTemplate = {
-  hash: 'bafybeifb3ehr4txpsurgt3lnpaq2v6c6eocd2trpu74nmpq4lyvvyqmq7m',
-  service_version: 'v0.39.1-rc2',
+  hash: 'bafybeieen4mng2rchxscfyqakmty42jyngojvhj54r572htle5g4qqteyy',
+  service_version: 'v0.40.0-rc2',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'trader',
-      version: 'v0.39.1-rc2',
+      version: 'v0.40.0-rc2',
     },
   },
   agentType: AgentMap.Polystrat,

--- a/frontend/constants/serviceTemplates/service/trader.ts
+++ b/frontend/constants/serviceTemplates/service/trader.ts
@@ -11,14 +11,14 @@ import { X402_ENABLED_FLAGS } from '../../x402';
 import { KPI_DESC_PREFIX } from '../constants';
 
 export const PREDICT_SERVICE_TEMPLATE: ServiceTemplate = {
-  hash: 'bafybeidjkz5vzts3sneeq5bs73djyus65yzsv7nmom766wivxhkfonjnhy',
-  service_version: 'v0.40.0-rc2',
+  hash: 'bafybeib77mnuixonl54u2d23ilvah67n2svenmu76b6mn7wkg3emgg5ity',
+  service_version: 'v0.40.0-rc3',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'trader',
-      version: 'v0.40.0-rc2',
+      version: 'v0.40.0-rc3',
     },
   },
   agentType: AgentMap.PredictTrader,
@@ -144,14 +144,14 @@ export const PREDICT_SERVICE_TEMPLATE: ServiceTemplate = {
 } as const;
 
 export const PREDICT_POLYMARKET_SERVICE_TEMPLATE: ServiceTemplate = {
-  hash: 'bafybeieen4mng2rchxscfyqakmty42jyngojvhj54r572htle5g4qqteyy',
-  service_version: 'v0.40.0-rc2',
+  hash: 'bafybeiap63bhbkiu7lyqjxejolu7ltfxnyfeupebyio7z6fz7o5v7t5wae',
+  service_version: 'v0.40.0-rc3',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'trader',
-      version: 'v0.40.0-rc2',
+      version: 'v0.40.0-rc3',
     },
   },
   agentType: AgentMap.Polystrat,

--- a/frontend/constants/stakingProgram.ts
+++ b/frontend/constants/stakingProgram.ts
@@ -18,16 +18,13 @@ const GNOSIS_STAKING_PROGRAM_IDS = {
   PearlBetaMechMarketplace7: 'pearl_beta_mech_marketplace_7',
   PearlBetaMechMarketplace8: 'pearl_beta_mech_marketplace_8',
   // New (decoupled-activity) staking contracts — PredictTrader on Gnosis ("Omenstrat").
-  // HIDDEN FOR QA (OPE-1803) — issues on these agents' new contracts. Re-enable by
-  // uncommenting here + the matching address/program entries in gnosis.ts and the
-  // checker entries in activityCheckers.ts.
-  // OmenstratI: 'omenstrat_i',
-  // OmenstratII: 'omenstrat_ii',
-  // OmenstratIII: 'omenstrat_iii',
-  // OmenstratIV: 'omenstrat_iv',
-  // OmenstratV: 'omenstrat_v',
-  // OmenstratVI: 'omenstrat_vi',
-  // OmenstratVII: 'omenstrat_vii',
+  OmenstratI: 'omenstrat_i',
+  OmenstratII: 'omenstrat_ii',
+  OmenstratIII: 'omenstrat_iii',
+  OmenstratIV: 'omenstrat_iv',
+  OmenstratV: 'omenstrat_v',
+  OmenstratVI: 'omenstrat_vi',
+  OmenstratVII: 'omenstrat_vii',
 } as const;
 
 const BASE_STAKING_PROGRAM_IDS = {
@@ -66,12 +63,9 @@ export const OPTIMISM_STAKING_PROGRAM_IDS = {
   OptimusAlpha3: 'optimus_alpha_3',
   OptimusAlpha4: 'optimus_alpha_4',
   // New (decoupled-activity) staking contracts — Optimus on Optimism.
-  // HIDDEN FOR QA (OPE-1803) — issues on these agents' new contracts. Re-enable by
-  // uncommenting here + the matching address/program entries in optimism.ts and the
-  // checker entries in activityCheckers.ts.
-  // OptimusI: 'optimus_i',
-  // OptimusII: 'optimus_ii',
-  // OptimusIII: 'optimus_iii',
+  OptimusI: 'optimus_i',
+  OptimusII: 'optimus_ii',
+  OptimusIII: 'optimus_iii',
 } as const;
 
 export type OptimismStakingProgramId = ValueOf<
@@ -83,12 +77,9 @@ const POLYGON_STAKING_PROGRAM_IDS = {
   PolygonBeta2: 'polygon_beta_2',
   PolygonBeta3: 'polygon_beta_3', // Note: “Polygon Alpha 3” is a typo in contract setup (in meta data) — the correct name is Polygon Beta 3.
   // New (decoupled-activity) staking contracts — Polystrat on Polygon.
-  // HIDDEN FOR QA (OPE-1803) — issues on these agents' new contracts. Re-enable by
-  // uncommenting here + the matching address/program entries in polygon.ts and the
-  // checker entries in activityCheckers.ts.
-  // PolystratI: 'polystrat_i',
-  // PolystratII: 'polystrat_ii',
-  // PolystratIII: 'polystrat_iii',
+  PolystratI: 'polystrat_i',
+  PolystratII: 'polystrat_ii',
+  PolystratIII: 'polystrat_iii',
 } as const;
 
 export type PolygonStakingProgramId = ValueOf<

--- a/frontend/tests/config/activityCheckers.test.ts
+++ b/frontend/tests/config/activityCheckers.test.ts
@@ -43,6 +43,13 @@ describe('GNOSIS_STAKING_PROGRAMS_ACTIVITY_CHECKERS', () => {
     'PearlBetaMechMarketplace6',
     'PearlBetaMechMarketplace7',
     'PearlBetaMechMarketplace8',
+    'OmenstratI',
+    'OmenstratII',
+    'OmenstratIII',
+    'OmenstratIV',
+    'OmenstratV',
+    'OmenstratVI',
+    'OmenstratVII',
   ] as const;
 
   it('has an activity checker for every Gnosis staking program', () => {
@@ -54,9 +61,9 @@ describe('GNOSIS_STAKING_PROGRAMS_ACTIVITY_CHECKERS', () => {
     }
   });
 
-  it('covers exactly 16 Gnosis staking programs', () => {
+  it('covers exactly 23 Gnosis staking programs', () => {
     expect(Object.keys(GNOSIS_STAKING_PROGRAMS_ACTIVITY_CHECKERS)).toHaveLength(
-      16,
+      23,
     );
   });
 });
@@ -121,6 +128,9 @@ describe('OPTIMISM_STAKING_PROGRAMS_ACTIVITY_CHECKERS', () => {
     'OptimusAlpha2',
     'OptimusAlpha3',
     'OptimusAlpha4',
+    'OptimusI',
+    'OptimusII',
+    'OptimusIII',
   ] as const;
 
   it('has an activity checker for every Optimism staking program', () => {
@@ -132,15 +142,22 @@ describe('OPTIMISM_STAKING_PROGRAMS_ACTIVITY_CHECKERS', () => {
     }
   });
 
-  it('covers exactly 3 Optimism staking programs', () => {
+  it('covers exactly 6 Optimism staking programs', () => {
     expect(
       Object.keys(OPTIMISM_STAKING_PROGRAMS_ACTIVITY_CHECKERS),
-    ).toHaveLength(3);
+    ).toHaveLength(6);
   });
 });
 
 describe('POLYGON_STAKING_PROGRAMS_ACTIVITY_CHECKERS', () => {
-  const polygonIds = ['PolygonBeta1', 'PolygonBeta2', 'PolygonBeta3'] as const;
+  const polygonIds = [
+    'PolygonBeta1',
+    'PolygonBeta2',
+    'PolygonBeta3',
+    'PolystratI',
+    'PolystratII',
+    'PolystratIII',
+  ] as const;
 
   it('has an activity checker for every Polygon staking program', () => {
     for (const idKey of polygonIds) {
@@ -151,10 +168,10 @@ describe('POLYGON_STAKING_PROGRAMS_ACTIVITY_CHECKERS', () => {
     }
   });
 
-  it('covers exactly 3 Polygon staking programs', () => {
+  it('covers exactly 6 Polygon staking programs', () => {
     expect(
       Object.keys(POLYGON_STAKING_PROGRAMS_ACTIVITY_CHECKERS),
-    ).toHaveLength(3);
+    ).toHaveLength(6);
   });
 });
 
@@ -168,7 +185,7 @@ describe('cross-chain completeness', () => {
       Object.keys(POLYGON_STAKING_PROGRAMS_ACTIVITY_CHECKERS).length;
 
     const totalPrograms = Object.keys(STAKING_PROGRAM_IDS).length;
-    // 16 + 14 + 5 + 3 + 3 = 41 (matches STAKING_PROGRAM_IDS count)
+    // 16 + 11 + 5 + 3 + 3 = 38 (matches STAKING_PROGRAM_IDS count)
     expect(totalCheckers).toBe(totalPrograms);
   });
 });

--- a/frontend/tests/config/stakingPrograms/gnosis.test.ts
+++ b/frontend/tests/config/stakingPrograms/gnosis.test.ts
@@ -24,7 +24,7 @@ jest.mock(
 const EVM_ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/;
 
 describe('GNOSIS_STAKING_PROGRAMS', () => {
-  it('covers all 16 Gnosis staking program IDs', () => {
+  it('covers all 23 Gnosis staking program IDs (16 legacy + 7 decoupled Omenstrat)', () => {
     const expectedIds = [
       STAKING_PROGRAM_IDS.PearlAlpha,
       STAKING_PROGRAM_IDS.PearlBeta,
@@ -42,11 +42,18 @@ describe('GNOSIS_STAKING_PROGRAMS', () => {
       STAKING_PROGRAM_IDS.PearlBetaMechMarketplace6,
       STAKING_PROGRAM_IDS.PearlBetaMechMarketplace7,
       STAKING_PROGRAM_IDS.PearlBetaMechMarketplace8,
+      STAKING_PROGRAM_IDS.OmenstratI,
+      STAKING_PROGRAM_IDS.OmenstratII,
+      STAKING_PROGRAM_IDS.OmenstratIII,
+      STAKING_PROGRAM_IDS.OmenstratIV,
+      STAKING_PROGRAM_IDS.OmenstratV,
+      STAKING_PROGRAM_IDS.OmenstratVI,
+      STAKING_PROGRAM_IDS.OmenstratVII,
     ];
     for (const id of expectedIds) {
       expect(GNOSIS_STAKING_PROGRAMS[id]).toBeDefined();
     }
-    expect(Object.keys(GNOSIS_STAKING_PROGRAMS)).toHaveLength(16);
+    expect(Object.keys(GNOSIS_STAKING_PROGRAMS)).toHaveLength(23);
   });
 
   it('all programs are on Gnosis chain (chainId 100)', () => {
@@ -199,6 +206,37 @@ describe('GNOSIS_STAKING_PROGRAMS', () => {
       expect(
         GNOSIS_STAKING_PROGRAMS[STAKING_PROGRAM_IDS.PearlAlpha].address,
       ).toBe('0xEE9F19b5DF06c7E8Bfc7B28745dcf944C504198A');
+    });
+  });
+
+  describe('decoupled-activity regime (OPE-1803)', () => {
+    const omenstratIds = [
+      STAKING_PROGRAM_IDS.OmenstratI,
+      STAKING_PROGRAM_IDS.OmenstratII,
+      STAKING_PROGRAM_IDS.OmenstratIII,
+      STAKING_PROGRAM_IDS.OmenstratIV,
+      STAKING_PROGRAM_IDS.OmenstratV,
+      STAKING_PROGRAM_IDS.OmenstratVI,
+      STAKING_PROGRAM_IDS.OmenstratVII,
+    ];
+
+    it('all Omenstrat programs carry an off-chain activityTarget of 8', () => {
+      for (const id of omenstratIds) {
+        expect(GNOSIS_STAKING_PROGRAMS[id].activityTarget).toBe(8);
+      }
+    });
+
+    it('all Omenstrat programs are active (not deprecated)', () => {
+      for (const id of omenstratIds) {
+        expect(GNOSIS_STAKING_PROGRAMS[id].deprecated).toBeUndefined();
+      }
+    });
+
+    it('legacy Pearl programs have no activityTarget (on-chain KPI regime)', () => {
+      expect(
+        GNOSIS_STAKING_PROGRAMS[STAKING_PROGRAM_IDS.PearlBetaMechMarketplace8]
+          .activityTarget,
+      ).toBeUndefined();
     });
   });
 });

--- a/frontend/tests/config/stakingPrograms/optimism.test.ts
+++ b/frontend/tests/config/stakingPrograms/optimism.test.ts
@@ -23,16 +23,19 @@ jest.mock(
 const EVM_ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/;
 
 describe('OPTIMISM_STAKING_PROGRAMS', () => {
-  it('covers all 3 Optimism staking program IDs (OptimusAlpha2/3/4)', () => {
+  it('covers all 6 Optimism staking program IDs (legacy OptimusAlpha2/3/4 + decoupled OptimusI/II/III)', () => {
     const expectedIds = [
       OPTIMISM_STAKING_PROGRAM_IDS.OptimusAlpha2,
       OPTIMISM_STAKING_PROGRAM_IDS.OptimusAlpha3,
       OPTIMISM_STAKING_PROGRAM_IDS.OptimusAlpha4,
+      OPTIMISM_STAKING_PROGRAM_IDS.OptimusI,
+      OPTIMISM_STAKING_PROGRAM_IDS.OptimusII,
+      OPTIMISM_STAKING_PROGRAM_IDS.OptimusIII,
     ];
     for (const id of expectedIds) {
       expect(OPTIMISM_STAKING_PROGRAMS[id]).toBeDefined();
     }
-    expect(Object.keys(OPTIMISM_STAKING_PROGRAMS)).toHaveLength(3);
+    expect(Object.keys(OPTIMISM_STAKING_PROGRAMS)).toHaveLength(6);
   });
 
   it('all programs are on Optimism chain (chainId 10)', () => {
@@ -99,6 +102,51 @@ describe('OPTIMISM_STAKING_PROGRAMS', () => {
         OPTIMISM_STAKING_PROGRAMS[OPTIMISM_STAKING_PROGRAM_IDS.OptimusAlpha4]
           .stakingRequirements['OLAS'],
       ).toBe(5000);
+    });
+
+    it('OptimusI requires 100 OLAS (entry tier)', () => {
+      expect(
+        OPTIMISM_STAKING_PROGRAMS[OPTIMISM_STAKING_PROGRAM_IDS.OptimusI]
+          .stakingRequirements['OLAS'],
+      ).toBe(100);
+    });
+
+    it('OptimusII requires 1000 OLAS (mid tier)', () => {
+      expect(
+        OPTIMISM_STAKING_PROGRAMS[OPTIMISM_STAKING_PROGRAM_IDS.OptimusII]
+          .stakingRequirements['OLAS'],
+      ).toBe(1000);
+    });
+
+    it('OptimusIII requires 5000 OLAS (premium tier)', () => {
+      expect(
+        OPTIMISM_STAKING_PROGRAMS[OPTIMISM_STAKING_PROGRAM_IDS.OptimusIII]
+          .stakingRequirements['OLAS'],
+      ).toBe(5000);
+    });
+  });
+
+  describe('decoupled-activity regime (OPE-1803)', () => {
+    it('new OptimusI/II/III carry an off-chain activityTarget of 1', () => {
+      const decoupledIds = [
+        OPTIMISM_STAKING_PROGRAM_IDS.OptimusI,
+        OPTIMISM_STAKING_PROGRAM_IDS.OptimusII,
+        OPTIMISM_STAKING_PROGRAM_IDS.OptimusIII,
+      ];
+      for (const id of decoupledIds) {
+        expect(OPTIMISM_STAKING_PROGRAMS[id].activityTarget).toBe(1);
+      }
+    });
+
+    it('legacy OptimusAlpha2/3/4 have no activityTarget (on-chain KPI regime)', () => {
+      const legacyIds = [
+        OPTIMISM_STAKING_PROGRAM_IDS.OptimusAlpha2,
+        OPTIMISM_STAKING_PROGRAM_IDS.OptimusAlpha3,
+        OPTIMISM_STAKING_PROGRAM_IDS.OptimusAlpha4,
+      ];
+      for (const id of legacyIds) {
+        expect(OPTIMISM_STAKING_PROGRAMS[id].activityTarget).toBeUndefined();
+      }
     });
   });
 

--- a/frontend/tests/config/stakingPrograms/polygon.test.ts
+++ b/frontend/tests/config/stakingPrograms/polygon.test.ts
@@ -23,16 +23,19 @@ jest.mock(
 const EVM_ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/;
 
 describe('POLYGON_STAKING_PROGRAMS', () => {
-  it('covers all 3 Polygon staking program IDs', () => {
+  it('covers all 6 Polygon staking program IDs (legacy PolygonBeta1/2/3 + decoupled PolystratI/II/III)', () => {
     const expectedIds = [
       STAKING_PROGRAM_IDS.PolygonBeta1,
       STAKING_PROGRAM_IDS.PolygonBeta2,
       STAKING_PROGRAM_IDS.PolygonBeta3,
+      STAKING_PROGRAM_IDS.PolystratI,
+      STAKING_PROGRAM_IDS.PolystratII,
+      STAKING_PROGRAM_IDS.PolystratIII,
     ];
     for (const id of expectedIds) {
       expect(POLYGON_STAKING_PROGRAMS[id]).toBeDefined();
     }
-    expect(Object.keys(POLYGON_STAKING_PROGRAMS)).toHaveLength(3);
+    expect(Object.keys(POLYGON_STAKING_PROGRAMS)).toHaveLength(6);
   });
 
   it('all programs are on Polygon chain (chainId 137)', () => {
@@ -99,6 +102,51 @@ describe('POLYGON_STAKING_PROGRAMS', () => {
         POLYGON_STAKING_PROGRAMS[STAKING_PROGRAM_IDS.PolygonBeta3]
           .stakingRequirements['OLAS'],
       ).toBe(10000);
+    });
+
+    it('PolystratI requires 100 OLAS (entry tier)', () => {
+      expect(
+        POLYGON_STAKING_PROGRAMS[STAKING_PROGRAM_IDS.PolystratI]
+          .stakingRequirements['OLAS'],
+      ).toBe(100);
+    });
+
+    it('PolystratII requires 1000 OLAS (mid tier)', () => {
+      expect(
+        POLYGON_STAKING_PROGRAMS[STAKING_PROGRAM_IDS.PolystratII]
+          .stakingRequirements['OLAS'],
+      ).toBe(1000);
+    });
+
+    it('PolystratIII requires 10000 OLAS (premium tier)', () => {
+      expect(
+        POLYGON_STAKING_PROGRAMS[STAKING_PROGRAM_IDS.PolystratIII]
+          .stakingRequirements['OLAS'],
+      ).toBe(10000);
+    });
+  });
+
+  describe('decoupled-activity regime (OPE-1803)', () => {
+    it('new PolystratI/II/III carry an off-chain activityTarget of 8', () => {
+      const decoupledIds = [
+        STAKING_PROGRAM_IDS.PolystratI,
+        STAKING_PROGRAM_IDS.PolystratII,
+        STAKING_PROGRAM_IDS.PolystratIII,
+      ];
+      for (const id of decoupledIds) {
+        expect(POLYGON_STAKING_PROGRAMS[id].activityTarget).toBe(8);
+      }
+    });
+
+    it('legacy PolygonBeta1/2/3 have no activityTarget (on-chain KPI regime)', () => {
+      const legacyIds = [
+        STAKING_PROGRAM_IDS.PolygonBeta1,
+        STAKING_PROGRAM_IDS.PolygonBeta2,
+        STAKING_PROGRAM_IDS.PolygonBeta3,
+      ];
+      for (const id of legacyIds) {
+        expect(POLYGON_STAKING_PROGRAMS[id].activityTarget).toBeUndefined();
+      }
     });
   });
 

--- a/frontend/tests/constants/stakingProgram.test.ts
+++ b/frontend/tests/constants/stakingProgram.test.ts
@@ -92,7 +92,18 @@ describe('STAKING_PROGRAM_IDS', () => {
         'pearl_beta_mech_marketplace_8',
       );
     });
-    // Omenstrat (decoupled-activity) ids hidden for QA (OPE-1803).
+
+    it.each([
+      ['OmenstratI', 'omenstrat_i'],
+      ['OmenstratII', 'omenstrat_ii'],
+      ['OmenstratIII', 'omenstrat_iii'],
+      ['OmenstratIV', 'omenstrat_iv'],
+      ['OmenstratV', 'omenstrat_v'],
+      ['OmenstratVI', 'omenstrat_vi'],
+      ['OmenstratVII', 'omenstrat_vii'],
+    ] as const)('%s resolves to "%s" (decoupled-activity)', (key, value) => {
+      expect(STAKING_PROGRAM_IDS[key]).toBe(value);
+    });
   });
 
   describe('Base programs', () => {
@@ -190,7 +201,14 @@ describe('STAKING_PROGRAM_IDS', () => {
       // OptimusAlpha1 on Optimism was deprecated and intentionally omitted.
       expect(STAKING_PROGRAM_IDS).not.toHaveProperty('OptimusAlpha1');
     });
-    // Optimus (decoupled-activity) ids hidden for QA (OPE-1803).
+
+    it.each([
+      ['OptimusI', 'optimus_i'],
+      ['OptimusII', 'optimus_ii'],
+      ['OptimusIII', 'optimus_iii'],
+    ] as const)('%s resolves to "%s" (decoupled-activity)', (key, value) => {
+      expect(STAKING_PROGRAM_IDS[key]).toBe(value);
+    });
   });
 
   describe('Polygon programs', () => {
@@ -207,15 +225,21 @@ describe('STAKING_PROGRAM_IDS', () => {
       // the correct identifier is "polygon_beta_3".
       expect(STAKING_PROGRAM_IDS.PolygonBeta3).toBe('polygon_beta_3');
     });
-    // Polystrat (decoupled-activity) ids hidden for QA (OPE-1803).
+
+    it.each([
+      ['PolystratI', 'polystrat_i'],
+      ['PolystratII', 'polystrat_ii'],
+      ['PolystratIII', 'polystrat_iii'],
+    ] as const)('%s resolves to "%s" (decoupled-activity)', (key, value) => {
+      expect(STAKING_PROGRAM_IDS[key]).toBe(value);
+    });
   });
 
   describe('completeness and uniqueness', () => {
-    it('covers exactly 41 staking programs across all chains', () => {
-      // Chain totals: 16 Gnosis + 14 Base (11 + 3 Basius) + 5 Mode + 3 Optimism
-      // + 3 Polygon = 41. Omenstrat/Optimus/Polystrat decoupled ids are hidden
-      // for QA (OPE-1803); only Basius's decoupled ids ship.
-      expect(Object.keys(STAKING_PROGRAM_IDS)).toHaveLength(41);
+    it('covers exactly 54 staking programs across all chains', () => {
+      // Chain totals: 23 Gnosis (16 legacy + 7 Omenstrat) + 14 Base (11 + 3 Basius)
+      // + 5 Mode + 6 Optimism (3 legacy + 3 Optimus) + 6 Polygon (3 legacy + 3 Polystrat) = 54
+      expect(Object.keys(STAKING_PROGRAM_IDS)).toHaveLength(54);
     });
 
     it('has no duplicate ID strings (each program has a unique registry key)', () => {

--- a/frontend/tests/context/RewardProvider.test.tsx
+++ b/frontend/tests/context/RewardProvider.test.tsx
@@ -112,12 +112,9 @@ jest.mock('../../config/stakingPrograms', () => ({
   STAKING_PROGRAMS: {
     [EvmChainIdMap.Gnosis]: {
       [STAKING_PROGRAM_IDS.PearlBetaMechMarketplace3]: { name: 'test' },
-      // Synthetic decoupled-activity program (presence of activityTarget marks the
-      // new regime). Uses BasiusI — the only decoupled id still shipping after the
-      // others were hidden for QA (OPE-1803) — under a Gnosis mock purely to
-      // exercise the generic isEpochTargetMet derivation.
-      [STAKING_PROGRAM_IDS.BasiusI]: {
-        name: 'Basius I',
+      // Decoupled-activity program: presence of activityTarget marks the new regime.
+      [STAKING_PROGRAM_IDS.OmenstratI]: {
+        name: 'Omenstrat I',
         activityTarget: 8,
       },
     },
@@ -330,7 +327,9 @@ describe('RewardProvider', () => {
           activityThisEpoch: 8,
         }),
       });
-      const { result } = renderWithStakingProgram(STAKING_PROGRAM_IDS.BasiusI);
+      const { result } = renderWithStakingProgram(
+        STAKING_PROGRAM_IDS.OmenstratI,
+      );
       expect(result.current.isEpochTargetMet).toBe(true);
     });
 
@@ -341,7 +340,9 @@ describe('RewardProvider', () => {
           activityThisEpoch: 3,
         }),
       });
-      const { result } = renderWithStakingProgram(STAKING_PROGRAM_IDS.BasiusI);
+      const { result } = renderWithStakingProgram(
+        STAKING_PROGRAM_IDS.OmenstratI,
+      );
       expect(result.current.isEpochTargetMet).toBe(false);
     });
   });

--- a/frontend/tests/hooks/useAllInstancesRewardStatus.test.ts
+++ b/frontend/tests/hooks/useAllInstancesRewardStatus.test.ts
@@ -53,10 +53,6 @@ const mockUseServices = useServices as jest.Mock;
 const mockCreateStakingRewardsQuery = createStakingRewardsQuery as jest.Mock;
 
 const traderConfig = AGENT_CONFIG[AgentMap.PredictTrader];
-// Basius is the only agent still shipping a decoupled-activity contract (the
-// others were hidden for QA, OPE-1803), so the decoupled regime is exercised
-// against Basius/Base below.
-const basiusConfig = AGENT_CONFIG[AgentMap.Basius];
 
 const baseContextValue: React.ContextType<typeof StakingProgramContext> = {
   isActiveStakingProgramLoaded: true,
@@ -293,17 +289,17 @@ describe('useAllInstancesRewardStatus', () => {
   });
 
   describe('decoupled-activity regime (OPE-1803)', () => {
-    const renderForBasius = (
+    const renderForOmenstrat = (
       data: ReturnType<typeof makeStakingRewardsInfo>,
     ) => {
-      const service = makeMiddlewareService(MiddlewareChainMap.BASE, {
+      const service = makeMiddlewareService(MiddlewareChainMap.GNOSIS, {
         service_config_id: DEFAULT_SERVICE_CONFIG_ID,
-        service_public_id: basiusConfig.servicePublicId,
-        home_chain: basiusConfig.middlewareHomeChainId,
-        chain_configs: makeChainConfig(basiusConfig.middlewareHomeChainId, {
+        service_public_id: traderConfig.servicePublicId,
+        home_chain: traderConfig.middlewareHomeChainId,
+        chain_configs: makeChainConfig(traderConfig.middlewareHomeChainId, {
           multisig: MOCK_MULTISIG_ADDRESS,
           token: DEFAULT_SERVICE_NFT_TOKEN_ID,
-          staking_program_id: STAKING_PROGRAM_IDS.BasiusI,
+          staking_program_id: STAKING_PROGRAM_IDS.OmenstratI,
         }),
       });
 
@@ -311,7 +307,7 @@ describe('useAllInstancesRewardStatus', () => {
       mockUseQueries.mockReturnValue([{ isSuccess: true, data }]);
 
       const stakingMap = new Map([
-        [DEFAULT_SERVICE_CONFIG_ID, STAKING_PROGRAM_IDS.BasiusI],
+        [DEFAULT_SERVICE_CONFIG_ID, STAKING_PROGRAM_IDS.OmenstratI],
       ]);
 
       return renderHook(() => useAllInstancesRewardStatus(), {
@@ -329,10 +325,10 @@ describe('useAllInstancesRewardStatus', () => {
       });
     };
 
-    it('is true when on-chain activity reaches the off-chain target (1)', () => {
-      const { result } = renderForBasius(
+    it('is true when on-chain activity reaches the off-chain target (8)', () => {
+      const { result } = renderForOmenstrat(
         makeStakingRewardsInfo({
-          activityThisEpoch: 1,
+          activityThisEpoch: 8,
           isEligibleForRewards: true,
         }),
       );
@@ -340,9 +336,9 @@ describe('useAllInstancesRewardStatus', () => {
     });
 
     it('is false below the target even when the staking KPI is already met', () => {
-      const { result } = renderForBasius(
+      const { result } = renderForOmenstrat(
         makeStakingRewardsInfo({
-          activityThisEpoch: 0,
+          activityThisEpoch: 3,
           isEligibleForRewards: true,
         }),
       );

--- a/frontend/tests/service/agents/Optimism.test.ts
+++ b/frontend/tests/service/agents/Optimism.test.ts
@@ -3,10 +3,7 @@ import { ethers } from 'ethers';
 import { formatEther } from 'ethers/lib/utils';
 
 import { EvmChainIdMap } from '../../../constants/chains';
-import {
-  STAKING_PROGRAM_IDS,
-  StakingProgramId,
-} from '../../../constants/stakingProgram';
+import { STAKING_PROGRAM_IDS } from '../../../constants/stakingProgram';
 import { OptimismService } from '../../../service/agents/Optimism';
 import { ONE_YEAR } from '../../../service/agents/shared-services/StakedAgentService';
 import { StakingState } from '../../../types/Autonolas';
@@ -83,10 +80,8 @@ jest.mock('../../../config/stakingPrograms', () => {
           address: stakingAddr1,
           chainId: EvmChainIdMap.Optimism,
         },
-        // Synthetic decoupled-activity marketplace-regime program. The real
-        // OptimusI id is hidden for QA (OPE-1803), but the Optimism reader still
-        // ships its marketplace branch, so we exercise it via a literal id.
-        ['optimus_i']: {
+        // New (decoupled-activity) marketplace-regime program.
+        [STAKING_PROGRAM_IDS.OptimusI]: {
           get activityChecker() {
             return shared.activityChecker;
           },
@@ -291,7 +286,7 @@ describe('OptimismService.getAgentStakingRewardsInfo (marketplace regime)', () =
     OptimismService.getAgentStakingRewardsInfo({
       agentMultisigAddress: MOCK_MULTISIG_ADDRESS,
       serviceId: DEFAULT_SERVICE_NFT_TOKEN_ID,
-      stakingProgramId: 'optimus_i' as StakingProgramId,
+      stakingProgramId: STAKING_PROGRAM_IDS.OptimusI,
       chainId: OPTIMISM,
       ...overrides,
     });

--- a/frontend/tests/utils/stakingRewards.test.ts
+++ b/frontend/tests/utils/stakingRewards.test.ts
@@ -137,12 +137,16 @@ describe('fetchAgentStakingRewardsInfo', () => {
 
 describe('getStakingProgramActivityTarget', () => {
   it('returns the off-chain target for a decoupled (new-regime) program', () => {
-    // Basius is the only decoupled contract still shipping (Omenstrat/Optimus/
-    // Polystrat were hidden for QA, OPE-1803).
     expect(
       getStakingProgramActivityTarget(
-        EvmChainIdMap.Base,
-        STAKING_PROGRAM_IDS.BasiusI,
+        EvmChainIdMap.Polygon,
+        STAKING_PROGRAM_IDS.PolystratI,
+      ),
+    ).toBe(8);
+    expect(
+      getStakingProgramActivityTarget(
+        EvmChainIdMap.Optimism,
+        STAKING_PROGRAM_IDS.OptimusI,
       ),
     ).toBe(1);
   });

--- a/package.json
+++ b/package.json
@@ -108,6 +108,6 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.6.27-rc27",
+  "version": "1.6.27-rc28",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -108,6 +108,6 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.6.27-rc26",
+  "version": "1.6.27-rc27",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -108,6 +108,6 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.6.27-rc29",
+  "version": "1.6.27-rc30",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -108,6 +108,6 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.6.27-rc24",
+  "version": "1.6.27-rc25",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -108,6 +108,6 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.6.27-rc28",
+  "version": "1.6.27-rc29",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -108,6 +108,6 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.6.27-rc25",
+  "version": "1.6.27-rc26",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-app"
-version = "1.6.27-rc24"
+version = "1.6.27-rc25"
 description = ""
 authors = [
     { name = "David Vilela", email = "dvilelaf@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-app"
-version = "1.6.27-rc26"
+version = "1.6.27-rc27"
 description = ""
 authors = [
     { name = "David Vilela", email = "dvilelaf@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-app"
-version = "1.6.27-rc28"
+version = "1.6.27-rc29"
 description = ""
 authors = [
     { name = "David Vilela", email = "dvilelaf@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-app"
-version = "1.6.27-rc29"
+version = "1.6.27-rc30"
 description = ""
 authors = [
     { name = "David Vilela", email = "dvilelaf@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-app"
-version = "1.6.27-rc25"
+version = "1.6.27-rc26"
 description = ""
 authors = [
     { name = "David Vilela", email = "dvilelaf@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-app"
-version = "1.6.27-rc27"
+version = "1.6.27-rc28"
 description = ""
 authors = [
     { name = "David Vilela", email = "dvilelaf@gmail.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -1144,7 +1144,7 @@ wheels = [
 
 [[package]]
 name = "olas-operate-app"
-version = "1.6.27rc29"
+version = "1.6.27rc30"
 source = { virtual = "." }
 dependencies = [
     { name = "olas-operate-middleware" },

--- a/uv.lock
+++ b/uv.lock
@@ -1144,7 +1144,7 @@ wheels = [
 
 [[package]]
 name = "olas-operate-app"
-version = "1.6.27rc28"
+version = "1.6.27rc29"
 source = { virtual = "." }
 dependencies = [
     { name = "olas-operate-middleware" },

--- a/uv.lock
+++ b/uv.lock
@@ -1144,7 +1144,7 @@ wheels = [
 
 [[package]]
 name = "olas-operate-app"
-version = "1.6.27rc24"
+version = "1.6.27rc25"
 source = { virtual = "." }
 dependencies = [
     { name = "olas-operate-middleware" },

--- a/uv.lock
+++ b/uv.lock
@@ -1144,7 +1144,7 @@ wheels = [
 
 [[package]]
 name = "olas-operate-app"
-version = "1.6.27rc26"
+version = "1.6.27rc27"
 source = { virtual = "." }
 dependencies = [
     { name = "olas-operate-middleware" },

--- a/uv.lock
+++ b/uv.lock
@@ -1144,7 +1144,7 @@ wheels = [
 
 [[package]]
 name = "olas-operate-app"
-version = "1.6.27rc25"
+version = "1.6.27rc26"
 source = { virtual = "." }
 dependencies = [
     { name = "olas-operate-middleware" },

--- a/uv.lock
+++ b/uv.lock
@@ -1144,7 +1144,7 @@ wheels = [
 
 [[package]]
 name = "olas-operate-app"
-version = "1.6.27rc27"
+version = "1.6.27rc28"
 source = { virtual = "." }
 dependencies = [
     { name = "olas-operate-middleware" },


### PR DESCRIPTION
## Purpose

Working branch for the team to inspect / iterate on the **full** new-staking-mechanism state — **all** new staking contracts visible for **every** agent, on the previous (new) hashes. Branched from `…-new-staking-mechanism` and targets it as base, so the diff below is exactly the inverse of the QA scope-down on that branch.

## What this restores (vs the parent QA branch)

The parent branch (`…-new-staking-mechanism`, PR #2035) hid all new contracts except Basius for the QA release. This branch re-enables everything:

- **Uncomments** the new staking contracts for all agents: Omenstrat ×7 (Gnosis / PredictTrader), Optimus ×3 (Optimism), Polystrat ×3 (Polygon) — ids, addresses, activity checkers, program entries.
- **Restores the previous (new) service-template hashes**: trader `v0.39.1-rc2 → v0.40.0-rc2` (PredictTrader + Polystrat); babydegen common `v0.10.1 → v0.12.0-rc3` (Modius + Optimus + Basius back on the shared template).
- Basius is unchanged in behaviour (still on the new contracts + mechanism).

Net content is byte-identical to commit `24d100aa8` (the pre-scope-down state, which was CI-green).

## Notes

- Single commit: a revert of the QA scope-down — clean, reviewable diff.
- Middleware pin unchanged (`00b6e401`, #464 head).
- **Not** intended to merge into the QA branch as-is — it's the opposite direction. It exists so the team can review/fix the issues that caused the other agents' new contracts to be hidden, then fold the fixes back in.