### PR TITLE
chore(basius): [OPE-1816] bump Basius + Optimus to optimus v0.12.5

### DIFF
--- a/frontend/constants/serviceTemplates/agentUiReleases.ts
+++ b/frontend/constants/serviceTemplates/agentUiReleases.ts
@@ -48,7 +48,7 @@ export const AGENT_UI_RELEASES: Partial<Record<AgentType, AgentUiRelease>> = {
   [AgentMap.Basius]: {
     owner: 'valory-xyz',
     name: AGENT_UI_MONOREPO,
-    version: 'v0.2.0-basius',
+    version: 'v0.2.1-basius',
   },
   [AgentMap.AgentsFun]: {
     owner: 'valory-xyz',

--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -15,9 +15,9 @@ import { STAKING_PROGRAM_IDS } from '../../stakingProgram';
 import { X402_ENABLED_FLAGS } from '../../x402';
 import { KPI_DESC_PREFIX } from '../constants';
 
-// Modius + Optimus share this (reverted to the version on `staging`; the new
-// staking contracts for these agents are hidden for now). Basius ships the
-// newer build with its own hash below.
+// Modius uses this (reverted to the version on `staging`; the new staking
+// contracts for that agent are hidden for now). Optimus and Basius each ship
+// their own newer build with their own hash below.
 const BABYDEGEN_COMMON_TEMPLATE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
@@ -40,14 +40,14 @@ const BASIUS_TEMPLATE_RELEASE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeigoetjxteip6ic7fryr3sikbl4f7iuannkqegf5fgurlgiibf574e',
-  service_version: 'v0.12.4',
+  hash: 'bafybeif4vwaxgn7mjxsbb2gimr7dqws6glnptexfwvq53pexox37wi4rvu',
+  service_version: 'v0.12.5',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.12.4',
+      version: 'v0.12.5',
     },
   },
 };
@@ -59,14 +59,14 @@ const OPTIMUS_TEMPLATE_RELEASE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeieauvbqf4mlsxfnt5yzs4hmhae43nkca2rsnklnyundzpqj42jyt4',
-  service_version: 'v0.12.4',
+  hash: 'bafybeigxjo3luwej3eissqwlowe6vez3toa72wq63rqxjfbjkljygs5ov4',
+  service_version: 'v0.12.5',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.12.4',
+      version: 'v0.12.5',
     },
   },
 };


### PR DESCRIPTION
## What & why

Picks up the Basius agent UI fixes from **[agent-ui-monorepo#114](https://github.com/valory-xyz/agent-ui-monorepo/pull/114)** (Aerodrome branding + msUSD token logo) so they finally ship in Pearl.

The chain of events that unblocked this:

1. agent-ui-monorepo#114 merged → released as **`v0.2.1-basius`** (2026-07-08).
2. **[optimus#362](https://github.com/valory-xyz/optimus/pull/362)** re-bundled that UI build into the `optimus_abci` skill (swapped the JS asset, added `logos/tokens/msusd.png`) and re-locked packages → released as **`v0.12.5`** (2026-07-09).

That second step is the release we were waiting on — there was no Optimus/Basius release planned at the time #114 landed, so the UI fix sat unshipped. `v0.12.5` is that release, and its only content is this UI re-bundle.

**Why Optimus is bumped too:** `optimus_abci` is a *shared* skill. Re-locking it changed the fingerprint of both the `basius` **and** `optimus` agents/services, so both service hashes moved in `v0.12.5`. Bumping only Basius would leave Optimus pointing at a superseded package.

## Changes

`frontend/constants/serviceTemplates/service/babydegen.ts`

| Constant | Field | Before | After |
|---|---|---|---|
| `BASIUS_TEMPLATE_RELEASE` | `hash` | `bafybeigoetjx…f574e` | `bafybeif4vwax…4rvu` |
| `BASIUS_TEMPLATE_RELEASE` | `service_version` / `agent_release.repository.version` | `v0.12.4` | `v0.12.5` |
| `OPTIMUS_TEMPLATE_RELEASE` | `hash` | `bafybeieauvbq…jyt4` | `bafybeigxjo3l…5ov4` |
| `OPTIMUS_TEMPLATE_RELEASE` | `service_version` / `agent_release.repository.version` | `v0.12.4` | `v0.12.5` |

Both hashes were copied verbatim from `packages/packages.json` at tag `v0.12.5`:

```
"service/valory/optimus/0.1.0": "bafybeigxjo3luwej3eissqwlowe6vez3toa72wq63rqxjfbjkljygs5ov4"
"service/valory/basius/0.1.0":  "bafybeif4vwaxgn7mjxsbb2gimr7dqws6glnptexfwvq53pexox37wi4rvu"
```

Verified the same way against tag `v0.12.4` — those matched the pre-change values in this file exactly, confirming the constant→service mapping.

`frontend/constants/serviceTemplates/agentUiReleases.ts`

- `AGENT_UI_RELEASES[Basius].version`: `v0.2.0-basius` → `v0.2.1-basius` (fixes the stale value on the Release Notes / settings page).
- `AGENT_UI_RELEASES[Optimus]` left at `v0.1.9-optimus` — no newer `-optimus` UI tag exists; #114 was Basius-only and gated on `agentType === 'basius'`.

**Out of scope, fixed in passing (1 comment):** the doc comment above `BABYDEGEN_COMMON_TEMPLATE` still claimed "Modius + Optimus share this". Optimus got its own `OPTIMUS_TEMPLATE_RELEASE` some time ago, so that constant is Modius-only now.

## Not changed

- **Modius** stays on `BABYDEGEN_COMMON_TEMPLATE` (`v0.12.0-rc11`) — deliberately pinned back to the `staging` version while its new staking contracts are hidden. Untouched here.
- `frontend/config/agents.ts` — both agents already have `isAgentEnabled: true`.

Supersedes the draft placeholder PR #2063, which is closed.

## Testing

- ✅ `cd frontend && npx tsx ../scripts/js/check_service_templates.ts` — all templates pass. "Optimus - Optimism" and "Basius" both report version match `v0.12.5`, all five `agent_runner_*` release binaries reachable, and `optimus/service.yaml` + `basius/service.yaml` both resolve on the IPFS gateway.
- ✅ `yarn typequality-check:frontend` — clean.
- ✅ `cd frontend && yarn lint` — 0 errors (53 pre-existing warnings, none in touched files).
- ✅ Grepped the repo for the old hashes / `v0.12.4` / `v0.2.0-basius` — no remaining references.
- [ ] **Manual QA on a Basius agent:** Operating protocols + Pool column show Aerodrome branding, Details column reads "Aerodrome pool", chat "Operating protocols updated:" message shows Aerodrome, msUSD token icon loads (no gray circle).
- [ ] **Regression:** Modius still shows Velodrome branding; Optimus starts normally on the new hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
