### PR TITLE
feat: [VLOP-119] warn that agents can send funds to any address

### DIFF
--- a/frontend/components/AgentWallet/FundAgent/FundAgent.tsx
+++ b/frontend/components/AgentWallet/FundAgent/FundAgent.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useUnmount } from 'usehooks-ts';
 
 import {
+  Alert,
   BackButton,
   CardFlex,
   cardStyles,
@@ -186,6 +187,11 @@ export const FundAgent = ({ onBack }: { onBack: () => void }) => {
           <Flex gap={12} vertical>
             <BackButton onPrev={onBack} />
             <FundAgentTitle />
+            <Alert
+              showIcon
+              type="warning"
+              message="Your agent can send funds to any address. Consider only funding it with what it needs."
+            />
           </Flex>
           <PearlWalletToAgentWallet />
 

--- a/frontend/components/AgentWallet/FundAgent/FundAgent.tsx
+++ b/frontend/components/AgentWallet/FundAgent/FundAgent.tsx
@@ -190,6 +190,7 @@ export const FundAgent = ({ onBack }: { onBack: () => void }) => {
             <Alert
               showIcon
               type="warning"
+              className="text-sm"
               message="Your agent can send funds to any address. Consider only funding it with what it needs."
             />
           </Flex>

--- a/frontend/components/Bridge/BridgeOnEvm/BridgeOnEvm.tsx
+++ b/frontend/components/Bridge/BridgeOnEvm/BridgeOnEvm.tsx
@@ -66,8 +66,17 @@ export const BridgeOnEvm = ({
           showIcon
           type="warning"
           className="mt-24"
-          message={`Only send funds on ${fromChainDetails.displayName} Chain`}
-          description="Your agent can send funds to any address. Consider only funding it with what it needs."
+          message={
+            <Flex vertical gap={2}>
+              <Text className="text-sm font-weight-600">
+                Only send funds on {fromChainDetails.displayName} Chain
+              </Text>
+              <Text className="text-sm">
+                Your agent can send funds to any address. Consider only funding
+                it with what it needs.
+              </Text>
+            </Flex>
+          }
         />
 
         {address && (

--- a/frontend/components/Bridge/BridgeOnEvm/BridgeOnEvm.tsx
+++ b/frontend/components/Bridge/BridgeOnEvm/BridgeOnEvm.tsx
@@ -1,6 +1,11 @@
 import { Flex, Typography } from 'antd';
 
-import { BackButton, CardFlex, FundingDescription } from '@/components/ui';
+import {
+  Alert,
+  BackButton,
+  CardFlex,
+  FundingDescription,
+} from '@/components/ui';
 import { CHAIN_IMAGE_MAP, MiddlewareChain } from '@/constants';
 import { useMasterWalletContext } from '@/hooks';
 import { CrossChainTransferDetails } from '@/types/Bridge';
@@ -56,6 +61,14 @@ export const BridgeOnEvm = ({
           Wallet address below. Pearl will automatically detect your transfer
           and bridge the funds for you.
         </Text>
+
+        <Alert
+          showIcon
+          type="warning"
+          className="mt-24"
+          message={`Only send funds on ${fromChainDetails.displayName} Chain`}
+          description="Your agent can send funds to any address. Consider only funding it with what it needs."
+        />
 
         {address && (
           <FundingDescription

--- a/frontend/components/SetupPage/FundYourAgent/TransferFunds.tsx
+++ b/frontend/components/SetupPage/FundYourAgent/TransferFunds.tsx
@@ -166,7 +166,8 @@ export const TransferFunds = () => {
           showIcon
           type="warning"
           className="mt-24"
-          message={`Only send on ${chainName} Chain — funds on other networks are unrecoverable.`}
+          message={`Only send funds on ${chainName} Chain`}
+          description="Your agent can send funds to any address. Consider only funding it with what it needs."
         />
 
         {destinationAddress && (

--- a/frontend/components/SetupPage/FundYourAgent/TransferFunds.tsx
+++ b/frontend/components/SetupPage/FundYourAgent/TransferFunds.tsx
@@ -166,8 +166,17 @@ export const TransferFunds = () => {
           showIcon
           type="warning"
           className="mt-24"
-          message={`Only send funds on ${chainName} Chain`}
-          description="Your agent can send funds to any address. Consider only funding it with what it needs."
+          message={
+            <Flex vertical gap={2}>
+              <Text className="text-sm font-weight-600">
+                Only send funds on {chainName} Chain
+              </Text>
+              <Text className="text-sm">
+                Your agent can send funds to any address. Consider only funding
+                it with what it needs.
+              </Text>
+            </Flex>
+          }
         />
 
         {destinationAddress && (

--- a/frontend/tests/components/Bridge/BridgeOnEvm/BridgeOnEvm.test.tsx
+++ b/frontend/tests/components/Bridge/BridgeOnEvm/BridgeOnEvm.test.tsx
@@ -53,6 +53,19 @@ let fundingDescriptionProps: Record<string, unknown> | null = null;
 let depositForBridgingProps: Record<string, unknown> | null = null;
 
 jest.mock('../../../../components/ui', () => ({
+  Alert: ({
+    message,
+    description,
+  }: {
+    message: React.ReactNode;
+    description?: React.ReactNode;
+  }) =>
+    createElement(
+      'div',
+      { 'data-testid': 'alert' },
+      createElement('div', null, message),
+      description ? createElement('div', null, description) : null,
+    ),
   BackButton: ({ onPrev }: { onPrev: () => void }) =>
     createElement('button', { onClick: onPrev }, 'Back'),
   CardFlex: ({ children }: { children: React.ReactNode }) =>
@@ -111,6 +124,14 @@ describe('BridgeOnEvm', () => {
 
     expect(screen.getByText('Bridge Crypto from Ethereum')).toBeInTheDocument();
     expect(screen.getByText('Step 1. Send Funds')).toBeInTheDocument();
+    expect(
+      screen.getByText('Only send funds on Ethereum Chain'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Your agent can send funds to any address. Consider only funding it with what it needs.',
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByTestId('funding-description')).toBeInTheDocument();
     expect(fundingDescriptionProps).toMatchObject({
       address: DEFAULT_EOA_ADDRESS,


### PR DESCRIPTION
## What

Adds an agent-custody warning — *"Your agent can send funds to any address. Consider only funding it with what it needs."* — to the three funding entry points for the Connect agent:

1. **Fund Agent (from Pearl Wallet)** — new warning alert under the page description (`FundAgent.tsx`).
2. **Onboarding bridge, Step 1. Send Funds** — this screen had no alert; adds a chain-scoped warning with the custody line as its description (`BridgeOnEvm.tsx`).
3. **Onboarding transfer** — extends the existing alert with the custody line as description (`TransferFunds.tsx`).

All three use the `Alert` wrapper from `@/components/ui`, with the app's compact alert style (`text-sm` title/body `Text` inside `message`, per `SetNewPasswordViaSRP`).

### Wording note (please confirm)

The transfer screen's alert previously read *"Only send on X Chain — funds on other networks are unrecoverable."* The design mocks title both onboarding alerts *"Only send funds on X Chain"* without the unrecoverable clause, so this PR matches the mocks. If the clause should stay, it's a one-line change.

Out of scope: `PearlWallet/components/TransferCryptoFromExternalWallet.tsx` keeps the old "Only send on…" wording — it funds the Pearl Wallet (not the agent), so the agent-custody warning doesn't apply there. Flagging so the two wordings coexisting is a known choice.

## Screenshots

*Fund Agent (from Pearl Wallet):*

![fund agent](https://raw.githubusercontent.com/valory-xyz/olas-operate-app/assets/pr-2085-screenshots/fund-agent.png)

*Onboarding — bridge from Ethereum:*

![bridge send funds](https://raw.githubusercontent.com/valory-xyz/olas-operate-app/assets/pr-2085-screenshots/bridge-send-funds.png)

*Onboarding — transfer on Polygon:*

![transfer crypto](https://raw.githubusercontent.com/valory-xyz/olas-operate-app/assets/pr-2085-screenshots/transfer-crypto.png)

*For comparison — existing alert convention in the app (Set New Password, `SetNewPasswordViaSRP.tsx`):*

![reference alert](https://raw.githubusercontent.com/valory-xyz/olas-operate-app/assets/pr-2085-screenshots/reference-set-new-password.png)

## Tests

- `BridgeOnEvm.test.tsx` — the `@/components/ui` mock now includes `Alert`; new assertions cover the alert message and description (4/4 pass on this branch).
- `yarn lint` clean, `tsc --noEmit` clean; adjacent suites (SetupPage index, FundAgent's ConfirmTransfer/prepare) pass — 46/46.
- TransferFunds and FundAgent have no dedicated suites; no other test updates needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
