### PR TITLE
feat(connect): [VLOP-98] Beta tag + exclude Connect from auto-run

### DIFF
--- a/frontend/components/SetupPage/AgentOnboarding/SelectAgent.tsx
+++ b/frontend/components/SetupPage/AgentOnboarding/SelectAgent.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import { LuConstruction } from 'react-icons/lu';
 import styled from 'styled-components';
 
+import { BetaTag } from '@/components/ui';
 import { ACTIVE_AGENTS } from '@/config/agents';
 import { AgentMap, AgentType, COLOR } from '@/constants';
 import { useServices } from '@/hooks';
@@ -115,7 +116,10 @@ const SelectYourAgentList = ({
               height={36}
               style={{ borderRadius: 8, border: `1px solid ${COLOR.GRAY_3}` }}
             />
-            <Text style={{ flex: 1 }}>{agentConfig.displayName}</Text>
+            <Flex align="center" gap={8} style={{ flex: 1 }}>
+              <Text>{agentConfig.displayName}</Text>
+              {agentConfig.isBeta && <BetaTag />}
+            </Flex>
             <InstanceCount count={instanceCount} />
             {(agentConfig.isUnderConstruction ||
               agentConfig.isAddingNewBlocked) && <UnderConstructionIcon />}

--- a/frontend/components/ui/AgentTree.tsx
+++ b/frontend/components/ui/AgentTree.tsx
@@ -6,6 +6,8 @@ import styled from 'styled-components';
 import { AGENT_CONFIG } from '@/config/agents';
 import { AgentType, COLOR } from '@/constants';
 
+import { BetaTag } from './BetaTag';
+
 const { Text } = Typography;
 
 export const TreeLine = styled.div`
@@ -51,9 +53,12 @@ export const AgentGroupHeader = ({
         align="center"
         style={{ flex: 1, minWidth: 0 }}
       >
-        <Text ellipsis style={{ fontSize: 14, lineHeight: '20px' }}>
-          {config.displayName}
-        </Text>
+        <Flex align="center" gap={8} style={{ minWidth: 0 }}>
+          <Text ellipsis style={{ fontSize: 14, lineHeight: '20px' }}>
+            {config.displayName}
+          </Text>
+          {config.isBeta && <BetaTag />}
+        </Flex>
         {children}
       </Flex>
     </>

--- a/frontend/components/ui/BetaTag.tsx
+++ b/frontend/components/ui/BetaTag.tsx
@@ -1,0 +1,13 @@
+import { Tag } from 'antd';
+import styled from 'styled-components';
+
+const NoShrinkTag = styled(Tag)`
+  flex-shrink: 0;
+`;
+
+/** Gray "Beta" pill rendered next to an agent name (selection list, sidebar). */
+export const BetaTag = () => (
+  <NoShrinkTag bordered={false} className="m-0">
+    Beta
+  </NoShrinkTag>
+);

--- a/frontend/components/ui/index.ts
+++ b/frontend/components/ui/index.ts
@@ -3,6 +3,7 @@ export * from './AgentSetupCompleteModal';
 export * from './Alert';
 export * from './animations';
 export * from './BackButton';
+export * from './BetaTag';
 export * from './CardFlex';
 export * from './CardSection';
 export * from './Collapse';

--- a/frontend/config/agents.ts
+++ b/frontend/config/agents.ts
@@ -313,6 +313,8 @@ export const AGENT_CONFIG: {
   },
   [AgentMap.Connect]: {
     isAgentEnabled: true,
+    isBeta: true,
+    isExcludedFromAutoRun: true,
     requiresSetup: false,
     isX402Enabled: X402_ENABLED_FLAGS[AgentMap.Connect],
     name: 'Connect',

--- a/frontend/context/AutoRunProvider/AutoRunProvider.tsx
+++ b/frontend/context/AutoRunProvider/AutoRunProvider.tsx
@@ -123,8 +123,13 @@ export const AutoRunProvider = ({ children }: PropsWithChildren) => {
     [includedInstancesSorted],
   );
   const excludedInstances = useMemo(
-    () => getExcludedInstances(configuredInstances, includedInstancesForUi),
-    [configuredInstances, includedInstancesForUi],
+    () =>
+      getExcludedInstances(
+        configuredInstances,
+        includedInstancesForUi,
+        configExcludedInstances,
+      ),
+    [configuredInstances, includedInstancesForUi, configExcludedInstances],
   );
 
   // Eligibility for the currently selected agent.
@@ -376,11 +381,18 @@ export const AutoRunProvider = ({ children }: PropsWithChildren) => {
     for (const id of decommissionedInstances) {
       base[id] = { canRun: false, reason: 'Decommissioned' };
     }
+    const configExcludedSet = new Set(configExcludedInstances);
     for (const id of configExcludedInstances) {
       base[id] = { canRun: false, reason: 'Not available in auto-run' };
     }
     const excludedSet = new Set(excludedInstances);
-    if (selectedServiceConfigId && !excludedSet.has(selectedServiceConfigId)) {
+    if (
+      selectedServiceConfigId &&
+      !excludedSet.has(selectedServiceConfigId) &&
+      // Config-excluded instances stay blocked even while selected — live
+      // eligibility must never overwrite their canRun: false entry.
+      !configExcludedSet.has(selectedServiceConfigId)
+    ) {
       base[selectedServiceConfigId] = getSelectedEligibility();
     }
     return base;

--- a/frontend/context/AutoRunProvider/AutoRunProvider.tsx
+++ b/frontend/context/AutoRunProvider/AutoRunProvider.tsx
@@ -27,6 +27,7 @@ import { useSelectedEligibility } from './hooks/useSelectedEligibility';
 import { AutoRunContextType } from './types';
 import {
   appendNewInstances,
+  getAutoRunExcludedByConfig,
   getDecommissionedInstances,
   getEligibleInstances,
   getExcludedInstances,
@@ -84,15 +85,25 @@ export const AutoRunProvider = ({ children }: PropsWithChildren) => {
     () => getDecommissionedInstances(configuredAgents),
     [configuredAgents],
   );
+  const configExcludedInstances = useMemo(
+    () => getAutoRunExcludedByConfig(configuredAgents),
+    [configuredAgents],
+  );
   const { archivedInstances: archivedInstanceIds } = useArchivedAgents();
 
   const eligibleInstances = useMemo(
     () =>
       getEligibleInstances(configuredInstances, [
         ...decommissionedInstances,
+        ...configExcludedInstances,
         ...archivedInstanceIds,
       ]),
-    [configuredInstances, decommissionedInstances, archivedInstanceIds],
+    [
+      configuredInstances,
+      decommissionedInstances,
+      configExcludedInstances,
+      archivedInstanceIds,
+    ],
   );
   const includedInstancesSorted = useMemo(
     () =>
@@ -365,6 +376,9 @@ export const AutoRunProvider = ({ children }: PropsWithChildren) => {
     for (const id of decommissionedInstances) {
       base[id] = { canRun: false, reason: 'Decommissioned' };
     }
+    for (const id of configExcludedInstances) {
+      base[id] = { canRun: false, reason: 'Not available in auto-run' };
+    }
     const excludedSet = new Set(excludedInstances);
     if (selectedServiceConfigId && !excludedSet.has(selectedServiceConfigId)) {
       base[selectedServiceConfigId] = getSelectedEligibility();
@@ -373,6 +387,7 @@ export const AutoRunProvider = ({ children }: PropsWithChildren) => {
   }, [
     configuredAgents,
     decommissionedInstances,
+    configExcludedInstances,
     excludedInstances,
     getSelectedEligibility,
     selectedServiceConfigId,

--- a/frontend/context/AutoRunProvider/utils/utils.ts
+++ b/frontend/context/AutoRunProvider/utils/utils.ts
@@ -166,6 +166,16 @@ export const getDecommissionedInstances = (configuredAgents: AgentMeta[]) =>
     )
     .map((agent) => agent.serviceConfigId);
 
+/**
+ * Returns the service config IDs from `configuredAgents` whose agent config
+ * opts out of auto-run (`isExcludedFromAutoRun`), e.g. Connect. These are
+ * never auto-included and cannot be added to the rotation manually.
+ */
+export const getAutoRunExcludedByConfig = (configuredAgents: AgentMeta[]) =>
+  configuredAgents
+    .filter((agent) => agent.agentConfig.isExcludedFromAutoRun)
+    .map((agent) => agent.serviceConfigId);
+
 export const getEligibleInstances = (
   configuredInstances: string[],
   decommissionedInstances: string[],

--- a/frontend/context/AutoRunProvider/utils/utils.ts
+++ b/frontend/context/AutoRunProvider/utils/utils.ts
@@ -195,10 +195,19 @@ export const getOrderedIncludedInstances = (
   return eligibleInstances;
 };
 
+/**
+ * Instances that are neither included nor hidden. `hiddenInstances` holds
+ * config-excluded instances (`isExcludedFromAutoRun`, e.g. Connect) — those
+ * must not appear in the auto-run options at all, not even as blocked rows.
+ */
 export const getExcludedInstances = (
   configuredInstances: string[],
   orderedIncludedInstances: string[],
+  hiddenInstances: string[] = [],
 ) => {
   const includedSet = new Set(orderedIncludedInstances);
-  return configuredInstances.filter((id) => !includedSet.has(id));
+  const hiddenSet = new Set(hiddenInstances);
+  return configuredInstances.filter(
+    (id) => !includedSet.has(id) && !hiddenSet.has(id),
+  );
 };

--- a/frontend/tests/components/MainPage/Sidebar/AgentTreeMenu.test.tsx
+++ b/frontend/tests/components/MainPage/Sidebar/AgentTreeMenu.test.tsx
@@ -82,6 +82,20 @@ describe('AgentTreeMenu', () => {
     expect(screen.getByText('Optimus')).toBeInTheDocument();
   });
 
+  it('renders a Beta tag only for beta agents in the group header', () => {
+    const connectGroup = makeGroup(AgentMap.Connect, [
+      { serviceConfigId: 'sc-connect-1', name: 'fafon-norlo48' },
+    ]);
+    render(
+      <AgentTreeMenu
+        {...defaultProps}
+        groups={[traderGroup, optimusGroup, connectGroup]}
+      />,
+    );
+    expect(screen.getByText('Connect')).toBeInTheDocument();
+    expect(screen.getAllByText('Beta')).toHaveLength(1);
+  });
+
   it('auto-expands group containing selected instance', () => {
     render(<AgentTreeMenu {...defaultProps} />);
     // The trader group should be expanded because selected instance is in it

--- a/frontend/tests/components/SetupPage/AgentOnboarding/SelectAgent.test.tsx
+++ b/frontend/tests/components/SetupPage/AgentOnboarding/SelectAgent.test.tsx
@@ -40,6 +40,16 @@ jest.mock('../../../../config/agents', () => ({
         isUnderConstruction: false,
       },
     ],
+    [
+      'connect',
+      {
+        displayName: 'Connect',
+        servicePublicId: 'sp-3',
+        middlewareHomeChainId: 100,
+        isUnderConstruction: false,
+        isBeta: true,
+      },
+    ],
   ],
 }));
 
@@ -116,5 +126,15 @@ describe('SelectAgent', () => {
     render(<SelectAgent {...defaultProps} activeTab="new" />);
     expect(screen.getByText('Omenstrat')).toBeInTheDocument();
     expect(screen.getByText('Agents.fun')).toBeInTheDocument();
+  });
+
+  it('renders a Beta tag only for agents flagged isBeta', () => {
+    mockUseServices.mockReturnValue({
+      services: [],
+      getInstancesOfAgentType: () => [],
+    });
+    render(<SelectAgent {...defaultProps} activeTab="new" />);
+    expect(screen.getByText('Connect')).toBeInTheDocument();
+    expect(screen.getAllByText('Beta')).toHaveLength(1);
   });
 });

--- a/frontend/tests/context/AutoRunProvider/AutoRunProvider.test.tsx
+++ b/frontend/tests/context/AutoRunProvider/AutoRunProvider.test.tsx
@@ -311,7 +311,7 @@ describe('AutoRunProvider', () => {
       expect(seeded.map((item) => item.serviceConfigId)).toEqual([scTrader]);
     });
 
-    it('marks config-excluded instances as blocked and ignores includeInstance', () => {
+    it('hides config-excluded instances from the options and ignores includeInstance', () => {
       mockAutoRunStore.isInitialized = true;
       mockAutoRunStore.includedInstances = [
         { serviceConfigId: scTrader, order: 0 },
@@ -320,7 +320,11 @@ describe('AutoRunProvider', () => {
 
       const { result } = renderHook(() => useAutoRunContext(), { wrapper });
 
-      expect(result.current.excludedInstances).toContain(scConnect);
+      // Not in the rotation, and not even listed as an excluded option.
+      expect(
+        result.current.includedInstances.map((item) => item.serviceConfigId),
+      ).not.toContain(scConnect);
+      expect(result.current.excludedInstances).not.toContain(scConnect);
       expect(result.current.eligibilityByInstance[scConnect]).toEqual({
         canRun: false,
         reason: 'Not available in auto-run',
@@ -335,6 +339,32 @@ describe('AutoRunProvider', () => {
           ]),
         }),
       );
+    });
+
+    it('keeps a selected config-excluded instance blocked in eligibility', () => {
+      mockAutoRunStore.isInitialized = true;
+      mockAutoRunStore.includedInstances = [
+        { serviceConfigId: scTrader, order: 0 },
+      ];
+      useAutoRunStore.mockImplementation(() => ({ ...mockAutoRunStore }));
+      useServices.mockReturnValue({
+        services: [
+          { service_config_id: scTrader },
+          { service_config_id: scConnect },
+        ],
+        selectedAgentType: AgentMap.Connect,
+        selectedService: { service_config_id: scConnect },
+        selectedServiceConfigId: scConnect,
+        updateSelectedServiceConfigId: mockUpdateSelectedServiceConfigId,
+      });
+
+      const { result } = renderHook(() => useAutoRunContext(), { wrapper });
+
+      // Live selected-eligibility (permissive) must not overwrite the block.
+      expect(result.current.eligibilityByInstance[scConnect]).toEqual({
+        canRun: false,
+        reason: 'Not available in auto-run',
+      });
     });
   });
 

--- a/frontend/tests/context/AutoRunProvider/AutoRunProvider.test.tsx
+++ b/frontend/tests/context/AutoRunProvider/AutoRunProvider.test.tsx
@@ -12,6 +12,7 @@ import { IncludedAgentInstance } from '../../../context/AutoRunProvider/types';
 import {
   DEFAULT_SERVICE_CONFIG_ID,
   MOCK_SERVICE_CONFIG_ID_2,
+  MOCK_SERVICE_CONFIG_ID_3,
 } from '../../helpers/factories';
 
 // --- Mutable mock state ---
@@ -265,6 +266,75 @@ describe('AutoRunProvider', () => {
         (call: [Record<string, unknown>]) => call[0]?.isInitialized === true,
       );
       expect(seedCalls).toHaveLength(0);
+    });
+  });
+
+  describe('config-excluded agents (isExcludedFromAutoRun)', () => {
+    const scConnect = MOCK_SERVICE_CONFIG_ID_3;
+
+    beforeEach(() => {
+      useServices.mockReturnValue({
+        services: [
+          { service_config_id: scTrader },
+          { service_config_id: scConnect },
+        ],
+        selectedAgentType: AgentMap.PredictTrader,
+        selectedService: { service_config_id: scTrader },
+        selectedServiceConfigId: scTrader,
+        updateSelectedServiceConfigId: mockUpdateSelectedServiceConfigId,
+      });
+      useConfiguredAgents.mockReturnValue([
+        {
+          agentType: AgentMap.PredictTrader,
+          agentConfig: AGENT_CONFIG[AgentMap.PredictTrader],
+          serviceConfigId: scTrader,
+        },
+        {
+          agentType: AgentMap.Connect,
+          agentConfig: AGENT_CONFIG[AgentMap.Connect],
+          serviceConfigId: scConnect,
+        },
+      ]);
+    });
+
+    it('does not seed config-excluded instances into the rotation', () => {
+      mockAutoRunStore.isInitialized = false;
+      useAutoRunStore.mockImplementation(() => ({ ...mockAutoRunStore }));
+
+      renderHook(() => useAutoRunContext(), { wrapper });
+
+      const seedCall = mockAutoRunStore.updateAutoRun.mock.calls.find(
+        (call: [Record<string, unknown>]) => call[0]?.isInitialized === true,
+      );
+      expect(seedCall).toBeDefined();
+      const seeded = seedCall![0].includedInstances as IncludedAgentInstance[];
+      expect(seeded.map((item) => item.serviceConfigId)).toEqual([scTrader]);
+    });
+
+    it('marks config-excluded instances as blocked and ignores includeInstance', () => {
+      mockAutoRunStore.isInitialized = true;
+      mockAutoRunStore.includedInstances = [
+        { serviceConfigId: scTrader, order: 0 },
+      ];
+      useAutoRunStore.mockImplementation(() => ({ ...mockAutoRunStore }));
+
+      const { result } = renderHook(() => useAutoRunContext(), { wrapper });
+
+      expect(result.current.excludedInstances).toContain(scConnect);
+      expect(result.current.eligibilityByInstance[scConnect]).toEqual({
+        canRun: false,
+        reason: 'Not available in auto-run',
+      });
+
+      act(() => result.current.includeInstance(scConnect));
+
+      expect(mockAutoRunStore.updateAutoRun).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          includedInstances: expect.arrayContaining([
+            expect.objectContaining({ serviceConfigId: scConnect }),
+          ]),
+        }),
+      );
     });
   });
 

--- a/frontend/tests/context/AutoRunProvider/utils/utils.test.ts
+++ b/frontend/tests/context/AutoRunProvider/utils/utils.test.ts
@@ -433,4 +433,16 @@ describe('getExcludedInstances', () => {
     const result = getExcludedInstances(configured, configured);
     expect(result).toEqual([]);
   });
+
+  it('omits hidden (config-excluded) instances entirely', () => {
+    const configured = [
+      DEFAULT_SERVICE_CONFIG_ID,
+      MOCK_SERVICE_CONFIG_ID_2,
+      MOCK_SERVICE_CONFIG_ID_3,
+    ];
+    const included = [DEFAULT_SERVICE_CONFIG_ID];
+    const hidden = [MOCK_SERVICE_CONFIG_ID_3];
+    const result = getExcludedInstances(configured, included, hidden);
+    expect(result).toEqual([MOCK_SERVICE_CONFIG_ID_2]);
+  });
 });

--- a/frontend/tests/context/AutoRunProvider/utils/utils.test.ts
+++ b/frontend/tests/context/AutoRunProvider/utils/utils.test.ts
@@ -6,6 +6,7 @@ import {
   appendNewInstances,
   getAgentDisplayName,
   getAgentFromService,
+  getAutoRunExcludedByConfig,
   getDecommissionedInstances,
   getEligibleInstances,
   getExcludedInstances,
@@ -314,6 +315,32 @@ describe('getDecommissionedInstances', () => {
       ),
     ];
     expect(getDecommissionedInstances(agents)).toEqual([]);
+  });
+});
+
+describe('getAutoRunExcludedByConfig', () => {
+  it('returns serviceConfigIds of agents excluded from auto-run by config', () => {
+    const agents = [
+      makeAutoRunAgentMeta(AgentMap.Connect, AGENT_CONFIG[AgentMap.Connect]),
+      makeAutoRunAgentMeta(
+        AgentMap.PredictTrader,
+        AGENT_CONFIG[AgentMap.PredictTrader],
+        MOCK_SERVICE_CONFIG_ID_2,
+      ),
+    ];
+    expect(getAutoRunExcludedByConfig(agents)).toEqual([
+      DEFAULT_SERVICE_CONFIG_ID,
+    ]);
+  });
+
+  it('returns empty when no agent opts out of auto-run', () => {
+    const agents = [
+      makeAutoRunAgentMeta(
+        AgentMap.PredictTrader,
+        AGENT_CONFIG[AgentMap.PredictTrader],
+      ),
+    ];
+    expect(getAutoRunExcludedByConfig(agents)).toEqual([]);
   });
 });
 

--- a/frontend/types/Agent.ts
+++ b/frontend/types/Agent.ts
@@ -76,6 +76,13 @@ export type AgentConfig = {
    * `shutdownDate` (sunsetting — still runs until the date).
    */
   isPhasedOut?: boolean;
+  /** Renders a "Beta" tag next to the agent name (agent selection + sidebar) */
+  isBeta?: boolean;
+  /**
+   * Keeps the agent's instances out of the auto-run rotation (never
+   * auto-included; the include button is disabled). Manual start still works.
+   */
+  isExcludedFromAutoRun?: boolean;
   /** Whether the agent is enabled and can be shown in the UI */
   isAgentEnabled: boolean;
   /** If agent is enabled but not yet available to use */


### PR DESCRIPTION
## Summary

PR 3 of the Connect agent plan ([docs/explorations/connect-agent-plan.md](https://github.com/valory-xyz/olas-operate-app/blob/feat/connect-agent/docs/explorations/connect-agent-plan.md), §9). Follows #2068 (merged).

### Beta tag
- New `AgentConfig.isBeta` flag, set on Connect.
- New shared `BetaTag` ui component (gray borderless antd `Tag`, exported from the `@/components/ui` barrel).
- Rendered in the **Select Your Agent** list (`SelectAgent`) and in **`AgentGroupHeader`** — the single render point for group headers, so it covers both the sidebar tree and the auto-run popover.

### Auto-run exclusion
- New `AgentConfig.isExcludedFromAutoRun` flag, set on Connect, plus `getAutoRunExcludedByConfig` util merged into the auto-run blocked set.
- Effects: Connect instances are never auto-seeded into the rotation, are dropped if already included, `includeInstance` no-ops, and they are **hidden from the popover options entirely** (not shown as blocked "excluded" rows) — `getExcludedInstances` gained a `hiddenInstances` param.
- `eligibilityByInstance` pins them to `canRun: false` / "Not available in auto-run"; live selected-instance eligibility cannot overwrite the block.
- Manual start is untouched (matters for PR 4, which makes Connect runnable).

## Tests
- Beta tag rendering: `SelectAgent.test.tsx`, `AgentTreeMenu.test.tsx` (tag renders only for beta agents).
- `getAutoRunExcludedByConfig` + `getExcludedInstances` hidden-param unit tests.
- Provider-level: Connect not seeded, not listed in included/excluded options, `includeInstance` ignored, eligibility stays blocked while selected.
- `tsc --noEmit` clean, eslint 0 errors, all affected suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)