### PR TITLE
chore(services): bump basius and optimus service hashes and version to v0.12.0-rc11

### DIFF
--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -22,14 +22,14 @@ const BABYDEGEN_COMMON_TEMPLATE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeiacgh74i7yz2rli2lkqaskd4fx5323ukgkdqth6lgpkyw5gayilj4',
-  service_version: 'v0.12.0-rc10',
+  hash: 'bafybeigjyo22nl622tn5kbntetyr6obbr3rtk2rzfu6zbqh7xaejehanum',
+  service_version: 'v0.12.0-rc11',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.12.0-rc10',
+      version: 'v0.12.0-rc11',
     },
   },
 };
@@ -40,14 +40,14 @@ const BASIUS_TEMPLATE_RELEASE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeiaxwi4vmgdutut3acfzudqahveck3alk54frx2xjsx3tranwavnfy',
-  service_version: 'v0.12.0-rc10',
+  hash: 'bafybeicp74th4cghtcnk4nvdhfnxwodwuuv3vrisk6ijetf7ausk7xsama',
+  service_version: 'v0.12.0-rc11',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.12.0-rc10',
+      version: 'v0.12.0-rc11',
     },
   },
 };


### PR DESCRIPTION
## Summary

| Template | Field | rc10 → rc11 |
|---|---|---|
| `BABYDEGEN_COMMON_TEMPLATE` (Modius + Optimus) | `hash` | `bafybeiacgh74i7yz2rli2lkqaskd4fx5323ukgkdqth6lgpkyw5gayilj4` → `bafybeigjyo22nl622tn5kbntetyr6obbr3rtk2rzfu6zbqh7xaejehanum` |
| `BABYDEGEN_COMMON_TEMPLATE` | `service_version` + `agent_release.version` | `v0.12.0-rc10` → `v0.12.0-rc11` |
| `BASIUS_TEMPLATE_RELEASE` | `hash` | `bafybeiaxwi4vmgdutut3acfzudqahveck3alk54frx2xjsx3tranwavnfy` → `bafybeicp74th4cghtcnk4nvdhfnxwodwuuv3vrisk6ijetf7ausk7xsama` |
| `BASIUS_TEMPLATE_RELEASE` | `service_version` + `agent_release.version` | `v0.12.0-rc10` → `v0.12.0-rc11` |

## Test plan

- [ ] Confirm `v0.12.0-rc11` release exists on optimus repo and `agent_runner_macos_arm64` artifact is present.
- [ ] Fresh Pearl basius deploy succeeds (no `KeyError: 'params'` from `try_update_runtime_params`).
- [ ] On a basius safe past `staking_threshold_period`, observe `Retrieved mechs' information: [<non-empty>]` replacing the empty-list loop; first mech request settles; `mapRequestCounts` increments on the activity checker.
- [ ] Modius/Optimus smoke-test app boot — they share the new `BABYDEGEN_COMMON_TEMPLATE` hash so worth confirming nothing regresses on their flow (no behaviour change expected, just the additional `optimus_abci.mechs_subgraph` block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)