### PR TITLE
feat: [VLOP-104] QA bundle — alert priority, low-balance copy, pUSD in agent wallet

### DIFF
--- a/frontend/config/agents.ts
+++ b/frontend/config/agents.ts
@@ -340,9 +340,11 @@ export const AGENT_CONFIG: {
     doesChatUiRequireApiKey: false,
     // PLACEHOLDER: real public id lands with the minted Connect package (PR2).
     servicePublicId: 'valory/connect:0.1.0',
-    // Per-chain: Connect uses USDC on Polygon only. Gnosis runs on native xDAI,
-    // so USDC must not appear in the Gnosis agent wallet.
-    erc20Tokens: { [EvmChainIdMap.Polygon]: [TokenSymbolMap.USDC] },
+    // Per-chain: Connect uses USDC and pUSD on Polygon only. Gnosis runs on
+    // native xDAI, so neither may appear in the Gnosis agent wallet.
+    erc20Tokens: {
+      [EvmChainIdMap.Polygon]: [TokenSymbolMap.USDC, TokenSymbolMap.pUSD],
+    },
   },
 };
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
     "lodash-es": "4.18.1",
     "minimatch": "9.0.9",
     "picomatch": "4.0.4",
-    "postcss": "8.5.10",
+    "postcss": "8.5.22",
     "sharp": "0.35.3",
     "tar": "7.5.16",
     "ws": "8.21.0"

--- a/frontend/tests/config/agents.test.ts
+++ b/frontend/tests/config/agents.test.ts
@@ -70,6 +70,13 @@ describe('AGENT_CONFIG', () => {
     }
   });
 
