### PR TITLE
chore(optimus): bump service template to v0.12.11

### DIFF
--- a/frontend/constants/serviceTemplates/service/babydegen.ts
+++ b/frontend/constants/serviceTemplates/service/babydegen.ts
@@ -59,14 +59,14 @@ const OPTIMUS_TEMPLATE_RELEASE: Pick<
   ServiceTemplate,
   'hash' | 'service_version' | 'agent_release'
 > = {
-  hash: 'bafybeigxjo3luwej3eissqwlowe6vez3toa72wq63rqxjfbjkljygs5ov4',
-  service_version: 'v0.12.5',
+  hash: 'bafybeih27aanglfrknkjokkgzp3lzrowxuh665eozclrozkgkodltoz2pi',
+  service_version: 'v0.12.11',
   agent_release: {
     is_aea: true,
     repository: {
       owner: 'valory-xyz',
       name: 'optimus',
-      version: 'v0.12.5',
+      version: 'v0.12.11',
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -114,6 +114,6 @@
     "start:frontend": "cd frontend && yarn start",
     "test:frontend": "cd frontend && yarn test"
   },
-  "version": "1.9.2-rc10",
+  "version": "1.9.2-rc12",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-app"
-version = "1.9.2-rc10"
+version = "1.9.2-rc12"
 description = ""
 authors = [
     { name = "David Vilela", email = "dvilelaf@gmail.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -1144,7 +1144,7 @@ wheels = [
 
 [[package]]
 name = "olas-operate-app"
-version = "1.9.2rc10"
+version = "1.9.2rc12"
 source = { virtual = "." }
 dependencies = [
     { name = "olas-operate-middleware" },


### PR DESCRIPTION
## Summary

- Bumps the Optimus service template hash and version to [v0.12.11](https://github.com/valory-xyz/optimus/releases/tag/v0.12.11).
- Picks up [valory-xyz/optimus#372](https://github.com/valory-xyz/optimus/pull/372) which restores the Optimism agent EOA \`fund_requirements\` to the pre-\`afe10cd0\` sizing. Users on Optimism should stop seeing "please fund" prompts every couple of days.
- Modius and Basius templates are unchanged.

## Test plan

- [ ] Run a fresh Optimism agent setup and confirm the new service hash is picked up.
- [ ] Confirm the "Add Funds" prompt no longer fires every 1-2 days for a normally-operating Optimism agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)