### PR TITLE
chore(trader): bump Omenstrat and Polystrat service templates to v0.40.3

### DIFF
--- a/frontend/constants/serviceTemplates/service/trader.ts
+++ b/frontend/constants/serviceTemplates/service/trader.ts
@@ -11,14 +11,14 @@ import { X402_ENABLED_FLAGS } from '../../x402';
 import { KPI_DESC_PREFIX } from '../constants';
 
 export const PREDICT_SERVICE_TEMPLATE: ServiceTemplate = {
-  hash: 'bafybeigfo273qta5ofgmidchoy6zy5ai464xi4prydsp4gen2mhgiy7rg4',
-  service_version: 'v0.40.1',
+  hash: 'bafybeibacz7xudlx3x42bdlntudom2ap37ecjjuhwminh66vv7xgj55poe',
+  service_version: 'v0.40.3',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'trader',
-      version: 'v0.40.1',
+      version: 'v0.40.3',
     },
   },
   agentType: AgentMap.PredictTrader,
@@ -145,14 +145,14 @@ export const PREDICT_SERVICE_TEMPLATE: ServiceTemplate = {
 } as const;
 
 export const PREDICT_POLYMARKET_SERVICE_TEMPLATE: ServiceTemplate = {
-  hash: 'bafybeigmltj5g6ewucxtctvptbbkfpapntpqmq5n6mshfwsbvz776htrzy',
-  service_version: 'v0.40.2',
+  hash: 'bafybeihxgs2r46hcmius2ftqjqk32zxex6pex2ejezb2djxlyrhanlyxda',
+  service_version: 'v0.40.3',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'trader',
-      version: 'v0.40.2',
+      version: 'v0.40.3',
     },
   },
   agentType: AgentMap.Polystrat,


### PR DESCRIPTION
## Summary

Bumps both trader service templates in `frontend/constants/serviceTemplates/service/trader.ts` to the [`v0.40.3` release](https://github.com/valory-xyz/trader/releases/tag/v0.40.3).

- **Omenstrat** (`PREDICT_SERVICE_TEMPLATE`): `v0.40.1` → `v0.40.3`, hash `bafybeibacz7xudlx3x42bdlntudom2ap37ecjjuhwminh66vv7xgj55poe`
- **Polystrat** (`PREDICT_POLYMARKET_SERVICE_TEMPLATE`): `v0.40.2` → `v0.40.3`, hash `bafybeihxgs2r46hcmius2ftqjqk32zxex6pex2ejezb2djxlyrhanlyxda`

Both hashes were read from `packages/packages.json` at the `v0.40.3` tag of the trader repo.

The release rolls up:
- ci(snyk): tag CLI scans with public repo URL (#1011)
- chore: bump mech-interact to v0.32.5 / v0.32.6 (#1012, #1015)
- chore: drop unused olas_mech_subgraph override from polymarket_trader (#1014)
- feat(agent-performance-summary): mech-analytics as an alternative source for mech data, flag-gated (#1013)
- fix(funding): raise Omenstrat Agent Safe topup to 10 xDAI, OPE-1853 (#1018)
- fix(agent-performance): stop mech-attribution drift in profit_over_time (#1019)

## Test plan

- [x] Grep confirmed no test asserts on the old hashes or versions
- [ ] Run frontend build against the staging branch to confirm templates typecheck and no consumers of the old hash remain
- [ ] Smoke test both agent variants pick up the new templates on start

🤖 Generated with [Claude Code](https://claude.com/claude-code)