### PR TITLE
chore(services): bump basius service hash and version to v0.12.0-rc9

### DIFF
--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -40,14 +40,14 @@ const BASIUS_TEMPLATE_RELEASE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeigrgrm66iriunfrflz2ybmeg4efmjj2xaiqnwzpo7ygc6dte2tqnm',
-  service_version: 'v0.12.0-rc8',
+  hash: 'bafybeicp74th4cghtcnk4nvdhfnxwodwuuv3vrisk6ijetf7ausk7xsama',
+  service_version: 'v0.12.0-rc9',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.12.0-rc8',
+      version: 'v0.12.0-rc9',
     },
   },
 };


### PR DESCRIPTION
## Summary

Bumps only the **Basius** template to **v0.12.0-rc9**. Modius/Optimus templates stay at rc8 — only the Basius config changed in [valory-xyz/optimus#350](https://github.com/valory-xyz/optimus/pull/350).

| Template | Field | rc8 → rc9 |
|---|---|---|
| `BASIUS_TEMPLATE_RELEASE` | `hash` | `bafybeigrgrm66iriunfrflz2ybmeg4efmjj2xaiqnwzpo7ygc6dte2tqnm` → `bafybeicp74th4cghtcnk4nvdhfnxwodwuuv3vrisk6ijetf7ausk7xsama` |
| `BASIUS_TEMPLATE_RELEASE` | `service_version` + `agent_release.version` | `v0.12.0-rc8` → `v0.12.0-rc9` |
| `BABYDEGEN_COMMON_TEMPLATE` (Modius/Optimus) | — | unchanged |

## What's in rc9

[valory-xyz/optimus#350](https://github.com/valory-xyz/optimus/pull/350): overrides `mechs_subgraph.url` in `basius/service.yaml` and `basius/aea-config.yaml` to point at the Base marketplace subgraph (`marketplace-base`) instead of inheriting the Optimism URL from `optimus_abci/skill.yaml`. Before this fix, `MechInformationBehaviour` fetched from the wrong chain's subgraph and got an empty mech list every cycle, so the FSM looped on `(MechInformationRound, NONE) → MechVersionDetectionRound` forever, `request()` never settled, and `mapRequestCounts` stayed at zero — KPI permanently unmet on the new RequesterActivityCheckerV2 regime.

Verified by direct GraphQL probe: the exact agent query against `marketplace-base` returns the priority mech (id 112, 10090 deliveries) with a fetchable IPFS manifest, vs `[]` against `marketplace-optimism`.

## Heads-up

optimus PR #350 is **open at time of writing**. Hash is stable as long as no follow-up commits land on that branch before merge. Worth coordinating the merge order if rc9 deploys before #350 is merged.

## Test plan
- [ ] CI green on this PR.
- [ ] Smoke-test app boot picks up the new Basius template version (Basius-only — Modius/Optimus unaffected).
- [ ] On a Basius safe past `staking_threshold_period`, observe `Updated mechs' information: ...` (non-empty) replacing the previous `Retrieved mechs' information: [].` infinite loop, the mech request settling on-chain, and `mapRequestCounts` ticking on the activity checker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)