### PR TITLE
fix(trader): raise PredictTrader first-install safe buffer to 10 xDAI (OPE-1853)

### DIFF
--- a/frontend/constants/serviceTemplates/service/trader.ts
+++ b/frontend/constants/serviceTemplates/service/trader.ts
@@ -37,7 +37,11 @@ export const PREDICT_SERVICE_TEMPLATE: ServiceTemplate = {
       fund_requirements: {
         [ethers.constants.AddressZero]: {
           agent: parseEther(2),
-          safe: parseEther(8),
+          // Matches the `safe` topup in the agent package's funds_manager
+          // overrides (OPE-1853). Raised 8 -> 10 because the omenstrat staking
+          // contracts now require 16 mech req/day instead of 8, doubling xDAI
+          // burn while redemptions still land days later.
+          safe: parseEther(10),
         },
       },
     },

--- a/frontend/constants/serviceTemplates/service/trader.ts
+++ b/frontend/constants/serviceTemplates/service/trader.ts
@@ -38,9 +38,6 @@ export const PREDICT_SERVICE_TEMPLATE: ServiceTemplate = {
         [ethers.constants.AddressZero]: {
           agent: parseEther(2),
           // Matches the `safe` topup in the agent package's funds_manager
-          // overrides (OPE-1853). Raised 8 -> 10 because the omenstrat staking
-          // contracts now require 16 mech req/day instead of 8, doubling xDAI
-          // burn while redemptions still land days later.
           safe: parseEther(10),
         },
       },


### PR DESCRIPTION
## Context

Companion to valory-xyz/trader#1018. The omenstrat staking contracts now require **16 mech req/day instead of 8**, doubling xDAI burn while redemptions still land days later, so Omenstrat Agent Safes deplete and re-trigger the low-balance alert within minutes of funding (ZD#1181).

## Change

`frontend/constants/serviceTemplates/service/trader.ts` — `PREDICT_SERVICE_TEMPLATE` Gnosis `fund_requirements.safe` **8 → 10 xDAI**, matching the `funds_manager` `safe` topup in the agent package.

`PREDICT_POLYMARKET_SERVICE_TEMPLATE` (Polystrat) is **not** touched — explicitly out of scope.

## Scope note

This field is the **first-install funding buffer only**. For a deployed service with a real Agent Safe, the middleware suppresses initial shortfalls (`funding_manager.py:1139-1143`), so this change does not by itself stop the recurring alert. The operative value is the `funds_manager` threshold inside the running agent, which arrives with the new package hash.

The onboarding funding-requirements card reads this same field (`useInitialFundingRequirements.ts`), so it follows automatically — no separate card change needed.

## Still required

- [ ] `hash`, `service_version`, `agent_release.version` bumps — blocked on the trader release (valory-xyz/trader#1018 → IPFS publish → release)

Existing instances pick the update up at their next stop→start via `updateServiceIfNeeded` (`useStartService.ts:40`); a service left running does not update until restarted.

## Verification

- `tsc --noEmit` clean
- `jest tests/utils/service.test.ts tests/hooks/useCreateConnectService.test.ts` — 50 passed
- No test asserted the previous value

Relates to: OPE-1853

🤖 Generated with [Claude Code](https://claude.com/claude-code)