### PR TITLE
fix(services): point Optimus and Basius at latest service hashes, drop FUND_REQUIREMENTS overrides

### DIFF
--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -22,7 +22,7 @@ const BABYDEGEN_COMMON_TEMPLATE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeigc77ps4pbrbjjeyeipe5gk4zp66sv2rlvgead2ccaxejqqzjlkx4',
+  hash: 'bafybeie2zrvd5mfswtktaagjtvhamnl4lv53hetu6skrzytv73sxn6joie',
   service_version: 'v0.10.1',
   agent_release: {
     is_aea: true,
@@ -40,7 +40,7 @@ const BASIUS_TEMPLATE_RELEASE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeie2zrvd5mfswtktaagjtvhamnl4lv53hetu6skrzytv73sxn6joie',
+  hash: 'bafybeiehwn2lc773hlwybuo6hwce556pnozk7z7c3cn25reegaefzcaoe4',
   service_version: 'v0.12.0-rc3',
   agent_release: {
     is_aea: true,
@@ -263,13 +263,6 @@ export const OPTIMUS_SERVICE_TEMPLATE: ServiceTemplate = {
       value: '',
       provision_type: EnvProvisionType.COMPUTED,
     },
-    FUND_REQUIREMENTS: {
-      name: 'Fund requirements',
-      description: '',
-      value:
-        '{"optimism":{"agent":{"0x0000000000000000000000000000000000000000":{"topup":200000000000000,"threshold":100000000000000}},"safe":{"0x0000000000000000000000000000000000000000":{"topup":0,"threshold":0}}}}',
-      provision_type: EnvProvisionType.FIXED,
-    },
     STAKING_TOKEN_CONTRACT_ADDRESS: {
       name: 'Staking token contract address',
       description: '',
@@ -409,13 +402,6 @@ export const BASIUS_SERVICE_TEMPLATE: ServiceTemplate = {
       description: '',
       value: '',
       provision_type: EnvProvisionType.COMPUTED,
-    },
-    FUND_REQUIREMENTS: {
-      name: 'Fund requirements',
-      description: '',
-      value:
-        '{"base":{"agent":{"0x0000000000000000000000000000000000000000":{"topup":200000000000000,"threshold":100000000000000}},"safe":{"0x0000000000000000000000000000000000000000":{"topup":0,"threshold":0}}}}',
-      provision_type: EnvProvisionType.FIXED,
     },
     STAKING_TOKEN_CONTRACT_ADDRESS: {
       name: 'Staking token contract address',

--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -23,13 +23,13 @@ const BABYDEGEN_COMMON_TEMPLATE: Pick<
   'hash' | 'service_version' | 'agent_release'
 > = {
   hash: 'bafybeie2zrvd5mfswtktaagjtvhamnl4lv53hetu6skrzytv73sxn6joie',
-  service_version: 'v0.10.1',
+  service_version: 'v0.12.0-rc5',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.10.1',
+      version: 'v0.12.0-rc5',
     },
   },
 };
@@ -41,13 +41,13 @@ const BASIUS_TEMPLATE_RELEASE: Pick<
   'hash' | 'service_version' | 'agent_release'
 > = {
   hash: 'bafybeiehwn2lc773hlwybuo6hwce556pnozk7z7c3cn25reegaefzcaoe4',
-  service_version: 'v0.12.0-rc3',
+  service_version: 'v0.12.0-rc5',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.12.0-rc3',
+      version: 'v0.12.0-rc5',
     },
   },
 };


### PR DESCRIPTION
## Summary
- Update `BABYDEGEN_COMMON_TEMPLATE.hash` (shared by Modius and Optimus) to the current Optimus service hash from the optimus repo: `bafybeie2zrvd5mfswtktaagjtvhamnl4lv53hetu6skrzytv73sxn6joie`.
- Update `BASIUS_TEMPLATE_RELEASE.hash` to the new dedicated Basius service hash: `bafybeiehwn2lc773hlwybuo6hwce556pnozk7z7c3cn25reegaefzcaoe4`. That service declares `agent: valory/basius`, which makes `autonomy/cli/helpers/chain.py:240 verify_service_dependencies` pass for token 115 instead of rejecting with the `valory/basius:any` vs `valory/optimus:any` publicId mismatch.
- Drop the `FUND_REQUIREMENTS` env-var entries that were added in #2041 from both `OPTIMUS_SERVICE_TEMPLATE` and `BASIUS_SERVICE_TEMPLATE`. They are no longer needed because the new basius service.yaml bakes Base-chain defaults into the `funds_manager` block (`fund_requirements`, `rpc_urls`, `safe_contract_addresses`), and the existing Optimus service.yaml's Optimism defaults already align with its home chain. No Pearl-side override is required to satisfy `funds_manager._validate_chain_keys`.

## Why drag Modius along
`BABYDEGEN_COMMON_TEMPLATE` is shared between Modius and Optimus by design. Moving the shared hash forward is the simpler change; the alternative was splitting the constant into separate Optimus and Modius releases. The team chose to update both together. Worth a quick smoke check that Modius still boots against this newer service hash before release.

## Depends on
- valory-xyz/optimus PR adding the `valory/basius` agent and service packages (this is the source of the new service hash referenced here). The IPFS hashes here are already pushed and resolvable.

## Test plan
- [x] `yarn typecheck` clean
- [x] `yarn jest tests/config/agents.guards.test.ts tests/utils/service.test.ts` — 37 tests pass
- [ ] Boot Basius in Pearl from this branch and confirm it gets past `verify_service_dependencies` and `funds_manager._validate_chain_keys`
- [ ] Boot Optimus in Pearl from this branch and confirm no regression (env vars now flow through the service.yaml defaults instead of a Pearl override; values should resolve to the same effective config)
- [ ] Boot Modius in Pearl from this branch and confirm it still works on the newer service hash

🤖 Generated with [Claude Code](https://claude.com/claude-code)