### PR TITLE
chore(basius): Aerodrome UI version bumps (tracking agent-ui#114)

### DIFF
--- a/frontend/constants/serviceTemplates/agentUiReleases.ts
+++ b/frontend/constants/serviceTemplates/agentUiReleases.ts
@@ -48,6 +48,9 @@ export const AGENT_UI_RELEASES: Partial<Record<AgentType, AgentUiRelease>> = {
   [AgentMap.Basius]: {
     owner: 'valory-xyz',
     name: AGENT_UI_MONOREPO,
+    // TODO(basius-aerodrome-ui): bump to the tag that ships agent-ui-monorepo#114
+    // (Aerodrome branding + msUSD logo), in lockstep with BASIUS_TEMPLATE_RELEASE
+    // in service/babydegen.ts.
     version: 'v0.2.0-basius',
   },
   [AgentMap.AgentsFun]: {

--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -36,6 +36,13 @@ const BABYDEGEN_COMMON_TEMPLATE: Pick<
 
 // Basius ships its own (latest) build — kept separate so reverting the shared
 // babydegen hash for Modius/Optimus doesn't drag Basius back.
+//
+// TODO(basius-aerodrome-ui): the Aerodrome-branding + msUSD-logo fixes in
+// agent-ui-monorepo#114 are bundled into the `optimus` agent package. Once that
+// UI lands in a new `optimus` release, bump all three fields below to that
+// release (hash = its IPFS hash) and update AGENT_UI_RELEASES in
+// agentUiReleases.ts to the matching `vX.Y-basius` tag. Then run
+// `scripts/js/check_service_templates.ts`.
 const BASIUS_TEMPLATE_RELEASE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'


### PR DESCRIPTION
## Tracking PR — blocked on agent UI release

Companion to **[agent-ui-monorepo#114](https://github.com/valory-xyz/agent-ui-monorepo/pull/114)** (Basius: Aerodrome branding + msUSD token logo).

That fix lives entirely in the Basius agent UI, which is **bundled inside the `optimus` agent package**. So nothing here changes until #114 is released and the `optimus` agent is repackaged with the new UI bundle. This PR is a **draft placeholder** that marks the exact lines to bump and keeps the current (valid) values so `check_service_templates.ts` still passes in the meantime.

## What this PR does now

Comment-only `TODO(basius-aerodrome-ui)` markers at the two edit sites — no value changes yet.

## Fill in when the UI ships (checklist)

1. **`frontend/constants/serviceTemplates/service/babydegen.ts`** → `BASIUS_TEMPLATE_RELEASE`:
   - `hash` → IPFS hash of the repackaged `optimus` agent
   - `service_version` → new `optimus` release (e.g. `v0.12.4`)
   - `agent_release.repository.version` → same
2. **`frontend/constants/serviceTemplates/agentUiReleases.ts`** → `AGENT_UI_RELEASES[Basius].version` → the new `vX.Y-basius` tag
3. Run `scripts/js/check_service_templates.ts`
4. Remove the `TODO(basius-aerodrome-ui)` comments

## Notes

- Modius/Optimus untouched — Basius has its own `BASIUS_TEMPLATE_RELEASE`.
- Base branch: targeting `main`; retarget to `staging` if this rides an rc cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
