### PR TITLE
chore(services): bump Optimus to v0.12.1 (repoint at Optimism mech 195)

### DIFF
--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -52,6 +52,25 @@ const BASIUS_TEMPLATE_RELEASE: Pick<
   },
 };
 
+// Optimus ships its own build — separated from the shared babydegen hash so
+// Optimism-specific mech config (priority mech 195 on Optimism, prediction-offline
+// tool) doesn't get applied to Modius too.
+const OPTIMUS_TEMPLATE_RELEASE: Pick<
+  ServiceTemplate,
+  'hash' | 'service_version' | 'agent_release'
+> = {
+  hash: 'bafybeieh7ipqea66s2p3km52fwnkeosileg5rqwecmon4azuohwbxvowye',
+  service_version: 'v0.12.0-rc12',
+  agent_release: {
+    is_aea: true,
+    repository: {
+      owner: 'valory-xyz',
+      name: 'optimus',
+      version: 'v0.12.0-rc12',
+    },
+  },
+};
+
 export const MODIUS_SERVICE_TEMPLATE: ServiceTemplate = {
   agentType: AgentMap.Modius,
   name: 'Optimus',
@@ -350,7 +369,7 @@ export const OPTIMUS_SERVICE_TEMPLATE: ServiceTemplate = {
       provision_type: EnvProvisionType.FIXED,
     },
   },
-  ...BABYDEGEN_COMMON_TEMPLATE,
+  ...OPTIMUS_TEMPLATE_RELEASE,
 } as const;
 
 export const BASIUS_SERVICE_TEMPLATE: ServiceTemplate = {

--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -60,13 +60,13 @@ const OPTIMUS_TEMPLATE_RELEASE: Pick<
   'hash' | 'service_version' | 'agent_release'
 > = {
   hash: 'bafybeieh7ipqea66s2p3km52fwnkeosileg5rqwecmon4azuohwbxvowye',
-  service_version: 'v0.12.0-rc12',
+  service_version: 'v0.12.1',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.12.0-rc12',
+      version: 'v0.12.1',
     },
   },
 };


### PR DESCRIPTION
## Summary

Bumps the Optimus Pearl template to `v0.12.1` and repoints it at the freshly-deployed Optimism mech (service id `195`, `0x3208Dc0D...AaF55E`).

The previous shared `BABYDEGEN_COMMON_TEMPLATE` hash pointed Optimus at service id 194 (`0x650C77F4...d0d`) on Optimism, which was a contract-only deployment with no Propel backend behind it. Pearl optimus's `MechInformationRound` filters the subgraph on `service_: {totalDeliveries_gt: 0}`, so it never discovered that mech and looped on `Failed to fetch mech information for the marketplace`. [valory-xyz/optimus#353](https://github.com/valory-xyz/optimus/pull/353) repoints the optimus agent defaults at the new mech (wired through Propel from the start in [valory-xyz/agent-deployments#299](https://github.com/valory-xyz/agent-deployments/pull/299)).

## What this PR does

Adds a dedicated `OPTIMUS_TEMPLATE_RELEASE` constant — mirroring the existing `BASIUS_TEMPLATE_RELEASE` pattern — so the Optimism-specific mech config doesn't bleed into Modius (which currently shares `BABYDEGEN_COMMON_TEMPLATE`).

| Template | Field | Was | Now |
|---|---|---|---|
| `OPTIMUS_SERVICE_TEMPLATE` | `hash` | `bafybeigjyo22nl622tn5kbntetyr6obbr3rtk2rzfu6zbqh7xaejehanum` (shared via `BABYDEGEN_COMMON_TEMPLATE`) | `bafybeieh7ipqea66s2p3km52fwnkeosileg5rqwecmon4azuohwbxvowye` (own) |
| `OPTIMUS_SERVICE_TEMPLATE` | `service_version` + `agent_release.version` | `v0.12.0-rc11` | `v0.12.1` |
| `MODIUS_SERVICE_TEMPLATE` | — | unchanged (still uses `BABYDEGEN_COMMON_TEMPLATE` at rc11) |  |
| `BASIUS_SERVICE_TEMPLATE` | — | unchanged (still uses `BASIUS_TEMPLATE_RELEASE` at rc11) |  |

## Dependencies

- [valory-xyz/optimus#353](https://github.com/valory-xyz/optimus/pull/353) must merge first (adds the new mech address + `prediction-offline` tool default in the optimus agent)
- A `v0.12.1` release tag needs to be cut on the optimus repo (release workflow builds the new `agent_runner_macos_arm64` from post-merge main)
- [valory-xyz/agent-deployments#299](https://github.com/valory-xyz/agent-deployments/pull/299) deploys the actual mech backend on Propel
- 1Password secret `op://Agent Deployments/single-optimism-mech-195/api-keys` needs an OpenAI key (the only tool the mech ships is `prediction-offline` which uses gpt-4o-2024-08-06 under the hood)

## Test plan

- [ ] Confirm `v0.12.1` release exists on optimus repo and the `agent_runner_macos_arm64` artifact is present
- [ ] Confirm the agent-deployments PR is merged and the Propel mech backend is online
- [ ] Fresh Pearl Optimus deploy succeeds
- [ ] On an Optimus safe past `staking_threshold_period`, observe `Retrieved mechs' information: [<non-empty>]` replacing the empty-list loop; first mech request settles; `mapRequestCounts` increments on the activity checker
- [ ] Modius and Basius smoke-test app boot — both are unchanged in this PR but worth confirming no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)