### PR TITLE
chore: bump Polymarket trader to v0.40.0-rc5

### DIFF
--- a/frontend/constants/serviceTemplates/service/trader.ts
+++ b/frontend/constants/serviceTemplates/service/trader.ts
@@ -144,14 +144,14 @@ export const PREDICT_SERVICE_TEMPLATE: ServiceTemplate = {
 } as const;
 
 export const PREDICT_POLYMARKET_SERVICE_TEMPLATE: ServiceTemplate = {
-  hash: 'bafybeiapvnpaw3gw342263wcngsrvoldf5bf7ovrl4n3ljybhapk4qlism',
-  service_version: 'v0.40.0-rc4',
+  hash: 'bafybeidqc5k3irb7vwhnftz5emazqvr5dqmnqqmiggd4usrhlsnpvhbczi',
+  service_version: 'v0.40.0-rc5',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'trader',
-      version: 'v0.40.0-rc4',
+      version: 'v0.40.0-rc5',
     },
   },
   agentType: AgentMap.Polystrat,

--- a/package.json
+++ b/package.json
@@ -111,6 +111,6 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.6.27-rc30",
+  "version": "1.6.27-rc31",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-app"
-version = "1.6.27-rc30"
+version = "1.6.27-rc31"
 description = ""
 authors = [
     { name = "David Vilela", email = "dvilelaf@gmail.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -1144,7 +1144,7 @@ wheels = [
 
 [[package]]
 name = "olas-operate-app"
-version = "1.6.27rc30"
+version = "1.6.27rc31"
 source = { virtual = "." }
 dependencies = [
     { name = "olas-operate-middleware" },


### PR DESCRIPTION
## What

Bumps `PREDICT_POLYMARKET_SERVICE_TEMPLATE` (Pearl Polymarket / Polystrat agent) to trader release [`v0.40.0-rc5`](https://github.com/valory-xyz/trader/releases/tag/v0.40.0-rc5).

| field | before | after |
|-------|--------|-------|
| `hash` | `bafybeiapvnpaw…qlism` | `bafybeidqc5k3ir…hbczi` |
| `service_version` | `v0.40.0-rc4` | `v0.40.0-rc5` |
| `agent_release…version` | `v0.40.0-rc4` | `v0.40.0-rc5` |

## Why

`v0.40.0-rc5` is the first release carrying the Polymarket bet-selection hardening and the strategy-pointer fixes:

- **Edge band + spread cap gates** on the CLOB path (kelly_criterion) — skip bets outside the configured edge band or above the max spread.
- **`file_hash_to_strategies` repointed** to the packaged `kelly_criterion` and `fixed_bet` CIDs. The runtime loads strategies from IPFS by this pointer, and it had drifted ~2 months behind the packaged code — so the gates (and an earlier depth fix) weren't actually deploying. A drift-guard test now prevents recurrence.

## Scope

- Polymarket template only. The Gnosis/Omen `PREDICT_SERVICE_TEMPLATE` is intentionally left on `v0.40.0-rc4` (those gates are Polymarket/CLOB-only).
- Service CID verified published to IPFS (gateway HTTP 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)