### PR TITLE
fix: make deployment stop/transition crash-safe to avoid wedged services

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,6 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.6.27-rc9",
+  "version": "1.6.27-rc15",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-app"
-version = "1.6.27-rc9"
+version = "1.6.27-rc15"
 description = ""
 authors = [
     { name = "David Vilela", email = "dvilelaf@gmail.com" },
@@ -28,3 +28,6 @@ package = false
 # provenance we had under Poetry). Drop this only if we want to
 # opt every release into uv-managed interpreters.
 python-preference = "only-system"
+
+[tool.uv.sources]
+olas-operate-middleware = { git = "https://github.com/valory-xyz/olas-operate-middleware.git", rev = "94a7ce68ee4347472f05e17654115ec6aca288fb" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "open-aea-ledger-cosmos==2.2.8",
     "open-aea-ledger-ethereum==2.2.8",
     "open-aea-cli-ipfs==2.2.8",
-    "olas-operate-middleware==0.15.29",
+    "olas-operate-middleware==0.15.30",
 ]
 
 [dependency-groups]
@@ -28,6 +28,3 @@ package = false
 # provenance we had under Poetry). Drop this only if we want to
 # opt every release into uv-managed interpreters.
 python-preference = "only-system"
-
-[tool.uv.sources]
-olas-operate-middleware = { git = "https://github.com/valory-xyz/olas-operate-middleware.git", rev = "94a7ce68ee4347472f05e17654115ec6aca288fb" }

--- a/uv.lock
+++ b/uv.lock
@@ -1161,7 +1161,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "olas-operate-middleware", git = "https://github.com/valory-xyz/olas-operate-middleware.git?rev=94a7ce68ee4347472f05e17654115ec6aca288fb" },
+    { name = "olas-operate-middleware", specifier = "==0.15.30" },
     { name = "open-aea-cli-ipfs", specifier = "==2.2.8" },
     { name = "open-aea-ledger-cosmos", specifier = "==2.2.8" },
     { name = "open-aea-ledger-ethereum", specifier = "==2.2.8" },
@@ -1173,8 +1173,8 @@ dev = [{ name = "pyinstaller", specifier = "==6.20.0" }]
 
 [[package]]
 name = "olas-operate-middleware"
-version = "0.15.29"
-source = { git = "https://github.com/valory-xyz/olas-operate-middleware.git?rev=94a7ce68ee4347472f05e17654115ec6aca288fb#94a7ce68ee4347472f05e17654115ec6aca288fb" }
+version = "0.15.30"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "argon2-cffi" },
@@ -1192,6 +1192,10 @@ dependencies = [
     { name = "requests" },
     { name = "uvicorn" },
     { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/6c/1720b70324001bef77c099762b85dc5f09836fe59814f918b36c4016a7fd/olas_operate_middleware-0.15.30.tar.gz", hash = "sha256:88b8c1a6c8c88a3385a3cdc63354dedb6b1ee7918af3dcb42f11acc1b5ce8856", size = 292297, upload-time = "2026-06-23T10:16:01.539Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/ba/fbcd00d4b34ec475315192505e9898f5971e16e72dcb919efe78ae4287cd/olas_operate_middleware-0.15.30-py3-none-any.whl", hash = "sha256:70c6e93a39df0bc8304c134ad788fbf1ef179d907235303109814e3c32ddaf2b", size = 351461, upload-time = "2026-06-23T10:15:59.97Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1144,7 +1144,7 @@ wheels = [
 
 [[package]]
 name = "olas-operate-app"
-version = "1.6.27rc9"
+version = "1.6.27rc15"
 source = { virtual = "." }
 dependencies = [
     { name = "olas-operate-middleware" },
@@ -1161,7 +1161,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "olas-operate-middleware", specifier = "==0.15.29" },
+    { name = "olas-operate-middleware", git = "https://github.com/valory-xyz/olas-operate-middleware.git?rev=94a7ce68ee4347472f05e17654115ec6aca288fb" },
     { name = "open-aea-cli-ipfs", specifier = "==2.2.8" },
     { name = "open-aea-ledger-cosmos", specifier = "==2.2.8" },
     { name = "open-aea-ledger-ethereum", specifier = "==2.2.8" },
@@ -1174,7 +1174,7 @@ dev = [{ name = "pyinstaller", specifier = "==6.20.0" }]
 [[package]]
 name = "olas-operate-middleware"
 version = "0.15.29"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/valory-xyz/olas-operate-middleware.git?rev=94a7ce68ee4347472f05e17654115ec6aca288fb#94a7ce68ee4347472f05e17654115ec6aca288fb" }
 dependencies = [
     { name = "aiohttp" },
     { name = "argon2-cffi" },
@@ -1192,10 +1192,6 @@ dependencies = [
     { name = "requests" },
     { name = "uvicorn" },
     { name = "werkzeug" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/7c/5765071cd60b91cdc878cb69a7bb03dde90801267708c2644c220fe9e174/olas_operate_middleware-0.15.29.tar.gz", hash = "sha256:f5f59d64a577cad1c576d554107e36c58960466ee90025a69844bec703462916", size = 291786, upload-time = "2026-06-18T12:40:02.945Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/ec/de16f3a0702543fe08dad976d8d6acf571be8380b55fc4c002d08e844aab/olas_operate_middleware-0.15.29-py3-none-any.whl", hash = "sha256:dfff253589d949314ce46a65b9c0efd6cbfd8dcf56ae5d6ca65b932b6c6afaeb", size = 350895, upload-time = "2026-06-18T12:40:01.18Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Proposed changes

A middleware process killed mid-transition (e.g. `SIGKILL` while the agent is being set up, observed as `aea command ... add-key ... exit code: -9`) could leave a service's persisted deployment status stuck at `STOPPING` or `DEPLOYING` forever. Such a service became **wedged**: it could be neither started nor stopped, and the frontend's autorun toggle stayed locked because it gates on the transitional deployment status.

Root cause: `Service.stop()` persists `STOPPING` *before* doing the work and only advances to `BUILT` *after*; if the process dies (or `stop_host_deployment` raises the swallowed `"Service already in transition"`) in between, the transient status survives. Nothing normalized it on the next launch.

### Changes

- **`Service.stop()` is now crash-safe** — the stop body is wrapped in `try/except`; on failure the status is reset to `BUILT` and the exception re-raised, instead of leaving `STOPPING` persisted. This mirrors the existing failure handling in `start()` and closes the swallowed `"Service already in transition"` path.
- **New `Deployment.recover_stale_transition_status()`** — called at daemon startup (in `pause_all_services_on_startup`) before pausing services. It resets any persisted `DEPLOYING`/`STOPPING` back to `BUILT`. A hard kill cannot be caught by `try/except`, so this self-heals a wedged service on the next launch. Safe by construction: at startup no deployment from the fresh process is running yet, so any transitional status is necessarily stale. Recovered services are logged at `WARNING`.
- **Tests** — added coverage for the `stop()` failure path (resets to and persists `BUILT`) and for `recover_stale_transition_status()` (resets `DEPLOYING`/`STOPPING`, leaves all other statuses untouched).

### Notes

- Frontend (`olas-operate-app`) needs **no change**: it keeps no persisted deployment status and derives `isServiceTransitioning` purely from polling the middleware, so once the backend reports a terminal status the UI unsticks on the next poll (≤5s) and the autorun toggle unlocks.
- Verified: `tox -e flake8 / black-check / isort-check / mypy` all pass; targeted unit suites green (`test_service_unit2.py`, `test_operate_cli.py`, `test_cli_unit.py`).

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)