### PR TITLE
feat: [OPE-1840] enable transaction history on Base

### DIFF
--- a/docs/features/transaction-history.md
+++ b/docs/features/transaction-history.md
@@ -36,6 +36,18 @@ pearl-transactions subgraph (Gnosis | Polygon | Optimism | Base)
                     └── <HistoryTab /> in BalancesAndAssets
 ```
 
+## Subgraph schema revisions (v1 / v2)
+
+Live deployments serve two incompatible schema revisions (2026-07): Gnosis/Optimism proxies pin subgraph **v0.0.6 (v1)**, Base pins **v0.0.7 (v2)** — its indexers no longer serve v0.0.6. Differences (verified against the live Base deployment, not the subgraph README):
+
+| | v1 (v0.0.6) | v2 (v0.0.7) |
+|---|---|---|
+| Bond rows | `fundsMovements` with `bondType` | separate `bondMovements` ledger (carries `bondType`) |
+| OLAS reward sweeps | `AGENT_TO_MASTER`, hidden client-side (`isOlasAgentToMaster`) | pre-split `AGENT_OLAS_TO_MASTER`, excluded by the query's category filter |
+| `Service.id` | numeric string | registry Bytes (`"0x7802"`); numeric id in new `serviceId` field |
+
+Mechanism: `TRANSACTION_HISTORY_SUBGRAPH_SCHEMA_BY_EVM_CHAIN` (`frontend/constants/urls.ts`) maps chain → revision (absent = v1). Both services pick the matching query document, Zod-parse with the matching schema, and — for v2 — normalize to the v1-shaped domain types via `normalize*V2` in `frontend/utils/transactionHistory.ts` (bond rows merged into `fundsMovements`, sweep rows dropped, `service.id` mapped from `serviceId`). Hooks and components are revision-agnostic. Migrating a chain to v0.0.7 = flip its map entry.
+
 ## New files
 
 | File | Purpose |

--- a/frontend/constants/urls.ts
+++ b/frontend/constants/urls.ts
@@ -41,7 +41,7 @@ export const TRANSACTION_HISTORY_SUBGRAPH_URLS_BY_EVM_CHAIN: Partial<
   [EvmChainIdMap.Polygon]: undefined,
   [EvmChainIdMap.Optimism]:
     'https://transactions-optimism.subgraph.autonolas.tech/',
-  [EvmChainIdMap.Base]: undefined,
+  [EvmChainIdMap.Base]: 'https://transactions-base.subgraph.autonolas.tech/',
 };
 
 // telegram

--- a/frontend/constants/urls.ts
+++ b/frontend/constants/urls.ts
@@ -1,3 +1,5 @@
+import { TransactionHistorySchemaRevision } from '@/types/TransactionHistory';
+
 import {
   EvmChainId,
   EvmChainIdMap,
@@ -43,6 +45,22 @@ export const TRANSACTION_HISTORY_SUBGRAPH_URLS_BY_EVM_CHAIN: Partial<
     'https://transactions-optimism.subgraph.autonolas.tech/',
   [EvmChainIdMap.Base]: 'https://transactions-base.subgraph.autonolas.tech/',
 };
+
+// Which pearl-transactions schema each chain's deployment serves (see
+// TransactionHistorySchemaRevision). Gnosis/Optimism proxies pin subgraph
+// v0.0.6 (v1); Base pins v0.0.7 (v2) — its indexers no longer serve v0.0.6.
+// When a chain's proxy migrates to v0.0.7, flip its entry here; absent
+// entries default to v1.
+export const TRANSACTION_HISTORY_SUBGRAPH_SCHEMA_BY_EVM_CHAIN: Partial<
+  Record<EvmChainId, TransactionHistorySchemaRevision>
+> = {
+  [EvmChainIdMap.Base]: 'v2',
+};
+
+export const getTransactionHistorySchemaRevision = (
+  chainId: EvmChainId,
+): TransactionHistorySchemaRevision =>
+  TRANSACTION_HISTORY_SUBGRAPH_SCHEMA_BY_EVM_CHAIN[chainId] ?? 'v1';
 
 // telegram
 export const SUPPORT_URL: Url = 'https://t.me/olaschat';

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
     "lodash-es": "4.18.1",
     "minimatch": "9.0.9",
     "picomatch": "4.0.4",
-    "postcss": "8.5.10",
+    "postcss": "8.5.12",
     "sharp": "0.35.3",
     "tar": "7.5.16",
     "ws": "8.21.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
     "graphql-request": "6.1.0",
     "lodash": "4.18.1",
     "lottie-react": "2.4.1",
-    "next": "15.5.18",
+    "next": "15.5.21",
     "react": "18.3.1",
     "react-canvas-confetti": "1.2.1",
     "react-dom": "18.3.1",

--- a/frontend/service/AgentTransactionHistory.ts
+++ b/frontend/service/AgentTransactionHistory.ts
@@ -1,12 +1,19 @@
 import { gql, request } from 'graphql-request';
 
 import { EvmChainId } from '@/constants/chains';
-import { TRANSACTION_HISTORY_SUBGRAPH_URLS_BY_EVM_CHAIN } from '@/constants/urls';
+import {
+  getTransactionHistorySchemaRevision,
+  TRANSACTION_HISTORY_SUBGRAPH_URLS_BY_EVM_CHAIN,
+} from '@/constants/urls';
 import { Address } from '@/types/Address';
 import {
   AgentTransactionHistoryResponse,
   AgentTransactionHistoryResponseSchema,
+  AgentTransactionHistoryResponseV2Schema,
 } from '@/types/TransactionHistory';
+// Deep import (not the '@/utils' barrel): config/chains pulls the barrel at
+// module init, so barrel-importing here forms a cycle that breaks test loads.
+import { normalizeAgentTransactionHistoryResponseV2 } from '@/utils/transactionHistory';
 
 const FETCH_AGENT_TRANSACTION_HISTORY_QUERY = gql`
   query GetAgentTransactionHistory(
@@ -56,6 +63,59 @@ const FETCH_AGENT_TRANSACTION_HISTORY_QUERY = gql`
   }
 `;
 
+// v2 (subgraph v0.0.7) variant: no `bondType` on FundsMovement, service refs
+// carry the numeric id in `serviceId`. The category filter is unchanged — on
+// v2 OLAS reward sweeps are categorized AGENT_OLAS_TO_MASTER, so the same
+// filter now excludes them server-side (v1 hides them client-side).
+const FETCH_AGENT_TRANSACTION_HISTORY_QUERY_V2 = gql`
+  query GetAgentTransactionHistoryV2(
+    $agentSafe: Bytes!
+    $first: Int!
+    $skip: Int!
+  ) {
+    fundsMovements(
+      where: {
+        agentSafe: $agentSafe
+        category_in: [MASTER_TO_AGENT, AGENT_TO_MASTER]
+      }
+      orderBy: blockTimestamp
+      orderDirection: desc
+      first: $first
+      skip: $skip
+    ) {
+      id
+      category
+      source
+      token
+      amount
+      from
+      to
+      blockTimestamp
+      transactionHash
+      agentSafe {
+        id
+        service {
+          id
+          serviceId
+          agentIds
+        }
+      }
+      service {
+        id
+        serviceId
+        agentIds
+      }
+    }
+    _meta {
+      block {
+        number
+        timestamp
+      }
+      hasIndexingErrors
+    }
+  }
+`;
+
 type GetAgentTransactionHistoryParams = {
   chainId: EvmChainId;
   agentSafe: Address;
@@ -78,12 +138,24 @@ const get = async ({
     );
   }
 
-  const raw = await request(url, FETCH_AGENT_TRANSACTION_HISTORY_QUERY, {
-    agentSafe: agentSafe.toLowerCase(),
-    first,
-    skip,
-  });
+  const variables = { agentSafe: agentSafe.toLowerCase(), first, skip };
 
+  if (getTransactionHistorySchemaRevision(chainId) === 'v2') {
+    const raw = await request(
+      url,
+      FETCH_AGENT_TRANSACTION_HISTORY_QUERY_V2,
+      variables,
+    );
+    return normalizeAgentTransactionHistoryResponseV2(
+      AgentTransactionHistoryResponseV2Schema.parse(raw),
+    );
+  }
+
+  const raw = await request(
+    url,
+    FETCH_AGENT_TRANSACTION_HISTORY_QUERY,
+    variables,
+  );
   return AgentTransactionHistoryResponseSchema.parse(raw);
 };
 

--- a/frontend/service/TransactionHistory.ts
+++ b/frontend/service/TransactionHistory.ts
@@ -1,12 +1,19 @@
 import { gql, request } from 'graphql-request';
 
 import { EvmChainId } from '@/constants/chains';
-import { TRANSACTION_HISTORY_SUBGRAPH_URLS_BY_EVM_CHAIN } from '@/constants/urls';
+import {
+  getTransactionHistorySchemaRevision,
+  TRANSACTION_HISTORY_SUBGRAPH_URLS_BY_EVM_CHAIN,
+} from '@/constants/urls';
 import { Address } from '@/types/Address';
 import {
   TransactionHistoryResponse,
   TransactionHistoryResponseSchema,
+  TransactionHistoryResponseV2Schema,
 } from '@/types/TransactionHistory';
+// Deep import (not the '@/utils' barrel): config/chains pulls the barrel at
+// module init, so barrel-importing here forms a cycle that breaks test loads.
+import { normalizeTransactionHistoryResponseV2 } from '@/utils/transactionHistory';
 
 const FETCH_TRANSACTION_HISTORY_QUERY = gql`
   query GetTransactionHistory($masterSafe: Bytes!, $first: Int!, $skip: Int!) {
@@ -103,6 +110,142 @@ const FETCH_TRANSACTION_HISTORY_QUERY = gql`
   }
 `;
 
+// v2 (subgraph v0.0.7) variant. Differences from v1: FundsMovement has no
+// `bondType` and no SERVICE_BOND_* rows — bonds live on the separate
+// `bondMovements` ledger (queried alongside and merged during normalization);
+// OLAS reward sweeps arrive pre-split as AGENT_OLAS_TO_MASTER (excluded by the
+// category filter, matching v1's client-side hiding); service refs carry the
+// numeric id in `serviceId`.
+const FETCH_TRANSACTION_HISTORY_QUERY_V2 = gql`
+  query GetTransactionHistoryV2(
+    $masterSafe: Bytes!
+    $first: Int!
+    $skip: Int!
+  ) {
+    masterSafe(id: $masterSafe) {
+      id
+      masterEoa
+      owners
+      threshold
+      historyFloorBlock
+      historyFloorTimestamp
+    }
+    fundsMovements(
+      where: {
+        masterSafe: $masterSafe
+        category_in: [
+          MASTER_FUNDING_IN
+          AGENT_TO_MASTER
+          MASTER_TO_AGENT
+          MASTER_WITHDRAWAL
+        ]
+      }
+      orderBy: blockTimestamp
+      orderDirection: desc
+      first: $first
+      skip: $skip
+    ) {
+      id
+      category
+      source
+      token
+      amount
+      from
+      to
+      blockTimestamp
+      transactionHash
+      agentSafe {
+        id
+        service {
+          id
+          serviceId
+          agentIds
+        }
+      }
+      service {
+        id
+        serviceId
+        agentIds
+      }
+    }
+    bondMovements(
+      where: { masterSafe: $masterSafe }
+      orderBy: blockTimestamp
+      orderDirection: desc
+      first: $first
+      skip: $skip
+    ) {
+      id
+      category
+      source
+      bondType
+      token
+      amount
+      from
+      to
+      blockTimestamp
+      transactionHash
+      agentSafe {
+        id
+        service {
+          id
+          serviceId
+          agentIds
+        }
+      }
+      service {
+        id
+        serviceId
+        agentIds
+      }
+    }
+    agentFundingEvents(
+      where: { masterSafe: $masterSafe }
+      orderBy: blockTimestamp
+      orderDirection: desc
+      first: $first
+      skip: $skip
+    ) {
+      id
+      txHash
+      blockTimestamp
+      totalNativeAmount
+      totalOlasAmount
+      transfers {
+        id
+        category
+        source
+        token
+        amount
+        from
+        to
+        blockTimestamp
+        transactionHash
+        agentSafe {
+          id
+          service {
+            id
+            serviceId
+            agentIds
+          }
+        }
+        service {
+          id
+          serviceId
+          agentIds
+        }
+      }
+    }
+    _meta {
+      block {
+        number
+        timestamp
+      }
+      hasIndexingErrors
+    }
+  }
+`;
+
 const DEFAULT_PAGE_SIZE = 100;
 
 type GetTransactionHistoryParams = {
@@ -125,12 +268,20 @@ const get = async ({
     );
   }
 
-  const raw = await request(url, FETCH_TRANSACTION_HISTORY_QUERY, {
-    masterSafe: masterSafe.toLowerCase(),
-    first,
-    skip,
-  });
+  const variables = { masterSafe: masterSafe.toLowerCase(), first, skip };
 
+  if (getTransactionHistorySchemaRevision(chainId) === 'v2') {
+    const raw = await request(
+      url,
+      FETCH_TRANSACTION_HISTORY_QUERY_V2,
+      variables,
+    );
+    return normalizeTransactionHistoryResponseV2(
+      TransactionHistoryResponseV2Schema.parse(raw),
+    );
+  }
+
+  const raw = await request(url, FETCH_TRANSACTION_HISTORY_QUERY, variables);
   return TransactionHistoryResponseSchema.parse(raw);
 };
 

--- a/frontend/tests/helpers/factories.ts
+++ b/frontend/tests/helpers/factories.ts
@@ -33,10 +33,16 @@ import { WalletBalance } from '../../types/Balance';
 import { MiddlewareServiceResponse, Service } from '../../types/Service';
 import {
   AgentFundingEvent,
+  AgentFundingEventV2,
+  AgentTransactionHistoryResponseV2,
+  BondMovementV2,
   FundsMovement,
+  FundsMovementV2,
   MasterSafeEntity,
+  ServiceRefV2,
   SubgraphMeta,
   TransactionHistoryResponse,
+  TransactionHistoryResponseV2,
 } from '../../types/TransactionHistory';
 import { TokenRequirement } from '../../types/Wallet';
 
@@ -622,6 +628,99 @@ export const makeTransactionHistoryResponse = (
   masterSafe: makeMasterSafeEntity(),
   fundsMovements: [],
   agentFundingEvents: [],
+  _meta: makeSubgraphMeta(),
+  ...overrides,
+});
+
+// --- v2 (subgraph v0.0.7) raw-response factories ----------------------------
+// Field values mirror real Base deployment responses. NB: v2 Service.id is
+// registry Bytes unrelated to the numeric id (deliberately mismatched here so
+// code reading `.id` instead of `.serviceId` fails tests).
+export const makeServiceRefV2 = (
+  overrides: Partial<ServiceRefV2> = {},
+): ServiceRefV2 => ({
+  id: '0x7802',
+  serviceId: '42',
+  agentIds: [25],
+  ...overrides,
+});
+
+export const makeFundsMovementV2 = (
+  overrides: Partial<FundsMovementV2> = {},
+): FundsMovementV2 => ({
+  id: `${MOCK_TX_HASH_1}-0`,
+  category: 'MASTER_FUNDING_IN',
+  source: 'RAW_TRANSFER',
+  token: null,
+  amount: '1000000000000000000',
+  from: DEFAULT_EOA_ADDRESS,
+  to: DEFAULT_SAFE_ADDRESS,
+  blockTimestamp: `${DEFAULT_TS_CHECKPOINT}`,
+  transactionHash: MOCK_TX_HASH_1,
+  agentSafe: null,
+  ...overrides,
+});
+
+export const makeBondMovementV2 = (
+  overrides: Partial<BondMovementV2> = {},
+): BondMovementV2 => ({
+  ...makeFundsMovementV2({
+    id: `${MOCK_TX_HASH_2}-0`,
+    category: 'SERVICE_BOND_DEPOSIT',
+    token: MOCK_OLAS_TOKEN_ADDRESS,
+    amount: '2500000000000000000000',
+    from: DEFAULT_SAFE_ADDRESS,
+    transactionHash: MOCK_TX_HASH_2,
+    service: makeServiceRefV2(),
+  }),
+  bondType: 'AGENT_BOND',
+  ...overrides,
+});
+
+export const makeAgentFundingEventV2 = (
+  overrides: Partial<AgentFundingEventV2> = {},
+): AgentFundingEventV2 => {
+  const txHash = overrides.txHash ?? MOCK_TX_HASH_2;
+  return {
+    id: `${txHash}-${DEFAULT_SAFE_ADDRESS}-42`.toLowerCase(),
+    txHash,
+    blockTimestamp: `${DEFAULT_TS_CHECKPOINT}`,
+    totalNativeAmount: '0',
+    totalOlasAmount: '0',
+    transfers: [
+      makeFundsMovementV2({
+        id: `${txHash}-0`,
+        category: 'MASTER_TO_AGENT',
+        token: MOCK_USDC_E_TOKEN_ADDRESS,
+        amount: '5000000',
+        from: DEFAULT_SAFE_ADDRESS,
+        to: MOCK_MULTISIG_ADDRESS,
+        transactionHash: txHash,
+        agentSafe: {
+          id: MOCK_MULTISIG_ADDRESS,
+          service: makeServiceRefV2(),
+        },
+      }),
+    ],
+    ...overrides,
+  };
+};
+
+export const makeTransactionHistoryResponseV2 = (
+  overrides: Partial<TransactionHistoryResponseV2> = {},
+): TransactionHistoryResponseV2 => ({
+  masterSafe: makeMasterSafeEntity(),
+  fundsMovements: [],
+  bondMovements: [],
+  agentFundingEvents: [],
+  _meta: makeSubgraphMeta(),
+  ...overrides,
+});
+
+export const makeAgentTransactionHistoryResponseV2 = (
+  overrides: Partial<AgentTransactionHistoryResponseV2> = {},
+): AgentTransactionHistoryResponseV2 => ({
+  fundsMovements: [],
   _meta: makeSubgraphMeta(),
   ...overrides,
 });

--- a/frontend/tests/service/AgentTransactionHistory.test.ts
+++ b/frontend/tests/service/AgentTransactionHistory.test.ts
@@ -1,0 +1,98 @@
+import { EvmChainIdMap } from '../../constants/chains';
+import {
+  TRANSACTION_HISTORY_SUBGRAPH_SCHEMA_BY_EVM_CHAIN,
+  TRANSACTION_HISTORY_SUBGRAPH_URLS_BY_EVM_CHAIN,
+} from '../../constants/urls';
+import { AgentTransactionHistoryService } from '../../service/AgentTransactionHistory';
+import {
+  makeAgentTransactionHistoryResponseV2,
+  makeFundsMovementV2,
+  makeServiceRefV2,
+  MOCK_MULTISIG_ADDRESS,
+  MOCK_OLAS_TOKEN_ADDRESS,
+  MOCK_USDC_E_TOKEN_ADDRESS,
+} from '../helpers/factories';
+
+const mockGraphqlRequest = jest.fn();
+jest.mock('graphql-request', () => ({
+  request: (...args: unknown[]) => mockGraphqlRequest(...args),
+  gql: (strings: TemplateStringsArray, ...values: unknown[]) =>
+    String.raw({ raw: strings }, ...values),
+}));
+
+describe('AgentTransactionHistoryService.get (v2 schema)', () => {
+  const URL = 'https://pearl-transactions.subgraph.example';
+
+  beforeEach(() => {
+    TRANSACTION_HISTORY_SUBGRAPH_URLS_BY_EVM_CHAIN[EvmChainIdMap.Base] = URL;
+    TRANSACTION_HISTORY_SUBGRAPH_SCHEMA_BY_EVM_CHAIN[EvmChainIdMap.Base] = 'v2';
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+    delete TRANSACTION_HISTORY_SUBGRAPH_URLS_BY_EVM_CHAIN[EvmChainIdMap.Base];
+    delete TRANSACTION_HISTORY_SUBGRAPH_SCHEMA_BY_EVM_CHAIN[EvmChainIdMap.Base];
+  });
+
+  it('sends the v2 query (no bondType selection) with lowercased agentSafe', async () => {
+    mockGraphqlRequest.mockResolvedValueOnce(
+      makeAgentTransactionHistoryResponseV2(),
+    );
+
+    await AgentTransactionHistoryService.get({
+      chainId: EvmChainIdMap.Base,
+      agentSafe: MOCK_MULTISIG_ADDRESS,
+    });
+
+    const [url, query, variables] = mockGraphqlRequest.mock.calls[0];
+    expect(url).toBe(URL);
+    expect(query).toContain('GetAgentTransactionHistoryV2');
+    expect(query).not.toContain('bondType');
+    expect(variables).toEqual({
+      agentSafe: MOCK_MULTISIG_ADDRESS.toLowerCase(),
+      first: 100,
+      skip: 0,
+    });
+  });
+
+  it('normalizes the v2 response to the domain shape', async () => {
+    mockGraphqlRequest.mockResolvedValueOnce(
+      makeAgentTransactionHistoryResponseV2({
+        fundsMovements: [
+          makeFundsMovementV2({
+            id: 'withdrawal',
+            category: 'AGENT_TO_MASTER',
+            token: MOCK_USDC_E_TOKEN_ADDRESS,
+            service: makeServiceRefV2({ id: '0x7802', serviceId: '632' }),
+          }),
+          makeFundsMovementV2({
+            id: 'sweep',
+            category: 'AGENT_OLAS_TO_MASTER',
+            token: MOCK_OLAS_TOKEN_ADDRESS,
+          }),
+        ],
+      }),
+    );
+
+    const result = await AgentTransactionHistoryService.get({
+      chainId: EvmChainIdMap.Base,
+      agentSafe: MOCK_MULTISIG_ADDRESS,
+    });
+
+    expect(result.fundsMovements.map((m) => m.id)).toEqual(['withdrawal']);
+    expect(result.fundsMovements[0].service?.id).toBe('632');
+  });
+
+  it('throws when a v1-shaped chain sends malformed v2 data', async () => {
+    mockGraphqlRequest.mockResolvedValueOnce({
+      fundsMovements: [{ id: 'broken' }],
+      _meta: null,
+    });
+
+    await expect(
+      AgentTransactionHistoryService.get({
+        chainId: EvmChainIdMap.Base,
+        agentSafe: MOCK_MULTISIG_ADDRESS,
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/frontend/tests/service/TransactionHistory.test.ts
+++ b/frontend/tests/service/TransactionHistory.test.ts
@@ -1,11 +1,19 @@
 import { EvmChainIdMap } from '../../constants/chains';
-import { TRANSACTION_HISTORY_SUBGRAPH_URLS_BY_EVM_CHAIN } from '../../constants/urls';
+import {
+  TRANSACTION_HISTORY_SUBGRAPH_SCHEMA_BY_EVM_CHAIN,
+  TRANSACTION_HISTORY_SUBGRAPH_URLS_BY_EVM_CHAIN,
+} from '../../constants/urls';
 import { TransactionHistoryService } from '../../service/TransactionHistory';
 import { Address } from '../../types/Address';
 import {
   DEFAULT_SAFE_ADDRESS,
+  makeBondMovementV2,
   makeFundsMovement,
+  makeFundsMovementV2,
+  makeServiceRefV2,
   makeTransactionHistoryResponse,
+  makeTransactionHistoryResponseV2,
+  MOCK_OLAS_TOKEN_ADDRESS,
 } from '../helpers/factories';
 
 const mockGraphqlRequest = jest.fn();
@@ -250,5 +258,92 @@ describe('TransactionHistoryService.getAll', () => {
     ).rejects.toThrow('No transaction-history subgraph configured');
 
     expect(mockGraphqlRequest).not.toHaveBeenCalled();
+  });
+});
+
+describe('TransactionHistoryService.get (v2 schema)', () => {
+  const URL = 'https://pearl-transactions.subgraph.example';
+
+  beforeEach(() => {
+    TRANSACTION_HISTORY_SUBGRAPH_URLS_BY_EVM_CHAIN[EvmChainIdMap.Gnosis] = URL;
+    TRANSACTION_HISTORY_SUBGRAPH_SCHEMA_BY_EVM_CHAIN[EvmChainIdMap.Gnosis] =
+      'v2';
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+    delete TRANSACTION_HISTORY_SUBGRAPH_URLS_BY_EVM_CHAIN[EvmChainIdMap.Gnosis];
+    delete TRANSACTION_HISTORY_SUBGRAPH_SCHEMA_BY_EVM_CHAIN[
+      EvmChainIdMap.Gnosis
+    ];
+  });
+
+  it('sends the v2 query (bondMovements ledger, no bondType on fundsMovements)', async () => {
+    mockGraphqlRequest.mockResolvedValueOnce(
+      makeTransactionHistoryResponseV2(),
+    );
+
+    await TransactionHistoryService.get({
+      chainId: EvmChainIdMap.Gnosis,
+      masterSafe: DEFAULT_SAFE_ADDRESS,
+    });
+
+    const [url, query, variables] = mockGraphqlRequest.mock.calls[0];
+    expect(url).toBe(URL);
+    expect(query).toContain('GetTransactionHistoryV2');
+    expect(query).toContain('bondMovements');
+    expect(query).not.toContain('SERVICE_BOND_DEPOSIT');
+    expect(variables).toEqual({
+      masterSafe: DEFAULT_SAFE_ADDRESS.toLowerCase(),
+      first: 100,
+      skip: 0,
+    });
+  });
+
+  it('normalizes the v2 response to the domain shape', async () => {
+    mockGraphqlRequest.mockResolvedValueOnce(
+      makeTransactionHistoryResponseV2({
+        fundsMovements: [
+          makeFundsMovementV2({
+            id: 'funding',
+            category: 'MASTER_TO_AGENT',
+            blockTimestamp: '100',
+            service: makeServiceRefV2({ id: '0x7802', serviceId: '632' }),
+          }),
+          makeFundsMovementV2({
+            id: 'sweep',
+            category: 'AGENT_OLAS_TO_MASTER',
+            token: MOCK_OLAS_TOKEN_ADDRESS,
+            blockTimestamp: '150',
+          }),
+        ],
+        bondMovements: [
+          makeBondMovementV2({ id: 'bond', blockTimestamp: '200' }),
+        ],
+      }),
+    );
+
+    const result = await TransactionHistoryService.get({
+      chainId: EvmChainIdMap.Gnosis,
+      masterSafe: DEFAULT_SAFE_ADDRESS,
+    });
+
+    // Bond rows merged in (newest first), sweep rows dropped, numeric
+    // serviceId surfaced as domain service.id.
+    expect(result.fundsMovements.map((m) => m.id)).toEqual(['bond', 'funding']);
+    expect(result.fundsMovements[0].bondType).toBe('AGENT_BOND');
+    expect(result.fundsMovements[1].service?.id).toBe('632');
+  });
+
+  it('throws when a v1-shaped response arrives on a v2 chain', async () => {
+    // makeTransactionHistoryResponse() has no bondMovements collection — the
+    // v2 Zod schema must reject it rather than silently passing bad data on.
+    mockGraphqlRequest.mockResolvedValueOnce(makeTransactionHistoryResponse());
+
+    await expect(
+      TransactionHistoryService.get({
+        chainId: EvmChainIdMap.Gnosis,
+        masterSafe: DEFAULT_SAFE_ADDRESS,
+      }),
+    ).rejects.toThrow();
   });
 });

--- a/frontend/tests/utils/transactionHistory.test.ts
+++ b/frontend/tests/utils/transactionHistory.test.ts
@@ -2,10 +2,19 @@ import { EvmChainIdMap } from '../../constants/chains';
 import {
   computeIsDataDelayed,
   isOlasAgentToMaster,
+  normalizeAgentTransactionHistoryResponseV2,
+  normalizeFundsMovementV2,
+  normalizeTransactionHistoryResponseV2,
 } from '../../utils/transactionHistory';
 import {
+  makeAgentFundingEventV2,
+  makeAgentTransactionHistoryResponseV2,
+  makeBondMovementV2,
   makeFundsMovement,
+  makeFundsMovementV2,
+  makeServiceRefV2,
   makeSubgraphMeta,
+  makeTransactionHistoryResponseV2,
   MOCK_OLAS_TOKEN_ADDRESS,
   MOCK_USDC_E_TOKEN_ADDRESS,
 } from '../helpers/factories';
@@ -94,5 +103,106 @@ describe('computeIsDataDelayed', () => {
         makeSubgraphMeta({ block: { number: 1, timestamp: null } }),
       ),
     ).toBe(false);
+  });
+});
+
+describe('normalizeFundsMovementV2', () => {
+  it('maps service refs so domain service.id is the numeric serviceId', () => {
+    const normalized = normalizeFundsMovementV2(
+      makeFundsMovementV2({
+        category: 'MASTER_TO_AGENT',
+        agentSafe: {
+          id: '0xagentsafe',
+          service: makeServiceRefV2({ id: '0x7802', serviceId: '632' }),
+        },
+        service: makeServiceRefV2({ id: '0x7802', serviceId: '632' }),
+      }),
+    );
+
+    expect(normalized?.agentSafe?.service?.id).toBe('632');
+    expect(normalized?.service?.id).toBe('632');
+  });
+
+  it('preserves agentIds and null refs', () => {
+    const normalized = normalizeFundsMovementV2(
+      makeFundsMovementV2({
+        agentSafe: { id: '0xagentsafe', service: null },
+      }),
+    );
+
+    expect(normalized?.agentSafe).toEqual({ id: '0xagentsafe', service: null });
+    expect(normalized?.service).toBeUndefined();
+  });
+
+  it('drops AGENT_OLAS_TO_MASTER rows (server-split reward sweeps)', () => {
+    expect(
+      normalizeFundsMovementV2(
+        makeFundsMovementV2({
+          category: 'AGENT_OLAS_TO_MASTER',
+          token: MOCK_OLAS_TOKEN_ADDRESS,
+        }),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('normalizeTransactionHistoryResponseV2', () => {
+  it('merges bondMovements into fundsMovements sorted by timestamp desc', () => {
+    const normalized = normalizeTransactionHistoryResponseV2(
+      makeTransactionHistoryResponseV2({
+        fundsMovements: [
+          makeFundsMovementV2({ id: 'funding', blockTimestamp: '100' }),
+        ],
+        bondMovements: [
+          makeBondMovementV2({ id: 'bond', blockTimestamp: '200' }),
+        ],
+      }),
+    );
+
+    expect(normalized.fundsMovements.map((m) => m.id)).toEqual([
+      'bond',
+      'funding',
+    ]);
+    expect(normalized.fundsMovements[0].bondType).toBe('AGENT_BOND');
+    expect(normalized.fundsMovements[0].category).toBe('SERVICE_BOND_DEPOSIT');
+  });
+
+  it('normalizes agentFundingEvent transfers and passes through meta/masterSafe', () => {
+    const response = makeTransactionHistoryResponseV2({
+      agentFundingEvents: [makeAgentFundingEventV2()],
+    });
+
+    const normalized = normalizeTransactionHistoryResponseV2(response);
+
+    expect(
+      normalized.agentFundingEvents[0].transfers[0].agentSafe?.service?.id,
+    ).toBe('42');
+    expect(normalized.masterSafe).toEqual(response.masterSafe);
+    expect(normalized._meta).toEqual(response._meta);
+  });
+});
+
+describe('normalizeAgentTransactionHistoryResponseV2', () => {
+  it('normalizes rows and drops sweep categories', () => {
+    const normalized = normalizeAgentTransactionHistoryResponseV2(
+      makeAgentTransactionHistoryResponseV2({
+        fundsMovements: [
+          makeFundsMovementV2({
+            id: 'kept',
+            category: 'AGENT_TO_MASTER',
+            token: MOCK_USDC_E_TOKEN_ADDRESS,
+            service: makeServiceRefV2(),
+          }),
+          makeFundsMovementV2({
+            id: 'dropped',
+            category: 'AGENT_OLAS_TO_MASTER',
+            token: MOCK_OLAS_TOKEN_ADDRESS,
+          }),
+        ],
+      }),
+    );
+
+    expect(normalized.fundsMovements.map((m) => m.id)).toEqual(['kept']);
+    expect(normalized.fundsMovements[0].service?.id).toBe('42');
   });
 });

--- a/frontend/types/TransactionHistory.ts
+++ b/frontend/types/TransactionHistory.ts
@@ -22,10 +22,11 @@ export const FUNDS_CATEGORY = {
   MASTER_FUNDING_IN: 'MASTER_FUNDING_IN',
   MASTER_TO_AGENT: 'MASTER_TO_AGENT',
   AGENT_TO_MASTER: 'AGENT_TO_MASTER',
-  // NB: the schema on subgraph main also splits an AGENT_OLAS_TO_MASTER
-  // category out of AGENT_TO_MASTER (OLAS reward sweeps). Deliberately not
-  // mirrored here until the live deployment ships it — see
-  // isOlasAgentToMaster in useTransactionHistory for the client-side filter.
+  // NB: the v2 schema (subgraph v0.0.7) splits an AGENT_OLAS_TO_MASTER
+  // category out of AGENT_TO_MASTER (OLAS reward sweeps). The domain shape
+  // deliberately keeps the v1 enum: v2 responses are normalized at the
+  // service boundary, where AGENT_OLAS_TO_MASTER rows are dropped — the same
+  // hiding that isOlasAgentToMaster applies client-side on v1 chains.
   MASTER_WITHDRAWAL: 'MASTER_WITHDRAWAL',
   AGENT_TO_APP: 'AGENT_TO_APP',
   APP_TO_AGENT: 'APP_TO_AGENT',
@@ -135,6 +136,94 @@ export const AgentTransactionHistoryResponseSchema = z.object({
 });
 export type AgentTransactionHistoryResponse = z.infer<
   typeof AgentTransactionHistoryResponseSchema
+>;
+
+/**
+ * Which pearl-transactions subgraph schema a chain's deployment serves.
+ * - v1 — subgraph v0.0.6: `bondType` on FundsMovement, bond rows in
+ *   `fundsMovements`, OLAS sweeps categorized AGENT_TO_MASTER.
+ * - v2 — subgraph v0.0.7: bond rows moved to a separate `bondMovements`
+ *   ledger (which carries `bondType`), sweeps split into
+ *   AGENT_OLAS_TO_MASTER, and Service.id reshaped to registry bytes with the
+ *   numeric id in `serviceId`.
+ * v2 responses are normalized back to the v1-shaped domain types at the
+ * service boundary, so hooks and components are revision-agnostic.
+ */
+export type TransactionHistorySchemaRevision = 'v1' | 'v2';
+
+// --- v2 (subgraph v0.0.7) raw-response schemas ------------------------------
+// Verified against the live Base deployment (schema introspection + sample
+// rows), not the subgraph README.
+
+const FundsCategoryV2Schema = z.enum([
+  ...FundsCategorySchema.options,
+  'AGENT_OLAS_TO_MASTER',
+]);
+
+// v2 Service.id is the registry key as Bytes (e.g. "0x7802"); the numeric id
+// the UI needs (TransactionHistoryRow consumers `Number()` it) lives in
+// `serviceId`.
+const ServiceRefV2Schema = z.object({
+  id: z.string(),
+  serviceId: z.string(),
+  agentIds: z.array(z.number()),
+});
+export type ServiceRefV2 = z.infer<typeof ServiceRefV2Schema>;
+
+const AgentSafeRefV2Schema = z.object({
+  id: z.string(),
+  service: ServiceRefV2Schema.nullable(),
+});
+
+const FundsMovementV2Schema = z.object({
+  id: z.string(),
+  category: FundsCategoryV2Schema,
+  source: FundsSourceSchema,
+  token: z.string().nullable(),
+  amount: z.string(),
+  from: z.string(),
+  to: z.string(),
+  blockTimestamp: z.string(),
+  transactionHash: z.string(),
+  agentSafe: AgentSafeRefV2Schema.nullable(),
+  service: ServiceRefV2Schema.nullable().optional(),
+});
+export type FundsMovementV2 = z.infer<typeof FundsMovementV2Schema>;
+
+// The v2 bond ledger: SERVICE_BOND_DEPOSIT / SERVICE_BOND_REFUND rows, the
+// only place `bondType` exists on v2.
+const BondMovementV2Schema = FundsMovementV2Schema.extend({
+  bondType: ServiceBondTypeSchema.nullable(),
+});
+export type BondMovementV2 = z.infer<typeof BondMovementV2Schema>;
+
+const AgentFundingEventV2Schema = z.object({
+  id: z.string(),
+  txHash: z.string(),
+  blockTimestamp: z.string(),
+  totalNativeAmount: z.string(),
+  totalOlasAmount: z.string(),
+  transfers: z.array(FundsMovementV2Schema),
+});
+export type AgentFundingEventV2 = z.infer<typeof AgentFundingEventV2Schema>;
+
+export const TransactionHistoryResponseV2Schema = z.object({
+  masterSafe: MasterSafeEntitySchema.nullable(),
+  fundsMovements: z.array(FundsMovementV2Schema),
+  bondMovements: z.array(BondMovementV2Schema),
+  agentFundingEvents: z.array(AgentFundingEventV2Schema),
+  _meta: SubgraphMetaSchema.nullable(),
+});
+export type TransactionHistoryResponseV2 = z.infer<
+  typeof TransactionHistoryResponseV2Schema
+>;
+
+export const AgentTransactionHistoryResponseV2Schema = z.object({
+  fundsMovements: z.array(FundsMovementV2Schema),
+  _meta: SubgraphMetaSchema.nullable(),
+});
+export type AgentTransactionHistoryResponseV2 = z.infer<
+  typeof AgentTransactionHistoryResponseV2Schema
 >;
 
 export type TransferDirection = 'in' | 'out';

--- a/frontend/utils/transactionHistory.ts
+++ b/frontend/utils/transactionHistory.ts
@@ -2,9 +2,17 @@ import { TOKEN_CONFIG, TokenSymbolMap } from '@/config/tokens';
 import { EvmChainId } from '@/constants/chains';
 import { TWELVE_HOURS_IN_SECONDS } from '@/constants/intervals';
 import {
+  AgentFundingEvent,
+  AgentFundingEventV2,
+  AgentTransactionHistoryResponse,
+  AgentTransactionHistoryResponseV2,
+  BondMovementV2,
   FUNDS_CATEGORY,
   FundsMovement,
+  FundsMovementV2,
   SubgraphMeta,
+  TransactionHistoryResponse,
+  TransactionHistoryResponseV2,
 } from '@/types/TransactionHistory';
 
 // Staking-reward sweeps surface as OLAS AGENT_TO_MASTER transfers (the agent
@@ -31,3 +39,90 @@ export const computeIsDataDelayed = (
   const nowSeconds = Math.floor(Date.now() / 1000);
   return nowSeconds - Number(indexedAt) >= TWELVE_HOURS_IN_SECONDS;
 };
+
+// --- v2 (subgraph v0.0.7) → domain normalization ----------------------------
+// v2 responses are reshaped to the v1 domain types right after Zod parsing so
+// hooks/components stay revision-agnostic. See TransactionHistorySchemaRevision.
+
+// Domain service.id must stay the numeric id string — row consumers `Number()`
+// it (e.g. generateAgentName). v2 Service.id is registry Bytes ("0x7802"), so
+// map from v2's `serviceId` instead.
+const toDomainServiceRef = (
+  service: FundsMovementV2['service'],
+): FundsMovement['service'] =>
+  service ? { id: service.serviceId, agentIds: service.agentIds } : service;
+
+const toDomainAgentSafeRef = (
+  agentSafe: FundsMovementV2['agentSafe'],
+): FundsMovement['agentSafe'] =>
+  agentSafe
+    ? {
+        id: agentSafe.id,
+        service: toDomainServiceRef(agentSafe.service) ?? null,
+      }
+    : agentSafe;
+
+// AGENT_OLAS_TO_MASTER (v2's server-side split of OLAS reward sweeps) maps to
+// null: v1 chains hide those rows client-side via isOlasAgentToMaster, and the
+// domain enum has no such category — dropping them preserves identical UI
+// behavior across revisions.
+export const normalizeFundsMovementV2 = (
+  movement: FundsMovementV2,
+): FundsMovement | null => {
+  if (movement.category === 'AGENT_OLAS_TO_MASTER') return null;
+  return {
+    ...movement,
+    category: movement.category,
+    agentSafe: toDomainAgentSafeRef(movement.agentSafe),
+    service: toDomainServiceRef(movement.service),
+  };
+};
+
+// Bond rows live on the separate v2 bond ledger; in the domain they are plain
+// FundsMovements carrying bondType (never AGENT_OLAS_TO_MASTER, so the cast
+// after normalize is safe in practice — normalize still guards it).
+const normalizeBondMovementV2 = (
+  bond: BondMovementV2,
+): FundsMovement | null => {
+  const normalized = normalizeFundsMovementV2(bond);
+  return normalized ? { ...normalized, bondType: bond.bondType } : null;
+};
+
+const normalizeAgentFundingEventV2 = (
+  event: AgentFundingEventV2,
+): AgentFundingEvent => ({
+  ...event,
+  transfers: event.transfers
+    .map(normalizeFundsMovementV2)
+    .filter((m): m is FundsMovement => m !== null),
+});
+
+const byBlockTimestampDesc = (a: FundsMovement, b: FundsMovement) =>
+  Number(b.blockTimestamp) - Number(a.blockTimestamp);
+
+export const normalizeTransactionHistoryResponseV2 = (
+  response: TransactionHistoryResponseV2,
+): TransactionHistoryResponse => ({
+  masterSafe: response.masterSafe,
+  // A complete v2 wallet ledger is fundsMovements ∪ bondMovements; merged here
+  // so the domain keeps v1's single-ledger shape.
+  fundsMovements: [
+    ...response.fundsMovements.map(normalizeFundsMovementV2),
+    ...response.bondMovements.map(normalizeBondMovementV2),
+  ]
+    .filter((m): m is FundsMovement => m !== null)
+    .sort(byBlockTimestampDesc),
+  agentFundingEvents: response.agentFundingEvents.map(
+    normalizeAgentFundingEventV2,
+  ),
+  _meta: response._meta,
+});
+
+export const normalizeAgentTransactionHistoryResponseV2 = (
+  response: AgentTransactionHistoryResponseV2,
+): AgentTransactionHistoryResponse => ({
+  fundsMovements: response.fundsMovements
+    .map(normalizeFundsMovementV2)
+    .filter((m): m is FundsMovement => m !== null),
+  _meta: response._meta,
+});

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5505,10 +5505,10 @@ postcss-value-parser@^4.0.2:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@8.4.31, postcss@8.4.49, postcss@8.5.10:
-  version "8.5.10"
-  resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz#8992d8c30acf3f12169e7c09514a12fed7e48356"
-  integrity sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==
+postcss@8.4.31, postcss@8.4.49, postcss@8.5.12:
+  version "8.5.12"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.12.tgz#cd0c0f667f7cb0521e2313234ea6e707a9ec1ddb"
+  integrity sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==
   dependencies:
     nanoid "^3.3.11"
     picocolors "^1.1.1"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1314,10 +1314,10 @@
     "@emnapi/runtime" "^1.4.3"
     "@tybys/wasm-util" "^0.10.0"
 
-"@next/env@15.5.18":
-  version "15.5.18"
-  resolved "https://registry.npmjs.org/@next/env/-/env-15.5.18.tgz#207ab150d3f1c787ac343946155392d478506c1b"
-  integrity sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==
+"@next/env@15.5.21":
+  version "15.5.21"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-15.5.21.tgz#782aa4d6b08ddfd12ac7e17ca85b7ee1b61c500b"
+  integrity sha512-hjJI/GfrjWHgNguRIBzItjRRu0m3Nrz17GhxsjuHfjIvg9hyg3239REd2dpI+bpMTFuVrVprHzEQ19m++cDtbw==
 
 "@next/eslint-plugin-next@15.5.18":
   version "15.5.18"
@@ -1326,45 +1326,45 @@
   dependencies:
     fast-glob "3.3.1"
 
-"@next/swc-darwin-arm64@15.5.18":
-  version "15.5.18"
-  resolved "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.18.tgz#d4376e2d31f90679128c5d83aecfb7aa244e475c"
-  integrity sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==
+"@next/swc-darwin-arm64@15.5.21":
+  version "15.5.21"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.21.tgz#bac5a07fc86a50555e0bab64fc7446605b028df4"
+  integrity sha512-ZfjqPEdi6TRC/fWx7UDbwb1fbVgyh2uD5tVTRKIDZDlYM+UNuE/LafDG2fwuAoZilADpABh46OY/F5qf9JjqLQ==
 
-"@next/swc-darwin-x64@15.5.18":
-  version "15.5.18"
-  resolved "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.18.tgz#35e179f2863d0ea1b249d5f8a1616593431f1645"
-  integrity sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==
+"@next/swc-darwin-x64@15.5.21":
+  version "15.5.21"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.21.tgz#b369644e8e5f0b3b51469542fc7d724c23762946"
+  integrity sha512-TlCf1NpxgQLzTrexuev75xwmNCJMd1/qkJpTVP1GRRcih93hlIBn1P72hkh8T0gnRFr6BmWksQtbyG3jT6jnww==
 
-"@next/swc-linux-arm64-gnu@15.5.18":
-  version "15.5.18"
-  resolved "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.18.tgz#5c97bd8422cc0d43b6b07329514bfaceb04b8014"
-  integrity sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==
+"@next/swc-linux-arm64-gnu@15.5.21":
+  version "15.5.21"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.21.tgz#90d8033f1411b1f1cd834d8d0b13daa6c1e978ac"
+  integrity sha512-LXRsq1p+HvHSi7ygwNcSEEcK0zuo5jS75ZlqFHtOH+LF7qntXAJVJxah+1Pi/GyBm7EpkwU7m4EgbvIKrMqm9A==
 
-"@next/swc-linux-arm64-musl@15.5.18":
-  version "15.5.18"
-  resolved "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.18.tgz#497dda6be6e905e3ab7b02624a5493ccf08f06e7"
-  integrity sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==
+"@next/swc-linux-arm64-musl@15.5.21":
+  version "15.5.21"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.21.tgz#fa3359b5d8e50d24a47d3f24fd663dd29b751abb"
+  integrity sha512-hyGixhFxpDKjqoev6l4KlcRBlt9AXWrGhDZwmwg49sMJM5tnKQPSi+SEj9+e5n+l/bthRGZUdh59GKIs6lQPRw==
 
-"@next/swc-linux-x64-gnu@15.5.18":
-  version "15.5.18"
-  resolved "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.18.tgz#c5863100284c0182ff546d212c74dc9348d16564"
-  integrity sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==
+"@next/swc-linux-x64-gnu@15.5.21":
+  version "15.5.21"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.21.tgz#8df24c447815a9d7c71c86209607fb2340275837"
+  integrity sha512-qfE+YfOba6S2+13e8qn1/UozDVNZ2clBlrs8UtDoax4s8ediu6sq93z66OEHUYlb69Tffh5JTNkgtsAKiSuugg==
 
-"@next/swc-linux-x64-musl@15.5.18":
-  version "15.5.18"
-  resolved "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.18.tgz#26f3fdc26707458481d40649a1420584bf1f3bf7"
-  integrity sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==
+"@next/swc-linux-x64-musl@15.5.21":
+  version "15.5.21"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.21.tgz#eec68325de1fa0c708c031754bd0310d145d9424"
+  integrity sha512-BXLGG+EvIwp/Rrgl6HY8sqvD6BOUOIRz8/naDbeLNX7mlA5H2XRcL6MW/0IGnJISfj5BA9gNhFyJj5yOoiIDJQ==
 
-"@next/swc-win32-arm64-msvc@15.5.18":
-  version "15.5.18"
-  resolved "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.18.tgz#8acdb2aeec6d768bffa3043485d22ecdf48a6e4c"
-  integrity sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==
+"@next/swc-win32-arm64-msvc@15.5.21":
+  version "15.5.21"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.21.tgz#d5fdddb7a96bc549ce2581a50c44bb9b44db0942"
+  integrity sha512-tNGNOlT0Wn7E4IMsSnufjXN/l2L2/AGdLLpa2vzS89SYCBuihgLn3ngLsIrvndAnWo9nAkus+4gZHTI/Ijx9HA==
 
-"@next/swc-win32-x64-msvc@15.5.18":
-  version "15.5.18"
-  resolved "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.18.tgz#beac6228e60e3ee08ce7a20b7f61b3dc516d4b10"
-  integrity sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==
+"@next/swc-win32-x64-msvc@15.5.21":
+  version "15.5.21"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.21.tgz#762363d4aaa353775b3c7a03e202f9eb0b1dca9e"
+  integrity sha512-DmIdWmC9p4rdNIiQqo8ap0+Cnj6kKtTZnuSCxoYydSc8sgpDgAg9wFhxplunak9imLV0pTvc5WVCOHwm5eHLtQ==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -5199,25 +5199,25 @@ neo-async@^2.6.2:
   resolved "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-next@15.5.18:
-  version "15.5.18"
-  resolved "https://registry.npmjs.org/next/-/next-15.5.18.tgz#b0a9d82763f7358938fe4732bb6f605f7e941815"
-  integrity sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==
+next@15.5.21:
+  version "15.5.21"
+  resolved "https://registry.yarnpkg.com/next/-/next-15.5.21.tgz#43355e37f9d1ed8cf96018aa57f84ea2ec213f7b"
+  integrity sha512-/TsdBtkWLhkl+NVL3Uqws2UphNd6IPzOtzSk1fHaf+0P7GQKLZDUytyhns/Ykbzdy9+YRjwG7ONvrHaaTDdFqQ==
   dependencies:
-    "@next/env" "15.5.18"
+    "@next/env" "15.5.21"
     "@swc/helpers" "0.5.15"
     caniuse-lite "^1.0.30001579"
     postcss "8.4.31"
     styled-jsx "5.1.6"
   optionalDependencies:
-    "@next/swc-darwin-arm64" "15.5.18"
-    "@next/swc-darwin-x64" "15.5.18"
-    "@next/swc-linux-arm64-gnu" "15.5.18"
-    "@next/swc-linux-arm64-musl" "15.5.18"
-    "@next/swc-linux-x64-gnu" "15.5.18"
-    "@next/swc-linux-x64-musl" "15.5.18"
-    "@next/swc-win32-arm64-msvc" "15.5.18"
-    "@next/swc-win32-x64-msvc" "15.5.18"
+    "@next/swc-darwin-arm64" "15.5.21"
+    "@next/swc-darwin-x64" "15.5.21"
+    "@next/swc-linux-arm64-gnu" "15.5.21"
+    "@next/swc-linux-arm64-musl" "15.5.21"
+    "@next/swc-linux-x64-gnu" "15.5.21"
+    "@next/swc-linux-x64-musl" "15.5.21"
+    "@next/swc-win32-arm64-msvc" "15.5.21"
+    "@next/swc-win32-x64-msvc" "15.5.21"
     sharp "^0.34.3"
 
 node-addon-api@^7.0.0:

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "graphql-request": "6.1.0",
     "lodash": "4.18.1",
     "lottie-react": "2.4.1",
-    "next": "15.5.18",
+    "next": "15.5.21",
     "node-forge": "1.4.0",
     "ps-tree": "1.2.0",
     "react": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -112,6 +112,6 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.8.5-rc2",
+  "version": "1.8.5-rc4",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lodash": "4.18.1",
     "node-gyp": "12.3.0",
     "picomatch": "2.3.2",
-    "postcss": "8.5.10",
+    "postcss": "8.5.12",
     "serialize-javascript": "7.0.5",
     "sharp": "0.35.3",
     "tar": "7.5.16",

--- a/package.json
+++ b/package.json
@@ -112,6 +112,6 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.8.5",
+  "version": "1.8.5-rc2",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-app"
-version = "1.8.5-rc2"
+version = "1.8.5-rc4"
 description = ""
 authors = [
     { name = "David Vilela", email = "dvilelaf@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-app"
-version = "1.8.5"
+version = "1.8.5-rc2"
 description = ""
 authors = [
     { name = "David Vilela", email = "dvilelaf@gmail.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -1144,7 +1144,7 @@ wheels = [
 
 [[package]]
 name = "olas-operate-app"
-version = "1.8.5rc2"
+version = "1.8.5rc4"
 source = { virtual = "." }
 dependencies = [
     { name = "olas-operate-middleware" },

--- a/uv.lock
+++ b/uv.lock
@@ -1144,7 +1144,7 @@ wheels = [
 
 [[package]]
 name = "olas-operate-app"
-version = "1.8.5"
+version = "1.8.5rc2"
 source = { virtual = "." }
 dependencies = [
     { name = "olas-operate-middleware" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5050,10 +5050,10 @@ postcss-value-parser@^4.0.2:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@8.4.31, postcss@8.4.49, postcss@8.5.10:
-  version "8.5.10"
-  resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz#8992d8c30acf3f12169e7c09514a12fed7e48356"
-  integrity sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==
+postcss@8.4.31, postcss@8.4.49, postcss@8.5.12:
+  version "8.5.12"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz#cd0c0f667f7cb0521e2313234ea6e707a9ec1ddb"
+  integrity sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==
   dependencies:
     nanoid "^3.3.11"
     picocolors "^1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -884,50 +884,50 @@
     tweetnacl "^1.0.3"
     tweetnacl-util "^0.15.1"
 
-"@next/env@15.5.18":
-  version "15.5.18"
-  resolved "https://registry.npmjs.org/@next/env/-/env-15.5.18.tgz#207ab150d3f1c787ac343946155392d478506c1b"
-  integrity sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==
+"@next/env@15.5.21":
+  version "15.5.21"
+  resolved "https://registry.npmjs.org/@next/env/-/env-15.5.21.tgz#782aa4d6b08ddfd12ac7e17ca85b7ee1b61c500b"
+  integrity sha512-hjJI/GfrjWHgNguRIBzItjRRu0m3Nrz17GhxsjuHfjIvg9hyg3239REd2dpI+bpMTFuVrVprHzEQ19m++cDtbw==
 
-"@next/swc-darwin-arm64@15.5.18":
-  version "15.5.18"
-  resolved "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.18.tgz#d4376e2d31f90679128c5d83aecfb7aa244e475c"
-  integrity sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==
+"@next/swc-darwin-arm64@15.5.21":
+  version "15.5.21"
+  resolved "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.21.tgz#bac5a07fc86a50555e0bab64fc7446605b028df4"
+  integrity sha512-ZfjqPEdi6TRC/fWx7UDbwb1fbVgyh2uD5tVTRKIDZDlYM+UNuE/LafDG2fwuAoZilADpABh46OY/F5qf9JjqLQ==
 
-"@next/swc-darwin-x64@15.5.18":
-  version "15.5.18"
-  resolved "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.18.tgz#35e179f2863d0ea1b249d5f8a1616593431f1645"
-  integrity sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==
+"@next/swc-darwin-x64@15.5.21":
+  version "15.5.21"
+  resolved "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.21.tgz#b369644e8e5f0b3b51469542fc7d724c23762946"
+  integrity sha512-TlCf1NpxgQLzTrexuev75xwmNCJMd1/qkJpTVP1GRRcih93hlIBn1P72hkh8T0gnRFr6BmWksQtbyG3jT6jnww==
 
-"@next/swc-linux-arm64-gnu@15.5.18":
-  version "15.5.18"
-  resolved "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.18.tgz#5c97bd8422cc0d43b6b07329514bfaceb04b8014"
-  integrity sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==
+"@next/swc-linux-arm64-gnu@15.5.21":
+  version "15.5.21"
+  resolved "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.21.tgz#90d8033f1411b1f1cd834d8d0b13daa6c1e978ac"
+  integrity sha512-LXRsq1p+HvHSi7ygwNcSEEcK0zuo5jS75ZlqFHtOH+LF7qntXAJVJxah+1Pi/GyBm7EpkwU7m4EgbvIKrMqm9A==
 
-"@next/swc-linux-arm64-musl@15.5.18":
-  version "15.5.18"
-  resolved "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.18.tgz#497dda6be6e905e3ab7b02624a5493ccf08f06e7"
-  integrity sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==
+"@next/swc-linux-arm64-musl@15.5.21":
+  version "15.5.21"
+  resolved "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.21.tgz#fa3359b5d8e50d24a47d3f24fd663dd29b751abb"
+  integrity sha512-hyGixhFxpDKjqoev6l4KlcRBlt9AXWrGhDZwmwg49sMJM5tnKQPSi+SEj9+e5n+l/bthRGZUdh59GKIs6lQPRw==
 
-"@next/swc-linux-x64-gnu@15.5.18":
-  version "15.5.18"
-  resolved "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.18.tgz#c5863100284c0182ff546d212c74dc9348d16564"
-  integrity sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==
+"@next/swc-linux-x64-gnu@15.5.21":
+  version "15.5.21"
+  resolved "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.21.tgz#8df24c447815a9d7c71c86209607fb2340275837"
+  integrity sha512-qfE+YfOba6S2+13e8qn1/UozDVNZ2clBlrs8UtDoax4s8ediu6sq93z66OEHUYlb69Tffh5JTNkgtsAKiSuugg==
 
-"@next/swc-linux-x64-musl@15.5.18":
-  version "15.5.18"
-  resolved "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.18.tgz#26f3fdc26707458481d40649a1420584bf1f3bf7"
-  integrity sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==
+"@next/swc-linux-x64-musl@15.5.21":
+  version "15.5.21"
+  resolved "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.21.tgz#eec68325de1fa0c708c031754bd0310d145d9424"
+  integrity sha512-BXLGG+EvIwp/Rrgl6HY8sqvD6BOUOIRz8/naDbeLNX7mlA5H2XRcL6MW/0IGnJISfj5BA9gNhFyJj5yOoiIDJQ==
 
-"@next/swc-win32-arm64-msvc@15.5.18":
-  version "15.5.18"
-  resolved "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.18.tgz#8acdb2aeec6d768bffa3043485d22ecdf48a6e4c"
-  integrity sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==
+"@next/swc-win32-arm64-msvc@15.5.21":
+  version "15.5.21"
+  resolved "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.21.tgz#d5fdddb7a96bc549ce2581a50c44bb9b44db0942"
+  integrity sha512-tNGNOlT0Wn7E4IMsSnufjXN/l2L2/AGdLLpa2vzS89SYCBuihgLn3ngLsIrvndAnWo9nAkus+4gZHTI/Ijx9HA==
 
-"@next/swc-win32-x64-msvc@15.5.18":
-  version "15.5.18"
-  resolved "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.18.tgz#beac6228e60e3ee08ce7a20b7f61b3dc516d4b10"
-  integrity sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==
+"@next/swc-win32-x64-msvc@15.5.21":
+  version "15.5.21"
+  resolved "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.21.tgz#762363d4aaa353775b3c7a03e202f9eb0b1dca9e"
+  integrity sha512-DmIdWmC9p4rdNIiQqo8ap0+Cnj6kKtTZnuSCxoYydSc8sgpDgAg9wFhxplunak9imLV0pTvc5WVCOHwm5eHLtQ==
 
 "@noble/hashes@1.2.0", "@noble/hashes@~1.2.0":
   version "1.2.0"
@@ -4681,25 +4681,25 @@ net@1.0.2:
   resolved "https://registry.npmjs.org/net/-/net-1.0.2.tgz#d1757ec9a7fb2371d83cf4755ce3e27e10829388"
   integrity sha512-kbhcj2SVVR4caaVnGLJKmlk2+f+oLkjqdKeQlmUtz6nGzOpbcobwVIeSURNgraV/v3tlmGIX82OcPCl0K6RbHQ==
 
-next@15.5.18:
-  version "15.5.18"
-  resolved "https://registry.npmjs.org/next/-/next-15.5.18.tgz#b0a9d82763f7358938fe4732bb6f605f7e941815"
-  integrity sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==
+next@15.5.21:
+  version "15.5.21"
+  resolved "https://registry.npmjs.org/next/-/next-15.5.21.tgz#43355e37f9d1ed8cf96018aa57f84ea2ec213f7b"
+  integrity sha512-/TsdBtkWLhkl+NVL3Uqws2UphNd6IPzOtzSk1fHaf+0P7GQKLZDUytyhns/Ykbzdy9+YRjwG7ONvrHaaTDdFqQ==
   dependencies:
-    "@next/env" "15.5.18"
+    "@next/env" "15.5.21"
     "@swc/helpers" "0.5.15"
     caniuse-lite "^1.0.30001579"
     postcss "8.4.31"
     styled-jsx "5.1.6"
   optionalDependencies:
-    "@next/swc-darwin-arm64" "15.5.18"
-    "@next/swc-darwin-x64" "15.5.18"
-    "@next/swc-linux-arm64-gnu" "15.5.18"
-    "@next/swc-linux-arm64-musl" "15.5.18"
-    "@next/swc-linux-x64-gnu" "15.5.18"
-    "@next/swc-linux-x64-musl" "15.5.18"
-    "@next/swc-win32-arm64-msvc" "15.5.18"
-    "@next/swc-win32-x64-msvc" "15.5.18"
+    "@next/swc-darwin-arm64" "15.5.21"
+    "@next/swc-darwin-x64" "15.5.21"
+    "@next/swc-linux-arm64-gnu" "15.5.21"
+    "@next/swc-linux-arm64-musl" "15.5.21"
+    "@next/swc-linux-x64-gnu" "15.5.21"
+    "@next/swc-linux-x64-musl" "15.5.21"
+    "@next/swc-win32-arm64-msvc" "15.5.21"
+    "@next/swc-win32-x64-msvc" "15.5.21"
     sharp "^0.34.3"
 
 node-abi@^4.2.0:


### PR DESCRIPTION
## Summary

Enables transaction history on Base — both Pearl Wallet → History and Agent Wallet → Balances & Assets.

Two parts:

1. **Subgraph URL** for Base plugged into `TRANSACTION_HISTORY_SUBGRAPH_URLS_BY_EVM_CHAIN` (was `undefined`, surfacing the 'not available on this network yet' state).
2. **v0.0.7 schema support.** Base's proxy pins pearl-transactions subgraph **v0.0.7**, whose schema breaks the queries Pearl sends (Gnosis/Optimism pin **v0.0.6**): `FundsMovement.bondType` removed, bond rows moved to a separate `bondMovements` ledger, OLAS sweeps pre-split into `AGENT_OLAS_TO_MASTER`, and `Service.id` reshaped to registry bytes (numeric id now in `serviceId`). Every request failed GraphQL validation → the tester's 'Error loading transaction history'. This PR adds a per-chain schema-revision map (Base → v2, absent → v1), v2 query documents + Zod schemas **verified against the live Base deployment**, and service-boundary normalization back to the v1-shaped domain types. Hooks and components are untouched and revision-agnostic; migrating Gnosis/Optimism to v0.0.7 later is a one-line map flip.

Also bumps `next` 15.5.18 → 15.5.21 in both trees (three new high advisories tripped the `yarn audit` CI gate).

## Screenshots
### Agent wallet
<img width="975" height="210" alt="Screenshot 2026-07-23 180532" src="https://github.com/user-attachments/assets/ff9393be-362f-45c2-b262-f9406628c195" />

### Pearl wallet
<img width="988" height="287" alt="Screenshot 2026-07-23 180544" src="https://github.com/user-attachments/assets/f851105f-1088-40b5-af26-d2a6692da1ee" />


## Verification

- v2 contract taken from live Base endpoint introspection + sample rows, not the subgraph README.
- New tests: v2 normalizers (utils), v2 service paths for both services (query document selection, normalization, wrong-revision rejection). 27 suites / 389 tests green; typecheck + lint clean.
- `serviceId` trap covered: v2 factories deliberately mismatch registry-bytes `id` vs numeric `serviceId` so any code reading `.id` fails tests.

## Out-of-scope follow-ups

- `config/chains.ts` imports `parseEther` from the `@/utils` barrel, creating a latent import cycle (services here deep-import `@/utils/transactionHistory` to avoid it). Worth switching that import to a deep path.
- **Ops:** Gnosis/Optimism proxy pins must stay on subgraph v0.0.6 until their map entries here flip to v2 — Base demonstrated indexers drop old versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)