### PR TITLE
chore(services): bump service hashes and version to v0.12.0-rc7

### DIFF
--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -22,14 +22,14 @@ const BABYDEGEN_COMMON_TEMPLATE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeih2ltyvqxllohrguokclyoj46updpap2byeknjrr34p6dm74mhemu',
-  service_version: 'v0.12.0-rc6',
+  hash: 'bafybeidbihpktbk6qxhi5y2edudokisyywnm5ny4vuawxmmd3igwq5gv34',
+  service_version: 'v0.12.0-rc7',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.12.0-rc6',
+      version: 'v0.12.0-rc7',
     },
   },
 };
@@ -40,14 +40,14 @@ const BASIUS_TEMPLATE_RELEASE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeicqm5hp6ag226oxwks2npx4ybacvaohfg2rm7ellfxqh2dx3m3zzi',
-  service_version: 'v0.12.0-rc6',
+  hash: 'bafybeihsrlgjqww5ktqiafvpovbzyai7rfbyr7d5lpoirt7rc4jqlovskm',
+  service_version: 'v0.12.0-rc7',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.12.0-rc6',
+      version: 'v0.12.0-rc7',
     },
   },
 };


### PR DESCRIPTION
## Summary
Picks up the four fixes bundled in valory-xyz/optimus#347:
- Five missing `mech_interact_abci` round entries added to `rounds_info.py` (fixes the `KeyError: 'mech_information_round'` at HttpHandler setup that killed rc6 boot).
- Basius `mech_marketplace_config` / `priority_mech_address` / `priority_mech_service_id` / `mech_contract_address` / `valid_mechs` switched from Optimism mech-deployment to Base (values from `mech-deployments/deployments/base_mech.env`).
- Basius `service_registry_address` switched from Optimism's ServiceRegistry to Base's (`0x3C1fF68f5aa342D296d4DEe4Bb1cACCA912D95fE`).
- Basius `multisend_address` switched from Optimism to Base (`0x998739BFdAAdde7C933B942a68053933098f9EDa`); `mech_request_prompt` re-branded from "Optimus..." to "Basius...".

Both `BABYDEGEN_COMMON_TEMPLATE` (Modius + Optimus) and `BASIUS_TEMPLATE_RELEASE` move because the rounds_info change cascades through both service hashes.

| Template | Field | Before (rc6) | After (rc7) |
|---|---|---|---|
| `BABYDEGEN_COMMON_TEMPLATE` | `hash` | `bafybeih2ltyvqxllohrguokclyoj46updpap2byeknjrr34p6dm74mhemu` | `bafybeidbihpktbk6qxhi5y2edudokisyywnm5ny4vuawxmmd3igwq5gv34` |
| `BABYDEGEN_COMMON_TEMPLATE` | versions | `v0.12.0-rc6` | `v0.12.0-rc7` |
| `BASIUS_TEMPLATE_RELEASE` | `hash` | `bafybeicqm5hp6ag226oxwks2npx4ybacvaohfg2rm7ellfxqh2dx3m3zzi` | `bafybeihsrlgjqww5ktqiafvpovbzyai7rfbyr7d5lpoirt7rc4jqlovskm` |
| `BASIUS_TEMPLATE_RELEASE` | versions | `v0.12.0-rc6` | `v0.12.0-rc7` |

Both new service hashes already pushed to IPFS via `autonomy push-all`.

## Release note
When cutting the `v0.12.0-rc7` tag on `valory-xyz/optimus`, **push the tag explicitly first and then create the release from the existing tag** in the UI. Selecting "create new tag on publish" with target=main triggers the workflow with `github.ref = refs/heads/main`, which causes `release.yaml`'s `Publish Release` step (gated by `if: startsWith(github.ref, 'refs/tags/')`) to silently skip the asset upload — the rc6 failure mode that needed re-cutting.

## Test plan
- [x] `yarn typecheck` clean
- [x] `yarn jest tests/config/agents.guards.test.ts tests/utils/service.test.ts` — 37 tests pass
- [ ] Boot Basius in Pearl from this branch — confirm HttpHandler setup completes (rc6 KeyError gone), and that the staking-activity path reaches and uses the Base mech marketplace
- [ ] Boot Optimus / Modius from this branch — confirm the cascading hash bump didn't regress anything

🤖 Generated with [Claude Code](https://claude.com/claude-code)