### PR TITLE
chore(trader): bump omenstrat + polystrat to v0.40.4; enable offchain mech dispatch

### DIFF
--- a/frontend/constants/serviceTemplates/service/trader.ts
+++ b/frontend/constants/serviceTemplates/service/trader.ts
@@ -11,14 +11,14 @@ import { X402_ENABLED_FLAGS } from '../../x402';
 import { KPI_DESC_PREFIX } from '../constants';
 
 export const PREDICT_SERVICE_TEMPLATE: ServiceTemplate = {
-  hash: 'bafybeibacz7xudlx3x42bdlntudom2ap37ecjjuhwminh66vv7xgj55poe',
-  service_version: 'v0.40.3',
+  hash: 'bafybeihbyiu23xc7jhjrlz376fsj4sqeaqhkldkk56djtsm45gr3bpsl4m',
+  service_version: 'v0.40.4',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'trader',
-      version: 'v0.40.3',
+      version: 'v0.40.4',
     },
   },
   agentType: AgentMap.PredictTrader,
@@ -141,18 +141,32 @@ export const PREDICT_SERVICE_TEMPLATE: ServiceTemplate = {
       value: 'false',
       provision_type: EnvProvisionType.FIXED,
     },
+    USE_OFFCHAIN: {
+      name: 'Use offchain mech dispatch',
+      description:
+        'Route mech requests via the offchain HTTP path instead of the on-chain marketplace tx. Requires the priority mech to have an offchain endpoint registered.',
+      value: 'true',
+      provision_type: EnvProvisionType.FIXED,
+    },
+    OFFCHAIN_DEPOSIT_TARGET_CALLS: {
+      name: 'Offchain deposit target calls',
+      description:
+        'Number of forward mech requests each auto-deposit to the BalanceTracker should cover. Deposit chunk = target_calls * delivery_rate, clamped by auto_deposit_cap_per_cycle.',
+      value: '5',
+      provision_type: EnvProvisionType.FIXED,
+    },
   },
 } as const;
 
 export const PREDICT_POLYMARKET_SERVICE_TEMPLATE: ServiceTemplate = {
-  hash: 'bafybeihxgs2r46hcmius2ftqjqk32zxex6pex2ejezb2djxlyrhanlyxda',
-  service_version: 'v0.40.3',
+  hash: 'bafybeibype6hrmmg7kurdy6sbjezfyid2fg74o3davo72kni6ewfgfacpu',
+  service_version: 'v0.40.4',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'trader',
-      version: 'v0.40.3',
+      version: 'v0.40.4',
     },
   },
   agentType: AgentMap.Polystrat,
@@ -273,6 +287,20 @@ export const PREDICT_POLYMARKET_SERVICE_TEMPLATE: ServiceTemplate = {
       description:
         'Enables feature of agents paying for api keys usage instead of asking users to manually provide them',
       value: X402_ENABLED_FLAGS[AgentMap.Polystrat].toString(),
+      provision_type: EnvProvisionType.FIXED,
+    },
+    USE_OFFCHAIN: {
+      name: 'Use offchain mech dispatch',
+      description:
+        'Route mech requests via the offchain HTTP path instead of the on-chain marketplace tx. Requires the priority mech to have an offchain endpoint registered.',
+      value: 'true',
+      provision_type: EnvProvisionType.FIXED,
+    },
+    OFFCHAIN_DEPOSIT_TARGET_CALLS: {
+      name: 'Offchain deposit target calls',
+      description:
+        'Number of forward mech requests each auto-deposit to the BalanceTracker should cover. Deposit chunk = target_calls * delivery_rate, clamped by auto_deposit_cap_per_cycle.',
+      value: '5',
       provision_type: EnvProvisionType.FIXED,
     },
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "lodash": "4.18.1",
     "lodash-es": "4.18.1",
     "minimatch": "9.0.9",
+    "nanoid": "3.3.17",
     "picomatch": "4.0.4",
     "postcss": "8.5.22",
     "sharp": "0.35.3",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5179,10 +5179,10 @@ ms@^2.1.1, ms@^2.1.3:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@^3.3.16:
-  version "3.3.16"
-  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
-  integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
+nanoid@3.3.17, nanoid@^3.3.16:
+  version "3.3.17"
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz#f1c3aa253c52547956a52c50bff754316f61037a"
+  integrity sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==
 
 napi-postinstall@^0.3.0:
   version "0.3.3"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "immutable": "5.1.9",
     "js-yaml": "4.3.1",
     "lodash": "4.18.1",
+    "nanoid": "3.3.17",
     "node-gyp": "12.3.0",
     "picomatch": "2.3.2",
     "postcss": "8.5.22",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,6 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.9.2",