+  it('Connect lists USDC and pUSD on Polygon only, no ERC20s on Gnosis', () => {
+    const connectErc20Tokens = AGENT_CONFIG[AgentMap.Connect].erc20Tokens;
+    expect(connectErc20Tokens).toEqual({
+      [EvmChainIdMap.Polygon]: [TokenSymbolMap.USDC, TokenSymbolMap.pUSD],
+    });
+  });
+
   it('Polystrat additionalRequirements surfaces pUSD safe amount from service template', () => {
     const polystratRequirements =
       AGENT_CONFIG[AgentMap.Polystrat].additionalRequirements;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5179,10 +5179,10 @@ ms@^2.1.1, ms@^2.1.3:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@^3.3.11:
-  version "3.3.12"
-  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz#ab3d912e217a6d0a514f00a72a16543a28982c05"
-  integrity sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==
+nanoid@^3.3.16:
+  version "3.3.16"
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
+  integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
 
 napi-postinstall@^0.3.0:
   version "0.3.3"
@@ -5505,12 +5505,12 @@ postcss-value-parser@^4.0.2:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@8.4.31, postcss@8.4.49, postcss@8.5.10:
-  version "8.5.10"
-  resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz#8992d8c30acf3f12169e7c09514a12fed7e48356"
-  integrity sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==
+postcss@8.4.31, postcss@8.4.49, postcss@8.5.22:
+  version "8.5.22"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz#086a0d5685a715acf5950ebbcb1538faf3051697"
+  integrity sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==
   dependencies:
-    nanoid "^3.3.11"
+    nanoid "^3.3.16"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lodash": "4.18.1",
     "node-gyp": "12.3.0",
     "picomatch": "2.3.2",
-    "postcss": "8.5.10",
+    "postcss": "8.5.22",
     "serialize-javascript": "7.0.5",
     "sharp": "0.35.3",
     "tar": "7.5.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4661,10 +4661,10 @@ ms@^2.1.1, ms@^2.1.3:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@^3.3.11:
-  version "3.3.12"
-  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz#ab3d912e217a6d0a514f00a72a16543a28982c05"
-  integrity sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==
+nanoid@^3.3.16:
+  version "3.3.16"
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
+  integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
 
 napi-macros@^2.2.2:
   version "2.2.2"
@@ -5050,12 +5050,12 @@ postcss-value-parser@^4.0.2:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@8.4.31, postcss@8.4.49, postcss@8.5.10:
-  version "8.5.10"
-  resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz#8992d8c30acf3f12169e7c09514a12fed7e48356"
-  integrity sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==
+postcss@8.4.31, postcss@8.4.49, postcss@8.5.22:
+  version "8.5.22"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz#086a0d5685a715acf5950ebbcb1538faf3051697"
+  integrity sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==
   dependencies:
-    nanoid "^3.3.11"
+    nanoid "^3.3.16"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 


### PR DESCRIPTION
## What

Review record for four Connect QA changes. Items 1–2 are already commits on `feat/connect-agent` (by @Tanya-atatakai, co-authored with Claude); items 3–4 are this PR's diff.

1. **One agent-card alert at a time, by priority** — `2677ed8f4`
   - Problem: the start-session nudge (`ConnectSessionAlert`) and the "Another agent is currently running…" alert (`AgentDisabledAlert`) are rendered by independent components, so both showed at once.
   - Fix: `frontend/hooks/useConnectSession.ts` gates `showStartInfo` on `!isAnotherAgentRunning` (via `useAgentRunning`). Another agent running → only the running-agent alert; nothing running → only the start-session nudge.
   - Tests: `useConnectSession.test.ts` adds a controllable `useAgentRunning` mock + a suppression case.

   *While another agent is running:*

   ![another agent running](https://raw.githubusercontent.com/valory-xyz/olas-operate-app/assets/pr-2084-screenshots/after-another-agent-running.png)

   *No agent running:*

   ![no agent running](https://raw.githubusercontent.com/valory-xyz/olas-operate-app/assets/pr-2084-screenshots/after-no-agent-running.png)

2. **Low-balance alert copy scoped to staking agents** — `aed152ad1`
   - Problem: the Low Agent Wallet Balance alert always ended with "…and meet staking requirements", which is wrong for non-staking agents (Connect).
   - Fix: `frontend/components/AgentLowBalanceAlert.tsx` appends the staking clause only when `selectedAgentConfig.hasStaking`.
   - Tests: new `AgentLowBalanceAlert.test.tsx` (3 cases: hidden when balance ok; staking copy for staking agents; clause omitted for non-staking).

   *Connect (non-staking):*

   ![low balance connect](https://raw.githubusercontent.com/valory-xyz/olas-operate-app/assets/pr-2084-screenshots/after-low-balance-connect.png)

   *Staking agents (unchanged):*

   ![low balance staking](https://raw.githubusercontent.com/valory-xyz/olas-operate-app/assets/pr-2084-screenshots/low-balance-staking-unchanged.png)

3. **pUSD in the Polygon agent wallet** — `f447ba548`
   - Adds `pUSD` to Connect's per-chain `erc20Tokens` (`frontend/config/agents.ts`) so the Agent Wallet lists it on Polygon instances; Gnosis stays ERC20-free (native xDAI only).
   - pUSD already has a full Polygon token config and `BalanceProvider` reads on-chain balances for every token in `TOKEN_CONFIG`, so amounts populate with no backend change.
   - Test in `agents.test.ts` pins Connect's token-list shape.

4. **postcss 8.5.22 resolution bump, both trees** — `4e17cd2d8`
   - Fixes the "yarn audit (both trees)" CI gate (the red ✕ visible on commits `2677ed8f4`/`aed152ad1`): postcss <=8.5.11 (GHSA-6g55-p6wh-862q, advisory 1124252) via `next>postcss`. Both trees pinned 8.5.10 via resolutions; bumped to 8.5.22, lockfiles regenerated. `audit:prod` green in both trees.

## Note on the diff

Items 1–2 landed directly on `feat/connect-agent`, so this PR's diff shows items 3–4 only. Screenshots are served from the `assets/pr-2084-screenshots` branch — keep it until this PR is closed.

## Testing

- `audit:prod` green in both trees; `useConnectSession` (16 tests), `AgentLowBalanceAlert` (3), config/agents + guards + `useAvailableAgentAssets` (98) all pass; lint + `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
