### PR TITLE
chore(services): bump basius and optimus service hashes and version to v0.12.0-rc10

### DIFF
--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -22,14 +22,14 @@ const BABYDEGEN_COMMON_TEMPLATE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeih5u7loukh2eah24dvshbebulsy425fcsjarncssrvx6i37h7ejqm',
-  service_version: 'v0.12.0-rc8',
+  hash: 'bafybeiacgh74i7yz2rli2lkqaskd4fx5323ukgkdqth6lgpkyw5gayilj4',
+  service_version: 'v0.12.0-rc10',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.12.0-rc8',
+      version: 'v0.12.0-rc10',
     },
   },
 };

--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -40,14 +40,14 @@ const BASIUS_TEMPLATE_RELEASE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeicp74th4cghtcnk4nvdhfnxwodwuuv3vrisk6ijetf7ausk7xsama',
-  service_version: 'v0.12.0-rc9',
+  hash: 'bafybeiaxwi4vmgdutut3acfzudqahveck3alk54frx2xjsx3tranwavnfy',
+  service_version: 'v0.12.0-rc10',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.12.0-rc9',
+      version: 'v0.12.0-rc10',
     },
   },
 };


### PR DESCRIPTION
## Summary

Repoints both babydegen templates at the corrected service hashes from [valory-xyz/optimus#351](https://github.com/valory-xyz/optimus/pull/351). rc9 (#2047, basius-only) shipped the half-fix from #350 which didn't actually take effect at runtime; this PR ships the symmetric fix for **both** basius and optimus, with the version label bumped to rc10 for both templates so the rc tag matches across templates.

| Template | Field | Previous → rc10 |
|---|---|---|
| `BABYDEGEN_COMMON_TEMPLATE` (consumed by Modius + Optimus) | `hash` | `bafybeih5u7loukh2eah24dvshbebulsy425fcsjarncssrvx6i37h7ejqm` (rc8) → `bafybeiacgh74i7yz2rli2lkqaskd4fx5323ukgkdqth6lgpkyw5gayilj4` |
| `BABYDEGEN_COMMON_TEMPLATE` | `service_version` + `agent_release.version` | `v0.12.0-rc8` → `v0.12.0-rc10` |
| `BASIUS_TEMPLATE_RELEASE` | `hash` | `bafybeicp74th4cghtcnk4nvdhfnxwodwuuv3vrisk6ijetf7ausk7xsama` (rc9) → `bafybeiaxwi4vmgdutut3acfzudqahveck3alk54frx2xjsx3tranwavnfy` |
| `BASIUS_TEMPLATE_RELEASE` | `service_version` + `agent_release.version` | `v0.12.0-rc9` → `v0.12.0-rc10` |

`MODIUS_SERVICE_TEMPLATE`, `OPTIMUS_SERVICE_TEMPLATE`, and `BASIUS_SERVICE_TEMPLATE` all spread one of these common blocks, so all three pick up the new hash automatically.

## Test plan
- [ ] CI green on this PR.
- [ ] Basius safe past `staking_threshold_period`: observe `Updated mechs' information: ...` (non-empty) replacing the empty-list loop; mech request settles; `mapRequestCounts` increments on the activity checker.
- [ ] Modius/Optimus smoke-test app boot — they share the new BABYDEGEN_COMMON_TEMPLATE hash so worth confirming nothing regresses on their flow (no behaviour change expected, just the additional yaml block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)