+  "version": "1.9.2-rc1",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-app"
-version = "1.9.2"
+version = "1.9.2-rc1"
 description = ""
 authors = [
     { name = "David Vilela", email = "dvilelaf@gmail.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -1144,7 +1144,7 @@ wheels = [
 
 [[package]]
 name = "olas-operate-app"
-version = "1.9.2"
+version = "1.9.2rc1"
 source = { virtual = "." }
 dependencies = [
     { name = "olas-operate-middleware" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4653,10 +4653,10 @@ ms@^2.1.1, ms@^2.1.3:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@^3.3.16:
-  version "3.3.16"
-  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
-  integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
+nanoid@3.3.17, nanoid@^3.3.16:
+  version "3.3.17"
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz#f1c3aa253c52547956a52c50bff754316f61037a"
+  integrity sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==
 
 napi-macros@^2.2.2:
   version "2.2.2"


### PR DESCRIPTION
## Summary

Trader [v0.40.4](https://github.com/valory-xyz/trader/releases/tag/v0.40.4) lands the [mech-interact v0.32.7 hoist](https://github.com/valory-xyz/mech-interact/pull/113) that moves \`use_offchain\` and \`offchain_deposit_target_calls\` out of \`mech_marketplace_config\` into top-level \`MechParams\` attributes. Pearl can now flip each with a dedicated FIXED env var without composing the whole \`MECH_MARKETPLACE_CONFIG\` dict.

## Changes

Both trader service templates in \`frontend/constants/serviceTemplates/service/trader.ts\`:

### PREDICT_SERVICE_TEMPLATE (omenstrat / Gnosis)
- \`hash\`: \`bafybeibacz7xudlx3x42bdlntudom2ap37ecjjuhwminh66vv7xgj55poe\` → \`bafybeihbyiu23xc7jhjrlz376fsj4sqeaqhkldkk56djtsm45gr3bpsl4m\`
- \`service_version\`, \`agent_release.repository.version\`: \`v0.40.3\` → \`v0.40.4\`
- **\`USE_OFFCHAIN=true\`** (FIXED)
- **\`OFFCHAIN_DEPOSIT_TARGET_CALLS=5\`** (FIXED)

### PREDICT_POLYMARKET_SERVICE_TEMPLATE (polystrat / Polygon)
- \`hash\`: \`bafybeihxgs2r46hcmius2ftqjqk32zxex6pex2ejezb2djxlyrhanlyxda\` → \`bafybeibype6hrmmg7kurdy6sbjezfyid2fg74o3davo72kni6ewfgfacpu\`
- \`service_version\`, \`agent_release.repository.version\`: \`v0.40.3\` → \`v0.40.4\`
- \`USE_OFFCHAIN=true\` (FIXED)
- \`OFFCHAIN_DEPOSIT_TARGET_CALLS=5\` (FIXED)

## Why these values

**\`USE_OFFCHAIN=true\`** — routes mech requests via the offchain HTTP path (POST to the mech's endpoint + poll) instead of an on-chain marketplace tx. Requires the priority mech configured for the Safe's staking program to have an offchain endpoint registered — the current Pearl priority mechs on both chains do.

**\`OFFCHAIN_DEPOSIT_TARGET_CALLS=5\`** — each auto-deposit to the BalanceTracker (triggered by a 402 challenge from the mech) sizes for 5 forward mech calls: deposit chunk = \`target_calls * delivery_rate\`, clamped by \`auto_deposit_cap_per_cycle\`. At ~0.01 xDAI / USDC per request and ~5 requests/day of typical Pearl trader volume, each chunk covers ~1 day of usage — meaning roughly 1 auto-deposit tx per day, keeping BalanceTracker balance-at-rest low without over-fragmenting.

## Pearl / middleware interaction

- \`olas-operate-middleware/operate/services/manage.py:541\` composes \`MECH_MARKETPLACE_CONFIG\` without either legacy key already, so the middleware path is unaffected by the upstream v0.32.7 fail-loud migration guard.
- Because Pearl's FIXED env vars are declared here, \`service.py:1327-1328\`'s \`update_env_variables_values\` COMPUTED-only guard leaves them untouched — Pearl's chosen values flow through to the agent runtime.
- Trader now requires both \`USE_OFFCHAIN\` and \`OFFCHAIN_DEPOSIT_TARGET_CALLS\` as top-level params via \`_ensure\` at boot. Without these FIXED declarations, the agent would crash with \`AEAEnforceError\` at startup once the hash bump lands.

## Test plan

- [x] \`yarn typecheck\` clean
- [x] \`yarn lint\` clean (existing warnings only, none from this change)
- [x] \`yarn test --testPathPattern="serviceTemplates|service.test"\` → 174 passed
- [ ] CI green on this PR
- [ ] Pearl preview deployment boots the trader against v0.40.4 with offchain dispatch enabled
- [ ] Auto-deposit fires on first mech request in the preview; BalanceTracker balance drawn down at expected rate

## Related

- Upstream trader release: https://github.com/valory-xyz/trader/releases/tag/v0.40.4
- Trader companion PR: https://github.com/valory-xyz/trader/pull/1020
- mech-interact upstream: https://github.com/valory-xyz/mech-interact/pull/113
- Other consumer companion PRs: optimus [#367](https://github.com/valory-xyz/optimus/pull/367), agents-fun ([meme-ooorr #101](https://github.com/valory-xyz/meme-ooorr/pull/101)), market-resolver [#47](https://github.com/valory-xyz/market-resolver/pull/47)

🤖 Generated with [Claude Code](https://claude.com/claude-code)