### PR TITLE
chore: bump Basius and Optimus to optimus v0.12.3

### DIFF
--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -40,14 +40,14 @@ const BASIUS_TEMPLATE_RELEASE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeieyje3avjjhlk2qtxswu7uvukaqnsvzmlfvgy3qzarxyv3cd6viru',
-  service_version: 'v0.12.2',
+  hash: 'bafybeiax2dkm6sw2j2scyd5zjsgufpgvsxtjow6clguz6qrgsizrpb7uqy',
+  service_version: 'v0.12.3',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.12.2',
+      version: 'v0.12.3',
     },
   },
 };
@@ -59,14 +59,14 @@ const OPTIMUS_TEMPLATE_RELEASE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeih52axldd5orb2pjavmxb6lxnke4tdggrlqotyk6oam6ipa5zeiyy',
-  service_version: 'v0.12.2',
+  hash: 'bafybeiadfyrrbypfbnfzg4v3fx2yxex6gcj5eqlknsnqfsz2vvp674o5su',
+  service_version: 'v0.12.3',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.12.2',
+      version: 'v0.12.3',
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -111,6 +111,6 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.8.1-rc3",
+  "version": "1.8.1-rc4",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-app"
-version = "1.8.1-rc3"
+version = "1.8.1-rc4"
 description = ""
 authors = [
     { name = "David Vilela", email = "dvilelaf@gmail.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -1144,7 +1144,7 @@ wheels = [
 
 [[package]]
 name = "olas-operate-app"
-version = "1.8.1rc3"
+version = "1.8.1rc4"
 source = { virtual = "." }
 dependencies = [
     { name = "olas-operate-middleware" },


### PR DESCRIPTION
## Summary
- Bumps the Basius and Optimus service templates to [optimus v0.12.3](https://github.com/valory-xyz/optimus/releases/tag/v0.12.3) (hash + service_version + agent_release version).
- Basius: `bafybeiax2dkm6sw2j2scyd5zjsgufpgvsxtjow6clguz6qrgsizrpb7uqy`
- Optimus: `bafybeiadfyrrbypfbnfzg4v3fx2yxex6gcj5eqlknsnqfsz2vvp674o5su`
- Picks up the mech fee reserve fix (agents no longer invest away the funds needed for mech request fees) and the Velodrome v2 gauge unstake tx fix.
- Modius stays on the shared babydegen template, unchanged.

## Test plan
- [x] `npx tsx scripts/js/check_service_templates.ts` passes (release assets and service YAMLs resolve for v0.12.3)
- [x] `yarn quality-check:frontend` passes (0 errors)
- [ ] Smoke-test Basius and Optimus onboarding/run via Pearl staging build

🤖 Generated with [Claude Code](https://claude.com/claude-code)