### PR TITLE
fix(funding): [OPE-1857] scope agent-custody alerts to Connect only

### DIFF
--- a/frontend/components/AgentWallet/FundAgent/FundAgent.tsx
+++ b/frontend/components/AgentWallet/FundAgent/FundAgent.tsx
@@ -14,7 +14,7 @@ import {
   TokenAmountInput,
 } from '@/components/ui';
 import { TOKEN_CONFIG, TokenSymbol, TokenSymbolMap } from '@/config/tokens';
-import { AddressZero, PAGES } from '@/constants';
+import { AddressZero, AgentMap, PAGES } from '@/constants';
 import { EvmChainIdMap } from '@/constants/chains';
 import { useAvailableAssets, usePageState, useServices } from '@/hooks';
 import { TokenAmountDetails, TokenAmounts } from '@/types/Wallet';
@@ -164,7 +164,11 @@ const useFundAgent = () => {
 };
 
 export const FundAgent = ({ onBack }: { onBack: () => void }) => {
+  const { selectedAgentType } = useServices();
   const { availableAssets, amountsToFund, onAmountChange } = useFundAgent();
+  // Connect is user-driven and can send funds anywhere; other agents only
+  // spend within their own strategy, so the custody warning is Connect-only.
+  const isConnect = selectedAgentType === AgentMap.Connect;
 
   const canTransfer = useMemo(() => {
     const entries = Object.entries(amountsToFund);
@@ -187,12 +191,14 @@ export const FundAgent = ({ onBack }: { onBack: () => void }) => {
           <Flex gap={12} vertical>
             <BackButton onPrev={onBack} />
             <FundAgentTitle />
-            <Alert
-              showIcon
-              type="warning"
-              className="text-sm"
-              message="Your agent can send funds to any address. Consider only funding it with what it needs."
-            />
+            {isConnect && (
+              <Alert
+                showIcon
+                type="warning"
+                className="text-sm"
+                message="Your agent can send funds to any address. Consider only funding it with what it needs."
+              />
+            )}
           </Flex>
           <PearlWalletToAgentWallet />
 

--- a/frontend/components/Bridge/Bridge.tsx
+++ b/frontend/components/Bridge/Bridge.tsx
@@ -31,6 +31,8 @@ type BridgeProps = {
   getBridgeRequirementsParams: GetBridgeRequirementsParams;
   onPrevBeforeBridging: () => void;
   onBridgingCompleted?: () => void;
+  /** See {@link BridgeOnEvm} — passed only by the Connect onboarding flow. */
+  showAgentCustodyAlert?: boolean;
 };
 
 /**
@@ -45,6 +47,7 @@ export const Bridge = ({
   getBridgeRequirementsParams,
   onPrevBeforeBridging,
   onBridgingCompleted,
+  showAgentCustodyAlert,
 }: BridgeProps) => {
   const { goto } = usePageState();
 
@@ -120,6 +123,7 @@ export const Bridge = ({
           updateCrossChainTransferDetails={updateCrossChainTransferDetails}
           onPrev={onPrevBeforeBridging}
           onNext={handleNextStep}
+          showAgentCustodyAlert={showAgentCustodyAlert}
         />
       );
     /**

--- a/frontend/components/Bridge/BridgeOnEvm/BridgeOnEvm.tsx
+++ b/frontend/components/Bridge/BridgeOnEvm/BridgeOnEvm.tsx
@@ -24,6 +24,13 @@ type BridgeOnEvmProps = {
   getBridgeRequirementsParams: GetBridgeRequirementsParams;
   updateQuoteId: (quoteId: string) => void;
   updateCrossChainTransferDetails: (details: CrossChainTransferDetails) => void;
+  /**
+   * Warn that the funded agent can send funds to any address. Only passed by
+   * the Connect onboarding flow — Connect is user-driven, while other agents
+   * spend within their own strategy and the deposit flow funds the Pearl
+   * Wallet, not an agent.
+   */
+  showAgentCustodyAlert?: boolean;
 };
 
 /**
@@ -38,6 +45,7 @@ export const BridgeOnEvm = ({
   getBridgeRequirementsParams,
   updateQuoteId,
   updateCrossChainTransferDetails,
+  showAgentCustodyAlert = false,
 }: BridgeOnEvmProps) => {
   const { masterEoa } = useMasterWalletContext();
   // TODO: check if master safe exists once we support agents on From Chain
@@ -62,22 +70,24 @@ export const BridgeOnEvm = ({
           and bridge the funds for you.
         </Text>
 
-        <Alert
-          showIcon
-          type="warning"
-          className="mt-24"
-          message={
-            <Flex vertical gap={2}>
-              <Text className="text-sm font-weight-600">
-                Only send funds on {fromChainDetails.displayName} Chain
-              </Text>
-              <Text className="text-sm">
-                Your agent can send funds to any address. Consider only funding
-                it with what it needs.
-              </Text>
-            </Flex>
-          }
-        />
+        {showAgentCustodyAlert && (
+          <Alert
+            showIcon
+            type="warning"
+            className="mt-24"
+            message={
+              <Flex vertical gap={2}>
+                <Text className="text-sm font-weight-600">
+                  Only send funds on {fromChainDetails.displayName} Chain
+                </Text>
+                <Text className="text-sm">
+                  Your agent can send funds to any address. Consider only
+                  funding it with what it needs.
+                </Text>
+              </Flex>
+            }
+          />
+        )}
 
         {address && (
           <FundingDescription

--- a/frontend/components/SetupPage/Create/SetupBridgeOnboarding/SetupBridgeOnboarding.tsx
+++ b/frontend/components/SetupPage/Create/SetupBridgeOnboarding/SetupBridgeOnboarding.tsx
@@ -3,7 +3,7 @@ import { useCallback, useState } from 'react';
 
 import { Bridge } from '@/components/Bridge';
 import { AgentSetupCompleteModal } from '@/components/ui';
-import { AllEvmChainIdMap, SETUP_SCREEN } from '@/constants';
+import { AgentMap, AllEvmChainIdMap, SETUP_SCREEN } from '@/constants';
 import { useGetBridgeRequirementsParams, useServices, useSetup } from '@/hooks';
 import { asAllMiddlewareChain } from '@/utils/middlewareHelpers';
 
@@ -11,7 +11,7 @@ export const SetupBridgeOnboarding = () => {
   const [isBridgeCompleted, setIsBridgeCompleted] = useState(false);
 
   const { goto: gotoSetup, prevState } = useSetup();
-  const { selectedAgentConfig } = useServices();
+  const { selectedAgentConfig, selectedAgentType } = useServices();
 
   // Determine the from chain based on the agent's home chain
   const toMiddlewareChain = selectedAgentConfig.middlewareHomeChainId;
@@ -38,6 +38,7 @@ export const SetupBridgeOnboarding = () => {
         getBridgeRequirementsParams={getBridgeRequirementsParams}
         onPrevBeforeBridging={handlePrevStep}
         onBridgingCompleted={handleBridgingCompleted}
+        showAgentCustodyAlert={selectedAgentType === AgentMap.Connect}
       />
       {isBridgeCompleted && <AgentSetupCompleteModal />}
     </Flex>

--- a/frontend/components/SetupPage/FundYourAgent/TransferFunds.tsx
+++ b/frontend/components/SetupPage/FundYourAgent/TransferFunds.tsx
@@ -14,7 +14,12 @@ import {
   TokenRequirementsTable,
 } from '@/components/ui';
 import { TokenSymbol } from '@/config/tokens';
-import { CHAIN_IMAGE_MAP, EvmChainName, SETUP_SCREEN } from '@/constants';
+import {
+  AgentMap,
+  CHAIN_IMAGE_MAP,
+  EvmChainName,
+  SETUP_SCREEN,
+} from '@/constants';
 import { useSupportModal } from '@/context/SupportModalProvider';
 import {
   useMasterSafeCreationAndTransfer,
@@ -36,7 +41,7 @@ export const TransferFunds = () => {
     getMasterSafeOf,
     isFetched: isMasterWalletFetched,
   } = useMasterWalletContext();
-  const { selectedAgentConfig } = useServices();
+  const { selectedAgentConfig, selectedAgentType } = useServices();
   const { isFullyFunded, tokensFundingStatus, isLoading } =
     useTokensFundingStatus();
   const {
@@ -162,22 +167,34 @@ export const TransferFunds = () => {
           Wallet address below. Pearl will automatically detect your transfer.
         </Text>
 
-        <Alert
-          showIcon
-          type="warning"
-          className="mt-24"
-          message={
-            <Flex vertical gap={2}>
-              <Text className="text-sm font-weight-600">
-                Only send funds on {chainName} Chain
-              </Text>
-              <Text className="text-sm">
-                Your agent can send funds to any address. Consider only funding
-                it with what it needs.
-              </Text>
-            </Flex>
-          }
-        />
+        {/* Connect is user-driven and can send funds anywhere; other agents
+            only spend within their own strategy, so the custody warning is
+            Connect-only. */}
+        {selectedAgentType === AgentMap.Connect ? (
+          <Alert
+            showIcon
+            type="warning"
+            className="mt-24"
+            message={
+              <Flex vertical gap={2}>
+                <Text className="text-sm font-weight-600">
+                  Only send funds on {chainName} Chain
+                </Text>
+                <Text className="text-sm">
+                  Your agent can send funds to any address. Consider only
+                  funding it with what it needs.
+                </Text>
+              </Flex>
+            }
+          />
+        ) : (
+          <Alert
+            showIcon
+            type="warning"
+            className="mt-24"
+            message={`Only send on ${chainName} Chain — funds on other networks are unrecoverable.`}
+          />
+        )}
 
         {destinationAddress && (
           <FundingDescription

--- a/frontend/tests/components/Bridge/BridgeOnEvm/BridgeOnEvm.test.tsx
+++ b/frontend/tests/components/Bridge/BridgeOnEvm/BridgeOnEvm.test.tsx
@@ -107,6 +107,7 @@ const defaultProps = {
   getBridgeRequirementsParams: mockGetBridgeRequirementsParams,
   updateQuoteId: mockUpdateQuoteId,
   updateCrossChainTransferDetails: mockUpdateCrossChainTransferDetails,
+  showAgentCustodyAlert: true,
 };
 
 describe('BridgeOnEvm', () => {
@@ -160,6 +161,22 @@ describe('BridgeOnEvm', () => {
     fireEvent.click(screen.getByText('Back'));
 
     expect(mockOnPrev).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the agent custody alert when showAgentCustodyAlert is not set', () => {
+    render(
+      createElement(BridgeOnEvm, {
+        ...defaultProps,
+        showAgentCustodyAlert: undefined,
+      }),
+    );
+
+    expect(screen.queryByText('Only send funds on Ethereum Chain')).toBeNull();
+    expect(
+      screen.queryByText(
+        'Your agent can send funds to any address. Consider only funding it with what it needs.',
+      ),
+    ).toBeNull();
   });
 
   it('skips the funding description when the master EOA is unavailable', () => {

--- a/package.json
+++ b/package.json
@@ -113,6 +113,6 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.8.5-rc3",
+  "version": "1.8.5-rc6",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-app"
-version = "1.8.5-rc3"
+version = "1.8.5-rc6"
 description = ""
 authors = [
     { name = "David Vilela", email = "dvilelaf@gmail.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -1144,7 +1144,7 @@ wheels = [
 
 [[package]]
 name = "olas-operate-app"
-version = "1.8.5rc3"
+version = "1.8.5rc6"
 source = { virtual = "." }
 dependencies = [
     { name = "olas-operate-middleware" },


### PR DESCRIPTION
## What

Follow-up to #2085: the agent-custody warning — *"Your agent can send funds to any address. Consider only funding it with what it needs."* — was intended for the **Connect agent only**, but shipped on the funding screens of every agent (and on the Pearl-deposit bridge flow). This PR scopes it:

1. **Fund Agent (from Pearl Wallet)** — custody alert renders only when the selected agent is Connect (`FundAgent.tsx`).
2. **Onboarding transfer** — Connect keeps the custody alert; all other agents get the original alert back: *"Only send on X Chain — funds on other networks are unrecoverable."* (`TransferFunds.tsx`).
3. **Onboarding bridge** — the alert is now behind a `showAgentCustodyAlert` prop (`BridgeOnEvm.tsx` ← `Bridge.tsx`), passed only by `SetupBridgeOnboarding` when the selected agent is Connect. The Pearl-deposit bridge flow (which funds the Pearl Wallet, not an agent) shows no alert again, as before #2085.

Rationale for the gate: Connect is user-driven and can send funds anywhere; other agents only spend within their own strategy.

## Screenshots

Connect keeps the #2085 custody alerts; Predict Trader shows the restored pre-#2085 behavior.

### Fund Agent (from Pearl Wallet)

*Connect — custody alert:*

![connect fund agent](https://raw.githubusercontent.com/valory-xyz/olas-operate-app/assets/pr-2087-screenshots/fund-agent-connect.png)

*Predict Trader — no alert (as before #2085):*

![non-connect fund agent](https://raw.githubusercontent.com/valory-xyz/olas-operate-app/assets/pr-2087-screenshots/fund-agent-non-connect.png)

### Onboarding — transfer

*Connect (Polygon) — custody alert:*

![connect transfer](https://raw.githubusercontent.com/valory-xyz/olas-operate-app/assets/pr-2087-screenshots/transfer-crypto-connect.png)

*Predict Trader (Gnosis) — original alert restored:*

![non-connect transfer](https://raw.githubusercontent.com/valory-xyz/olas-operate-app/assets/pr-2087-screenshots/transfer-crypto-non-connect.png)

### Onboarding — bridge from Ethereum

*Connect — custody alert:*

![connect bridge](https://raw.githubusercontent.com/valory-xyz/olas-operate-app/assets/pr-2087-screenshots/bridge-connect.png)

*Predict Trader — no alert (as before #2085):*

![non-connect bridge](https://raw.githubusercontent.com/valory-xyz/olas-operate-app/assets/pr-2087-screenshots/bridge-non-connect.png)

## Tests

- `BridgeOnEvm.test.tsx`: existing alert assertions now pass `showAgentCustodyAlert`, plus a new case asserting the alert is absent when the prop isn't set — 5/5 pass.
- Adjacent suites green: `Bridge.test.tsx` + `BridgeTransferFlow.test.tsx` (20/20), SetupPage index + FundAgent suites (46/46).
- `yarn lint` clean on touched files, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
