### PR TITLE
refactor(babydegen): rename BABYDEGEN_COMMON_TEMPLATE to MODIUS_TEMPLATE_RELEASE

### DIFF
--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -15,10 +15,10 @@ import { STAKING_PROGRAM_IDS } from '../../stakingProgram';
 import { X402_ENABLED_FLAGS } from '../../x402';
 import { KPI_DESC_PREFIX } from '../constants';
 
-// Modius + Optimus share this (reverted to the version on `staging`; the new
-// staking contracts for these agents are hidden for now). Basius ships the
-// newer build with its own hash below.
-const BABYDEGEN_COMMON_TEMPLATE: Pick<
+// Modius only (reverted to the version on `staging`; the new staking contracts
+// for that agent are hidden for now). Optimus and Basius each ship their own
+// newer build with their own hash below.
+const MODIUS_TEMPLATE_RELEASE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
@@ -237,7 +237,7 @@ export const MODIUS_SERVICE_TEMPLATE: ServiceTemplate = {
       provision_type: EnvProvisionType.FIXED,
     },
   },
-  ...BABYDEGEN_COMMON_TEMPLATE,
+  ...MODIUS_TEMPLATE_RELEASE,
 } as const;
 
 export const OPTIMUS_SERVICE_TEMPLATE: ServiceTemplate = {

--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -18,7 +18,7 @@ import { KPI_DESC_PREFIX } from '../constants';
 // Modius uses this (reverted to the version on `staging`; the new staking
 // contracts for that agent are hidden for now). Optimus and Basius each ship
 // their own newer build with their own hash below.
-const BABYDEGEN_COMMON_TEMPLATE: Pick<
+const MODIUS_TEMPLATE_RELEASE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {


### PR DESCRIPTION
## What & why

Follow-up to **#2099**. Pure rename, no behaviour change.

`BABYDEGEN_COMMON_TEMPLATE` stopped being common a while ago:

- Optimus moved to its own `OPTIMUS_TEMPLATE_RELEASE` (Optimism-specific mech config).
- Basius has `BASIUS_TEMPLATE_RELEASE`.

That leaves **Modius as the only consumer**. Both the `COMMON` name and the doc comment above it ("Modius + Optimus share this") implied a sharing that no longer exists — actively misleading when picking which constant to bump during a release.

Renamed to `MODIUS_TEMPLATE_RELEASE` so all three siblings follow one pattern:

```
MODIUS_TEMPLATE_RELEASE   -> MODIUS_SERVICE_TEMPLATE
OPTIMUS_TEMPLATE_RELEASE  -> OPTIMUS_SERVICE_TEMPLATE
BASIUS_TEMPLATE_RELEASE   -> BASIUS_SERVICE_TEMPLATE
```

(Not a bare `MODIUS` — that would break the sibling pattern and read confusingly next to the existing `MODIUS_SERVICE_TEMPLATE` export.)

## Scope

The constant is **file-local** (never exported), so the blast radius is two lines in one file: the declaration and a single spread inside `MODIUS_SERVICE_TEMPLATE`. Grepped repo-wide — no other references.

**Deliberately left alone:** `BABYDEGEN_FORM_STEP` in `components/AgentForms/common/formUtils.ts`. That one *is* genuinely shared by the Modius and Optimus setup forms, so its name is accurate.

## No value changes

`hash` stays `bafybeigjyo22nl…anum` and `service_version` stays `v0.12.0-rc11`. Modius remains deliberately pinned back to the `staging` version while its new staking contracts are hidden — this PR does not touch that.

## Testing

- ✅ `yarn typequality-check:frontend` — clean (a missed reference would be a compile error, since the constant is file-local and typed).
- ✅ `cd frontend && yarn lint` — 0 errors (53 pre-existing warnings, none in this file).
- ✅ Grepped repo-wide for `BABYDEGEN_COMMON_TEMPLATE` — no matches remain.
- Not run: `check_service_templates.ts` — no hash or version changed, so there is nothing new for it to validate.

## Merge note

This branches from `staging`, same as #2099, and the two touch **adjacent lines** — #2099 rewrites the doc comment on lines 18–20, this renames the declaration on line 21. Whichever lands second will need a trivial rebase on that one comment block. Both edits move the comment toward the same wording, so resolution is mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
