### PR TITLE
chore(deps): bump adm-zip to 0.6.0 (GHSA-xcpc-8h2w-3j85)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@ant-design/icons": "5.6.1",
     "@fontsource/inter": "5.2.6",
     "@tanstack/react-query": "5.85.5",
-    "adm-zip": "0.5.16",
+    "adm-zip": "0.6.0",
     "antd": "5.27.4",
     "child_process": "1.0.2",
     "cross-env": "7.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1618,10 +1618,10 @@ acorn@^8.9.0:
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
 
-adm-zip@0.5.16:
-  version "0.5.16"
-  resolved "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz#0b5e4c779f07dedea5805cdccb1147071d94a909"
-  integrity sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==
+adm-zip@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz#bbc5c6c333755e967a06dd98747f431e1d53a3cf"
+  integrity sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==
 
 adm-zip@^0.4.16:
   version "0.4.16"


### PR DESCRIPTION
## Why

CI's `yarn audit (both trees)` job fails on `feat/connect-agent` (and any other branch) at **Audit root tree**:

```
1 HIGH/CRITICAL advisory/advisories in the production tree are not allowlisted:
  [high] adm-zip <0.6.0 → fix in >=0.6.0
  advisory 1123686 (GHSA-xcpc-8h2w-3j85)
  adm-zip: Crafted ZIP file triggers 4GB memory allocation
```

`package.json` pinned `0.5.16`; `0.6.0` is the first fixed release. This blocks the `Create Feature Release` workflow, whose `guard-ci-passed` step requires a green CI run on the release commit.

## What

Bump the exact pin to `0.6.0` and refresh `yarn.lock`. No allowlist entry — the advisory is fixable, so it should not become suppressed debt.

## Risk

Our only consumer is `electron/features/logs.js`, which builds support-log archives via `addLocalFile` / `writeZip`. Both are unchanged in 0.6.0; `engines: node >=14`. Round-tripped a zip locally on the new version.

The remaining `adm-zip@^0.4.16` in the lockfile comes from Hardhat (dev-only) and is outside the production audit scope.

## Verification

- `yarn audit:prod` — OK, root and frontend trees
- `yarn deps:check-pinned` — OK (71 exact-pinned specifiers)
- `yarn license-check` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)