### PR TITLE
chore(services): bump service hashes and version to v0.12.0-rc6

### DIFF
--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -22,14 +22,14 @@ const BABYDEGEN_COMMON_TEMPLATE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeie2zrvd5mfswtktaagjtvhamnl4lv53hetu6skrzytv73sxn6joie',
-  service_version: 'v0.12.0-rc5',
+  hash: 'bafybeih2ltyvqxllohrguokclyoj46updpap2byeknjrr34p6dm74mhemu',
+  service_version: 'v0.12.0-rc6',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.12.0-rc5',
+      version: 'v0.12.0-rc6',
     },
   },
 };
@@ -40,14 +40,14 @@ const BASIUS_TEMPLATE_RELEASE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeiehwn2lc773hlwybuo6hwce556pnozk7z7c3cn25reegaefzcaoe4',
-  service_version: 'v0.12.0-rc5',
+  hash: 'bafybeicqm5hp6ag226oxwks2npx4ybacvaohfg2rm7ellfxqh2dx3m3zzi',
+  service_version: 'v0.12.0-rc6',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.12.0-rc5',
+      version: 'v0.12.0-rc6',
     },
   },
 };


### PR DESCRIPTION
## Summary
Picks up the optimus and basius service.yaml cleanups merged in valory-xyz/optimus#346 (literal CoinGecko key default removed, Tenderly virtual forks replaced with public mainnet endpoints). The service IPFS hashes change as a result, so bump both templates and the rc label to match.

| Template | Field | Before | After |
|---|---|---|---|
| `BABYDEGEN_COMMON_TEMPLATE` (Modius + Optimus) | `hash` | `bafybeie2zrvd5mfswtktaagjtvhamnl4lv53hetu6skrzytv73sxn6joie` | `bafybeih2ltyvqxllohrguokclyoj46updpap2byeknjrr34p6dm74mhemu` |
| `BABYDEGEN_COMMON_TEMPLATE` | `service_version` / `agent_release.repository.version` | `v0.12.0-rc5` | `v0.12.0-rc6` |
| `BASIUS_TEMPLATE_RELEASE` | `hash` | `bafybeiehwn2lc773hlwybuo6hwce556pnozk7z7c3cn25reegaefzcaoe4` | `bafybeicqm5hp6ag226oxwks2npx4ybacvaohfg2rm7ellfxqh2dx3m3zzi` |
| `BASIUS_TEMPLATE_RELEASE` | `service_version` / `agent_release.repository.version` | `v0.12.0-rc5` | `v0.12.0-rc6` |

Both new service hashes already pushed to IPFS via `autonomy push-all` from valory-xyz/optimus#346.

## Test plan
- [x] `yarn typecheck` clean
- [x] `yarn jest tests/config/agents.guards.test.ts tests/utils/service.test.ts` — 37 tests pass
- [ ] Boot Basius in Pearl from this branch and confirm it still works end-to-end with the new service hashes
- [ ] Boot Optimus / Modius from this branch and confirm the cleanup-driven service hash bump didn't regress anything

🤖 Generated with [Claude Code](https://claude.com/claude-code)