### PR TITLE
chore(services): bump basius/optimus to v0.12.4, refresh trader hashes

### DIFF
--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -40,7 +40,7 @@ const BASIUS_TEMPLATE_RELEASE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeihtx4xbpj22kmarp2pivanccocfeqjuedlaac44zcwaidx3cm6664',
+  hash: 'bafybeigoetjxteip6ic7fryr3sikbl4f7iuannkqegf5fgurlgiibf574e',
   service_version: 'v0.12.4',
   agent_release: {
     is_aea: true,
@@ -59,7 +59,7 @@ const OPTIMUS_TEMPLATE_RELEASE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeicyvlb7ftfcfyhhevjhfaeeubagve45xhbymx3qyill3bdykofszu',
+  hash: 'bafybeieauvbqf4mlsxfnt5yzs4hmhae43nkca2rsnklnyundzpqj42jyt4',
   service_version: 'v0.12.4',
   agent_release: {
     is_aea: true,

--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -40,14 +40,14 @@ const BASIUS_TEMPLATE_RELEASE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeiax2dkm6sw2j2scyd5zjsgufpgvsxtjow6clguz6qrgsizrpb7uqy',
-  service_version: 'v0.12.3',
+  hash: 'bafybeihtx4xbpj22kmarp2pivanccocfeqjuedlaac44zcwaidx3cm6664',
+  service_version: 'v0.12.4',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.12.3',
+      version: 'v0.12.4',
     },
   },
 };
@@ -59,14 +59,14 @@ const OPTIMUS_TEMPLATE_RELEASE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeiadfyrrbypfbnfzg4v3fx2yxex6gcj5eqlknsnqfsz2vvp674o5su',
-  service_version: 'v0.12.3',
+  hash: 'bafybeicyvlb7ftfcfyhhevjhfaeeubagve45xhbymx3qyill3bdykofszu',
+  service_version: 'v0.12.4',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.12.3',
+      version: 'v0.12.4',
     },
   },
 };

--- a/frontend/constants/serviceTemplates/service/trader.ts
+++ b/frontend/constants/serviceTemplates/service/trader.ts
@@ -11,7 +11,7 @@ import { X402_ENABLED_FLAGS } from '../../x402';
 import { KPI_DESC_PREFIX } from '../constants';
 
 export const PREDICT_SERVICE_TEMPLATE: ServiceTemplate = {
-  hash: 'bafybeif5xjgk4tubgitdgi5mlvq3x3wf62vix337s66vrlmxlvqf7q6ioi',
+  hash: 'bafybeigfo273qta5ofgmidchoy6zy5ai464xi4prydsp4gen2mhgiy7rg4',
   service_version: 'v0.40.1',
   agent_release: {
     is_aea: true,
@@ -144,7 +144,7 @@ export const PREDICT_SERVICE_TEMPLATE: ServiceTemplate = {
 } as const;
 
 export const PREDICT_POLYMARKET_SERVICE_TEMPLATE: ServiceTemplate = {
-  hash: 'bafybeihhmwu4mqp5pliriiwepnkfebpy5us3zlsbtcmfwwcm77jtutctde',
+  hash: 'bafybeifdwuq5dlzb4wnwb45h54zo7owlkj6ogrpw74mqnxtdgokiim67t4',
   service_version: 'v0.40.1',
   agent_release: {
     is_aea: true,

--- a/frontend/constants/serviceTemplates/service/trader.ts
+++ b/frontend/constants/serviceTemplates/service/trader.ts
@@ -11,14 +11,14 @@ import { X402_ENABLED_FLAGS } from '../../x402';
 import { KPI_DESC_PREFIX } from '../constants';
 
 export const PREDICT_SERVICE_TEMPLATE: ServiceTemplate = {
-  hash: 'bafybeifuphhsarhdvymixytqmndwj4cwzs7azkgytvrzrkllgc4zqq3qoq',
-  service_version: 'v0.40.0-rc4',
+  hash: 'bafybeif5xjgk4tubgitdgi5mlvq3x3wf62vix337s66vrlmxlvqf7q6ioi',
+  service_version: 'v0.40.1',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'trader',
-      version: 'v0.40.0-rc4',
+      version: 'v0.40.1',
     },
   },
   agentType: AgentMap.PredictTrader,
@@ -144,14 +144,14 @@ export const PREDICT_SERVICE_TEMPLATE: ServiceTemplate = {
 } as const;
 
 export const PREDICT_POLYMARKET_SERVICE_TEMPLATE: ServiceTemplate = {
-  hash: 'bafybeif4r7ftadt5wz6k3abniud245yiazbmrivd4wr7mrqt2znudwgxpy',
-  service_version: 'v0.40.0-rc6',
+  hash: 'bafybeihhmwu4mqp5pliriiwepnkfebpy5us3zlsbtcmfwwcm77jtutctde',
+  service_version: 'v0.40.1',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'trader',
-      version: 'v0.40.0-rc6',
+      version: 'v0.40.1',
     },
   },
   agentType: AgentMap.Polystrat,

--- a/package.json
+++ b/package.json
@@ -111,6 +111,6 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.8.1-rc4",
+  "version": "1.8.1-rc5",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-app"
-version = "1.8.1-rc4"
+version = "1.8.1-rc5"
 description = ""
 authors = [
     { name = "David Vilela", email = "dvilelaf@gmail.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -1144,7 +1144,7 @@ wheels = [
 
 [[package]]
 name = "olas-operate-app"
-version = "1.8.1rc4"
+version = "1.8.1rc5"
 source = { virtual = "." }
 dependencies = [
     { name = "olas-operate-middleware" },


### PR DESCRIPTION
## Summary

- Basius: service hash, `service_version`, and `agent_release.version` bumped to `v0.12.4`
- Optimus: service hash, `service_version`, and `agent_release.version` bumped to `v0.12.4`
- Trader (Gnosis) and Trader (Polymarket): service hashes refreshed to the latest trader build

Shared `BABYDEGEN_COMMON_TEMPLATE` (Modius/Optimus fallback) is intentionally left at `v0.12.0-rc11` per the existing comment — this PR only touches the release-track templates.

## Test plan

- [ ] CI green
- [ ] Manual smoke test of Basius / Optimus / Trader / Polystrat spin-up on staging build