### PR TITLE
fix(services): declare FUND_REQUIREMENTS env var for Optimus and Basius

### DIFF
--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -263,6 +263,13 @@ export const OPTIMUS_SERVICE_TEMPLATE: ServiceTemplate = {
       value: '',
       provision_type: EnvProvisionType.COMPUTED,
     },
+    FUND_REQUIREMENTS: {
+      name: 'Fund requirements',
+      description: '',
+      value:
+        '{"optimism":{"agent":{"0x0000000000000000000000000000000000000000":{"topup":200000000000000,"threshold":100000000000000}},"safe":{"0x0000000000000000000000000000000000000000":{"topup":0,"threshold":0}}}}',
+      provision_type: EnvProvisionType.FIXED,
+    },
     STAKING_TOKEN_CONTRACT_ADDRESS: {
       name: 'Staking token contract address',
       description: '',
@@ -402,6 +409,13 @@ export const BASIUS_SERVICE_TEMPLATE: ServiceTemplate = {
       description: '',
       value: '',
       provision_type: EnvProvisionType.COMPUTED,
+    },
+    FUND_REQUIREMENTS: {
+      name: 'Fund requirements',
+      description: '',
+      value:
+        '{"base":{"agent":{"0x0000000000000000000000000000000000000000":{"topup":200000000000000,"threshold":100000000000000}},"safe":{"0x0000000000000000000000000000000000000000":{"topup":0,"threshold":0}}}}',
+      provision_type: EnvProvisionType.FIXED,
     },
     STAKING_TOKEN_CONTRACT_ADDRESS: {
       name: 'Staking token contract address',


### PR DESCRIPTION
## Summary
- Basius fails to boot in Pearl with `safe_contract_addresses is missing chains declared in fund_requirements: ['optimism']`. Pearl computes `SAFE_CONTRACT_ADDRESSES` per the service's home chain (base for Basius, optimism for Optimus) but never set `FUND_REQUIREMENTS`. The agent then resolved `${FUND_REQUIREMENTS:dict:{...}}` from its `service.yaml` default, which hardcodes optimism. For Basius the two maps disagreed on chains and `funds_manager._validate_chain_keys` rejected the boot.
- Declare `FUND_REQUIREMENTS` as a `FIXED` env var in `OPTIMUS_SERVICE_TEMPLATE` (optimism payload) and `BASIUS_SERVICE_TEMPLATE` (base payload). Both maps now move together by construction.
- Numbers mirror the agent's existing `service.yaml` default: `topup` 0.0002 ETH and `threshold` 0.0001 ETH on the agent EOA native token, zeros on the safe. Only the chain key differs per template.

## Why FIXED
Matches the pattern already used in these templates for `INITIAL_ASSETS`, `STAKING_CHAIN`, `TARGET_INVESTMENT_CHAINS` — all per-template constants. No operator-time variability here that justifies a COMPUTED entry.

## Out of scope
- `MODIUS_SERVICE_TEMPLATE` has the same structural issue (home_chain mode, no FUND_REQUIREMENTS declaration). Not touched here to keep the diff tight to the Basius release. Worth a follow-up if Modius is ever re-deployed fresh against the current agent code.

## Test plan
- [x] `yarn lint` clean on the edited file
- [x] `yarn typecheck` clean
- [x] `yarn jest tests/config/agents.guards.test.ts tests/utils/service.test.ts` — 37 tests pass
- [ ] Spin up Basius in Pearl from this branch and confirm the agent boots past `funds_manager` (the specific error from the original log)
- [ ] Spin up Optimus from this branch and confirm no behavioural change (env var now explicit but value matches the previous service.yaml default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)