### PR TITLE
chore(optimus,basius): bump service hashes for funds_manager USDC fix

### DIFF
--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -41,13 +41,13 @@ const BASIUS_TEMPLATE_RELEASE: Pick<
   'hash' | 'service_version' | 'agent_release'
 > = {
   hash: 'bafybeieyje3avjjhlk2qtxswu7uvukaqnsvzmlfvgy3qzarxyv3cd6viru',
-  service_version: 'v0.12.0-rc11',
+  service_version: 'v0.12.2',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.12.0-rc11',
+      version: 'v0.12.2',
     },
   },
 };
@@ -60,13 +60,13 @@ const OPTIMUS_TEMPLATE_RELEASE: Pick<
   'hash' | 'service_version' | 'agent_release'
 > = {
   hash: 'bafybeih52axldd5orb2pjavmxb6lxnke4tdggrlqotyk6oam6ipa5zeiyy',
-  service_version: 'v0.12.1',
+  service_version: 'v0.12.2',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.12.1',
+      version: 'v0.12.2',
     },
   },
 };

--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -40,7 +40,7 @@ const BASIUS_TEMPLATE_RELEASE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeicp74th4cghtcnk4nvdhfnxwodwuuv3vrisk6ijetf7ausk7xsama',
+  hash: 'bafybeieyje3avjjhlk2qtxswu7uvukaqnsvzmlfvgy3qzarxyv3cd6viru',
   service_version: 'v0.12.0-rc11',
   agent_release: {
     is_aea: true,
@@ -59,7 +59,7 @@ const OPTIMUS_TEMPLATE_RELEASE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeieh7ipqea66s2p3km52fwnkeosileg5rqwecmon4azuohwbxvowye',
+  hash: 'bafybeih52axldd5orb2pjavmxb6lxnke4tdggrlqotyk6oam6ipa5zeiyy',
   service_version: 'v0.12.1',
   agent_release: {
     is_aea: true,


### PR DESCRIPTION
## Summary

Bumps \`OPTIMUS_TEMPLATE_RELEASE.hash\` and \`BASIUS_TEMPLATE_RELEASE.hash\` to the new optimus repo service hashes that add a USDC entry to the \`funds_manager\` \`fund_requirements\` default.

## Why

Mech payments settle in USDC (\`FixedPriceTokenUSDC\` flavour on both Optimism mech 195 and Base mech 112). The agent's \`/funds-status\` endpoint only ever tracked native ETH because \`funds_manager.fund_requirements\` defaulted to a zero-address entry. The Pearl template's USDC requirement was used at onboarding but never reached the agent at runtime, so the agent silently ran out of USDC and \`mech_interact_abci\` only learned about it reactively (\"balance is not enough to pay for the mech's price\").

Reproduced on optimus mech 195: agent logged the warning repeatedly, KPI never ticked, on-chain USDC balance on the agent's safe was 0.

## What changes

- \`OPTIMUS_TEMPLATE_RELEASE.hash\` → \`bafybeih52axldd5orb2pjavmxb6lxnke4tdggrlqotyk6oam6ipa5zeiyy\`
- \`BASIUS_TEMPLATE_RELEASE.hash\` → \`bafybeieyje3avjjhlk2qtxswu7uvukaqnsvzmlfvgy3qzarxyv3cd6viru\`

Both new service hashes add a USDC entry to \`funds_manager.fund_requirements\` for the relevant chain (Optimism USDC for optimus, Base USDC for basius), with threshold 0.35 USDC and topup 0.70 USDC (sized for ~1 week of mech requests at 5 reqs/day × 0.01 USDC/request).

\`BABYDEGEN_COMMON_TEMPLATE\` (Modius) is intentionally untouched. Modius doesn't run mechs and the new optimus service hash declares an Optimism chain requirement, which would fail Modius's chain validation.

## Tracks

- valory-xyz/optimus#354 (the source change adding USDC to the funds_manager defaults)

## Test plan

- [ ] Boot a Pearl optimus deployment against the new hash, confirm \`/funds-status\` reports a USDC deficit when the safe is empty
- [ ] Fund the safe with 1 USDC, confirm the mech request fires and the KPI ticks

🤖 Generated with [Claude Code](https://claude.com/claude-code)