### PR TITLE
chore(services): bump polymarket_trader to v0.40.2

### DIFF
--- a/frontend/constants/serviceTemplates/service/trader.ts
+++ b/frontend/constants/serviceTemplates/service/trader.ts
@@ -144,14 +144,14 @@ export const PREDICT_SERVICE_TEMPLATE: ServiceTemplate = {
 } as const;
 
 export const PREDICT_POLYMARKET_SERVICE_TEMPLATE: ServiceTemplate = {
-  hash: 'bafybeifdwuq5dlzb4wnwb45h54zo7owlkj6ogrpw74mqnxtdgokiim67t4',
-  service_version: 'v0.40.1',
+  hash: 'bafybeigmltj5g6ewucxtctvptbbkfpapntpqmq5n6mshfwsbvz776htrzy',
+  service_version: 'v0.40.2',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'trader',
-      version: 'v0.40.1',
+      version: 'v0.40.2',
     },
   },
   agentType: AgentMap.Polystrat,

--- a/package.json
+++ b/package.json
@@ -111,6 +111,6 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.8.1-rc5",
+  "version": "1.8.1-rc6",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-app"
-version = "1.8.1-rc5"
+version = "1.8.1-rc6"
 description = ""
 authors = [
     { name = "David Vilela", email = "dvilelaf@gmail.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -1144,7 +1144,7 @@ wheels = [
 
 [[package]]
 name = "olas-operate-app"
-version = "1.8.1rc5"
+version = "1.8.1rc6"
 source = { virtual = "." }
 dependencies = [
     { name = "olas-operate-middleware" },


### PR DESCRIPTION
## Summary
- Bumps the Polystrat (`polymarket_trader`) service hash and version to trader release [v0.40.2](https://github.com/valory-xyz/trader/releases/tag/v0.40.2).
- v0.40.2 restores `max_edge = 0.30` for Polymarket (trader PR #1010) — the widening from #1004 that was lost in an earlier conflict resolution.
- Omenstrat (`trader_pearl`) hash is unchanged in v0.40.2, so only the Polystrat template is touched here.

## Test plan
- [ ] Frontend build passes
- [ ] Verify Polystrat template resolves to the new hash on staging