### PR TITLE
chore(optimus): switch mech tool to prediction-offline-v1

### DIFF
--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -53,8 +53,8 @@ const BASIUS_TEMPLATE_RELEASE: Pick<
 };
 
 // Optimus ships its own build — separated from the shared babydegen hash so
-// Optimism-specific mech config (priority mech 195 on Optimism, prediction-offline
-// tool) doesn't get applied to Modius too.
+// Optimism-specific mech config (priority mech 195 on Optimism,
+// prediction-offline-v1 tool) doesn't get applied to Modius too.
 const OPTIMUS_TEMPLATE_RELEASE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
@@ -304,6 +304,13 @@ export const OPTIMUS_SERVICE_TEMPLATE: ServiceTemplate = {
       name: 'Staking chain',
       description: '',
       value: 'optimism',
+      provision_type: EnvProvisionType.FIXED,
+    },
+    MECH_TOOL: {
+      name: 'Mech tool',
+      description:
+        'Tool name requested from mech 195. Bumped to `prediction-offline-v1` because the upstream prediction_request_v1 package renamed all tool names to `*-v1` (see mech 5a557e5b). The previous `prediction-offline` no longer exists in any current mech-predict service.',
+      value: 'prediction-offline-v1',
       provision_type: EnvProvisionType.FIXED,
     },
     ACTIVITY_CHECKER_CONTRACT_ADDRESS: {

--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -308,8 +308,7 @@ export const OPTIMUS_SERVICE_TEMPLATE: ServiceTemplate = {
     },
     MECH_TOOL: {
       name: 'Mech tool',
-      description:
-        'Tool name requested from mech 195. Bumped to `prediction-offline-v1` because the upstream prediction_request_v1 package renamed all tool names to `*-v1` (see mech 5a557e5b). The previous `prediction-offline` no longer exists in any current mech-predict service.',
+      description: '',
       value: 'prediction-offline-v1',
       provision_type: EnvProvisionType.FIXED,
     },


### PR DESCRIPTION
## Summary

Adds a fixed \`MECH_TOOL=prediction-offline-v1\` env override to the OPTIMUS service template. Without it, Pearl optimus falls back to the optimus aea-config default (\`prediction-offline\`), which no current mech-predict service serves.

## Why

The mech-predict \`prediction_request_v1\` package was rewritten in mech \`5a557e5b\` (\"bump anthropic SDK 0.23.1 -> 0.109.1; fork claude prediction tools to _v1\"). All tool names got a \`-v1\` suffix. Mech 195 ran fine while we were pointing Pearl optimus at an older mech-predict service hash (which bundled the pre-rename custom serving \`prediction-offline\`). We're now switching mech 195 to a new mech-predict service hash that adds Optimism RPC support (see mech-predict#376 + agent-deployments#300), and that newer service only serves \`prediction-offline-v1\`.

Without this PR: optimus → mech 195 with \`tool: prediction-offline\` → mech rejects as unknown tool (\`task_execution/behaviours.py:1270\`) → no delivery → KPI doesn't tick.

## Test plan
- [ ] After agent-deployments#300 merges and mech 195 is redeployed against the new service hash, ship a Pearl release with this template change
- [ ] Confirm optimus sends \`tool: prediction-offline-v1\` in its mech requests
- [ ] Confirm mech 195 delivers a real prediction (not an invalid-tool error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)